### PR TITLE
Replace direct version string comparison with packaging.version.parse()

### DIFF
--- a/magic_pdf/model/doc_analyze_by_custom_model.py
+++ b/magic_pdf/model/doc_analyze_by_custom_model.py
@@ -10,6 +10,7 @@ os.environ['NO_ALBUMENTATIONS_UPDATE'] = '1'  # 禁止albumentations检查更新
 import paddle
 paddle.disable_signal_handler()
 
+from packaging import version
 from loguru import logger
 
 from magic_pdf.model.batch_analyze import BatchAnalyze
@@ -17,7 +18,8 @@ from magic_pdf.model.sub_modules.model_utils import get_vram
 
 try:
     import torchtext
-    if torchtext.__version__ >= '0.18.0':
+
+    if version.parse(torchtext.__version__) >= version.parse('0.18.0'):
         torchtext.disable_torchtext_deprecation_warning()
 except ImportError:
     pass

--- a/magic_pdf/model/pdf_extract_kit.py
+++ b/magic_pdf/model/pdf_extract_kit.py
@@ -8,13 +8,14 @@ import torch
 import yaml
 from loguru import logger
 from PIL import Image
+from packaging import version
 
 os.environ['NO_ALBUMENTATIONS_UPDATE'] = '1'  # 禁止albumentations检查更新
 
 try:
     import torchtext
 
-    if torchtext.__version__ >= '0.18.0':
+    if version.parse(torchtext.__version__) >= version.parse('0.18.0'):
         torchtext.disable_torchtext_deprecation_warning()
 except ImportError:
     pass

--- a/magic_pdf/pdf_parse_union_core_v2.py
+++ b/magic_pdf/pdf_parse_union_core_v2.py
@@ -5,6 +5,7 @@ import re
 import statistics
 import time
 from typing import List
+from packaging import version
 
 import cv2
 import fitz
@@ -21,16 +22,14 @@ from magic_pdf.libs.config_reader import get_local_layoutreader_model_dir, get_l
 from magic_pdf.libs.convert_utils import dict_to_list
 from magic_pdf.libs.hash_utils import compute_md5
 from magic_pdf.libs.pdf_image_tools import cut_image_to_pil_image
-from magic_pdf.libs.performance_stats import measure_time, PerformanceStats
 from magic_pdf.model.magic_model import MagicModel
 from magic_pdf.post_proc.llm_aided import llm_aided_formula, llm_aided_text, llm_aided_title
 
-from concurrent.futures import ThreadPoolExecutor
 
 try:
     import torchtext
 
-    if torchtext.__version__ >= '0.18.0':
+    if version.parse(torchtext.__version__) >= version.parse('0.18.0'):
         torchtext.disable_torchtext_deprecation_warning()
 except ImportError:
     pass

--- a/magic_pdf/pdf_parse_union_core_v2.py
+++ b/magic_pdf/pdf_parse_union_core_v2.py
@@ -22,9 +22,11 @@ from magic_pdf.libs.config_reader import get_local_layoutreader_model_dir, get_l
 from magic_pdf.libs.convert_utils import dict_to_list
 from magic_pdf.libs.hash_utils import compute_md5
 from magic_pdf.libs.pdf_image_tools import cut_image_to_pil_image
+from magic_pdf.libs.performance_stats import measure_time, PerformanceStats
 from magic_pdf.model.magic_model import MagicModel
 from magic_pdf.post_proc.llm_aided import llm_aided_formula, llm_aided_text, llm_aided_title
 
+from concurrent.futures import ThreadPoolExecutor
 
 try:
     import torchtext


### PR DESCRIPTION
## Motivation

Current direct version comparison fails with torchtext < 0.10.0

## Modification

Replaced direct version string comparisons with packaging.version.parse()

## BC-breaking (Optional)

No
