### PR TITLE
Allow batch ratio to be tuned

### DIFF
--- a/magic_pdf/model/doc_analyze_by_custom_model.py
+++ b/magic_pdf/model/doc_analyze_by_custom_model.py
@@ -174,20 +174,26 @@ def doc_analyze(
         if torch_npu.npu.is_available():
             npu_support = True
 
+    override_batch_ratio = int(os.getenv("MINERU_OVERRIDE_BATCH_RATIO", 0))
+
     if torch.cuda.is_available() and device != 'cpu' or npu_support:
         gpu_memory = int(os.getenv("VIRTUAL_VRAM_SIZE", round(get_vram(device))))
         if gpu_memory is not None and gpu_memory >= 8:
+            batch_ratio = 0
 
-            if 8 <= gpu_memory < 10:
-                batch_ratio = 2
-            elif 10 <= gpu_memory <= 12:
-                batch_ratio = 4
-            elif 12 < gpu_memory <= 16:
-                batch_ratio = 8
-            elif 16 < gpu_memory <= 24:
-                batch_ratio = 16
+            if override_batch_ratio > 0:
+                batch_ratio = override_batch_ratio 
             else:
-                batch_ratio = 32
+                if 8 <= gpu_memory < 10:
+                    batch_ratio = 2
+                elif 10 <= gpu_memory <= 12:
+                    batch_ratio = 4
+                elif 12 < gpu_memory <= 16:
+                    batch_ratio = 8
+                elif 16 < gpu_memory <= 24:
+                    batch_ratio = 16
+                else:
+                    batch_ratio = 32
 
             if batch_ratio >= 1:
                 logger.info(f'gpu_memory: {gpu_memory} GB, batch_ratio: {batch_ratio}')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Current logic automatically determines batch ratio based on available VRAM. For certain complex, scanned PDFs, higher batch ratio leads to NPU OOM. Unclear if this is an issue with CUDA-based acceleration

## Modification

Added an env var "MINERU_OVERRIDE_BATCH_RATIO" to tune batch ratio manually. Alternatively we can also change this to a ratio to be multiplied by vram-based batch ratio. 

## BC-breaking (Optional)

No - no backwards compatibility issue (unless MINERU_OVERRIDE_BATCH_RATIO is already used for some other application)

## Use cases (Optional)

Processing scanned pdfs with high resource consumption 

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
