### PR TITLE
optimize batch ratio for different GPU memory sizes

### DIFF
--- a/magic_pdf/model/doc_analyze_by_custom_model.py
+++ b/magic_pdf/model/doc_analyze_by_custom_model.py
@@ -170,7 +170,11 @@ def doc_analyze(
         gpu_memory = int(os.getenv("VIRTUAL_VRAM_SIZE", round(get_vram(device))))
         if gpu_memory is not None and gpu_memory >= 8:
 
-            if gpu_memory >= 16:
+            if gpu_memory >= 40:
+                 batch_ratio = 32
+            elif gpu_memory >=24:
+                 batch_ratio = 16
+            elif gpu_memory >= 16:
                 batch_ratio = 8
             elif gpu_memory >= 10:
                 batch_ratio = 4


### PR DESCRIPTION
## Motivation

I don't know why batch_ratio has been reduced to a maximum of 8 recently while 32 for GPU with > 40 GB RAM was definitely ok.

## Modification

Back to the old way of defining batch_ratio based on GPU RAM available.

Maybe batch_ratio could  be a settable parameter by the user?

## Checklist

**Before PR**:

- [X] Pre-commit or other linting tools are used to fix the potential lint issues.
- [X] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [X] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [X] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [X] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [X] CLA has been signed and all committers have signed the CLA in this PR.
