### PR TITLE
fix(url-markdown): :bug: set output mathml to deduplicate formula

### DIFF
--- a/projects/web/src/pages/extract/components/url-markdown/index.tsx
+++ b/projects/web/src/pages/extract/components/url-markdown/index.tsx
@@ -29,7 +29,7 @@ const LazyUrlMarkdown: React.FC<IMarkdownProps> = ({
             remarkMath,
             [remarkGfm, { singleTilde: false }, { strict: "ignore" }],
           ]}
-          rehypePlugins={[[rehypeKatex, { strict: "ignore" }], rehypeRaw]}
+          rehypePlugins={[[rehypeKatex, { strict: "ignore", output: 'mathml' }], rehypeRaw]}
           components={{
             code(props) {
               const { children, className, node, ...rest } = props;


### PR DESCRIPTION
## Motivation

修复公式内容重复渲染的问题
#1783 
![image](https://github.com/user-attachments/assets/8c3a7f94-9f03-46a4-906d-878da4393628)



## Modification

为 katex 设置参数 `output: "mathml"`


