### PR TITLE
perf(model): add threading lock for OCR model initialization

### DIFF
--- a/magic_pdf/model/sub_modules/model_init.py
+++ b/magic_pdf/model/sub_modules/model_init.py
@@ -82,9 +82,12 @@ def ocr_model_init(show_log: bool = False,
     return model
 
 
+from threading import Lock
+
 class AtomModelSingleton:
     _instance = None
     _models = {}
+    _lock = Lock()
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
@@ -95,8 +98,13 @@ class AtomModelSingleton:
         lang = kwargs.get('lang', None)
         layout_model_name = kwargs.get('layout_model_name', None)
         key = (atom_model_name, layout_model_name, lang)
-        if key not in self._models:
-            self._models[key] = atom_model_init(model_name=atom_model_name, **kwargs)
+        if atom_model_name == AtomicModel.OCR:
+            with self._lock:
+                if key not in self._models:
+                    self._models[key] = atom_model_init(model_name=atom_model_name, **kwargs)
+        else:
+            if key not in self._models:
+                self._models[key] = atom_model_init(model_name=atom_model_name, **kwargs)
         return self._models[key]
 
 


### PR DESCRIPTION
- Introduce a lock to synchronize access to OCR model initialization- This change improves thread safety when multiple threads access the OCR model concurrently
- The lock ensures that the OCR model is initialized only once, even in multi-threaded scenarios

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
