### PR TITLE
fix(doc-analyze): adjust image scaling limit to 9000 pixels

### DIFF
--- a/magic_pdf/model/doc_analyze_by_custom_model.py
+++ b/magic_pdf/model/doc_analyze_by_custom_model.py
@@ -37,8 +37,8 @@ def load_images_from_pdf(pdf_bytes: bytes, dpi=200) -> list:
             mat = fitz.Matrix(dpi / 72, dpi / 72)
             pm = page.get_pixmap(matrix=mat, alpha=False)
 
-            # if width or height > 3000 pixels, don't enlarge the image
-            if pm.width > 3000 or pm.height > 3000:
+            # If the width or height exceeds 9000 after scaling, do not scale further.
+            if pm.width > 9000 or pm.height > 9000:
                 pm = page.get_pixmap(matrix=fitz.Matrix(1, 1), alpha=False)
 
             img = Image.frombytes("RGB", (pm.width, pm.height), pm.samples)


### PR DESCRIPTION
Previously, images were not enlarged if their width or height exceeded 3000 pixels. This threshold has been increased to 9000 pixels to better handle high-resolutionscans and improve the analysis of documents with larger dimensions.