### PR TITLE
feat(classify)：add OCR mode switching based on char overlap detection

### DIFF
--- a/magic_pdf/pipe/AbsPipe.py
+++ b/magic_pdf/pipe/AbsPipe.py
@@ -76,6 +76,7 @@ class AbsPipe(ABC):
                     pdf_meta['imgs_per_page'],
                     pdf_meta['text_layout_per_page'],
                     pdf_meta['invalid_chars'],
+                    pdf_meta['char_overlap_counter']
                 )
                 if is_text_pdf:
                     return AbsPipe.PIP_TXT


### PR DESCRIPTION
## Motivation

### (1) Observed
In some PDFs, bold fonts are present (some exhibit overlapping characters due to multiple renderings, while others do not show obvious character overlaps). When using the TXT mode to parse the content, partial duplication occurs, but the OCR mode works correctly. I believe that the MinerU framework's ability to automatically recognize and handle such cases is more intelligent.

**Original PDF**
![case原图](https://github.com/user-attachments/assets/90f3bfea-f57b-48c9-8181-f58f9f66006c)

**TXT Mode Recognition Result**
![TXT_mode](https://github.com/user-attachments/assets/e02a800a-2ad9-49b9-87e0-94c728349f32)

**OCR Mode Recognition Result**
![OCR_mode](https://github.com/user-attachments/assets/e62888d9-f4f3-4e6a-a790-37325de6159c)

### (2) Error Location
I have identified that the cause of the error is the overlapping of characters in the span read by PyMuPDF, and the IOU of the overlapping parts of the bounding boxes (bbox) may not be very high.

### (3) Example
```json
[
  {
    "origin": [135.0, 150.39999389648438],
    "bbox": [135.0, 133.22799682617188, 153.0, 154.95399475097656],
    "c": "辐"
  },
  {
    "origin": [128.92857360839844, 150.47747802734375],
    "bbox": [128.92857360839844, 134.64581298828125, 146.5, 153.05772399902344],
    "c": "辐"
  },
  {
    "origin": [128.92857360839844, 150.47747802734375],
    "bbox": [128.92857360839844, 134.64581298828125, 146.5, 153.05772399902344],
    "c": "辐"
  },
  {
    "origin": [153.0, 150.39999389648438],
    "bbox": [153.0, 133.22799682617188, 171.0, 154.95399475097656],
    "c": "射"
  },
  {
    "origin": [146.5, 150.47747802734375],
    "bbox": [146.5, 134.64581298828125, 164.07142639160156, 153.05772399902344],
    "c": "射"
  },
  {
    "origin": [146.5, 150.47747802734375],
    "bbox": [146.5, 134.64581298828125, 164.07142639160156, 153.05772399902344],
    "c": "射"
  }
]
```

### (4) Attempted Methods
* **Filtering Characters with High IOU**  
Directly filter out characters from the span where the IOU exceeds a certain threshold.
* **Identifying Overlapping Characters within a Span**  
Determine if there is any overlap (IOU exceeding a certain threshold) between characters within a span, and add an overlap flag fixme=true. This flag is then used to trigger OCR correction.

Neither of the above methods effectively addresses this issue. Additionally, If the threshold we set is too high, duplicated content may still exist; if it is set too low, it may inadvertently affect normal content. For example, in the example above, the character '辐' appears only once in the original text, but it appears three times in the span. And its IOU list is `[0.4210700432518626, 1.0]`,
So i believe that setting the IOU threshold is a challenging. 


## Modification

This commit primarily modifies the `pdf_meta_scan` class. It adds the function `get_char_overlap_per_page` to obtain statistics on character overlaps. When certain conditions are met, the OCR mode can be triggered.

## Use cases

[char_overlaps_case1.pdf](https://github.com/user-attachments/files/18207950/char_overlaps_case1.pdf)

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
