### PR TITLE
修正了由于结束页id错误导致的文档解析速度计算不准的问题。

### DIFF
--- a/magic_pdf/model/doc_analyze_by_custom_model.py
+++ b/magic_pdf/model/doc_analyze_by_custom_model.py
@@ -163,7 +163,7 @@ def doc_analyze(
     doc_analyze_start = time.time()
 
     if end_page_id is None:
-        end_page_id = len(dataset)
+        end_page_id = len(dataset) - 1
 
     for index in range(len(dataset)):
         page_data = dataset.get_page(index)
@@ -190,7 +190,7 @@ def doc_analyze(
     doc_analyze_time = round(time.time() - doc_analyze_start, 2)
     doc_analyze_speed = round((end_page_id + 1 - start_page_id) / doc_analyze_time, 2)
     logger.info(
-        f'doc analyze time: {round(time.time() - doc_analyze_start, 2)},'
+        f'doc analyze time: {doc_analyze_time} seconds,'
         f' speed: {doc_analyze_speed} pages/second'
     )
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Solve the problem of incorrect calculation of document parsing speed due to wrong end_page_id.
解决因为结束页id错误而导致的文档解析速度计算有误的问题。

## Modification

When start_page_id starts from 0, end_page_id should be document length minus 1. Otherwise, the total number of document pages will be increased by 1 when calculating doc_analyze_speed.
当start_page_id从0开始时，end_page_id应该为文档长度-1。否则会在计算doc_analyze_speed时，导致文档总页数多1页。

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
