### PR TITLE
fix: skip the char corresponding to invalid bounding boxes

### DIFF
--- a/magic_pdf/pdf_parse_union_core_v2.py
+++ b/magic_pdf/pdf_parse_union_core_v2.py
@@ -108,6 +108,10 @@ def fill_char_in_spans(spans, all_chars):
     spans = sorted(spans, key=lambda x: x['bbox'][1])
 
     for char in all_chars:
+        # 跳过非法bbox的char
+        x1, y1, x2, y2 = char['bbox']
+        if abs(x1 - x2) <= 0.01 or abs(y1 - y2) <= 0.01:
+            continue
         for span in spans:
             if calculate_char_in_span(char['bbox'], span['bbox'], char['c']):
                 span['chars'].append(char)

--- a/magic_pdf/pre_proc/remove_bbox_overlap.py
+++ b/magic_pdf/pre_proc/remove_bbox_overlap.py
@@ -70,7 +70,7 @@ def _remove_overlap_between_bboxes(arr):
                     res[i] = None
                 else:
                     keeps[idx] = False
-                drop_reasons.append(drop_reasons)
+                drop_reasons.append(drop_reason)
         if keeps[idx]:
             res[idx] = v
     return res, drop_reasons


### PR DESCRIPTION
## Motivation

In a specific PDF document, the parsed text content contains partial duplication

![openai_demo_badcase](https://github.com/user-attachments/assets/dcfa1108-1b50-4504-84ee-d6ca508329fa)

By tracing the source code, I discovered that the issue lies in the metadata read by PuMuPDF. Some of the duplicated character content appears identical but is actually not the same character. Additionally, the bounding boxes corresponding to the duplicated characters are abnormal, with `abs(char['bbox'][0] - char['bbox'][2])` being very small. Below is some of the problematic metadata:

> {'origin': (71.113037109375, 117.0), 'bbox': (71.113037109375, 102.16000366210938, 85.113037109375, 121.76000213623047), 'c': '年'}
> {'origin': (85.113037109375, 117.0), 'bbox': (85.113037109375, 102.16000366210938, 85.113037109375, 121.76000213623047), 'c': '年'}
> {'origin': (85.35517120361328, 117.0), 'bbox': (85.35517120361328, 106.22000122070312, 93.13917541503906, 120.22000122070312), 'c': '5'}
> {'origin': (93.38343048095703, 117.0), 'bbox': (93.38343048095703, 102.16000366210938, 107.38343048095703, 121.76000213623047), 'c': '⽉'}
> {'origin': (107.38343048095703, 117.0), 'bbox': (107.38343048095703, 102.16000366210938, 107.38343048095703, 121.76000213623047), 'c': '月'}
> {'origin': (107.62554931640625, 117.0), 'bbox': (107.62554931640625, 106.22000122070312, 115.40955352783203, 120.22000122070312), 'c': '2'}

## Modification

pdf parse union method

## Use cases 

[text_duplicate_badcase_1.pdf](https://github.com/user-attachments/files/18186272/text_duplicate_badcase_1.pdf)

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
