### PR TITLE
Use png for higher resolution

### DIFF
--- a/magic_pdf/libs/pdf_image_tools.py
+++ b/magic_pdf/libs/pdf_image_tools.py
@@ -19,16 +19,16 @@ def cut_image(bbox: tuple, page_num: int, page: fitz.Page, return_path, imageWri
     img_path = join_path(return_path, filename) if return_path is not None else None
 
     # 新版本生成平铺路径
-    img_hash256_path = f'{compute_sha256(img_path)}.jpg'
+    img_hash256_path = f'{compute_sha256(img_path)}.png'
 
     # 将坐标转换为fitz.Rect对象
     rect = fitz.Rect(*bbox)
     # 配置缩放倍数为3倍
-    zoom = fitz.Matrix(3, 3)
+    zoom = fitz.Matrix(5, 5)
     # 截取图片
     pix = page.get_pixmap(clip=rect, matrix=zoom)
 
-    byte_data = pix.tobytes(output='jpeg', jpg_quality=95)
+    byte_data = pix.tobytes(output='png')
 
     imageWriter.write(img_hash256_path, byte_data)
 


### PR DESCRIPTION
## Motivation

When using the magic-pdf tool to extract images from academic papers, the resulting images often have relatively low resolution. This is particularly problematic for scientific papers where figures contain important details, graphs, charts, and fine text that become difficult to read in the extracted images (low resolution). The current implementation uses a fixed 3x zoom factor and JPEG compression (quality level 95) when extracting images, which may not be sufficient for high-quality scientific publications.

Users who need to refer to these figures after extraction (such as researchers, students, or professionals analyzing papers) would benefit from higher resolution images that preserve more details from the original document. Improving the image extraction quality would enhance the overall utility of the magic-pdf tool for academic and research use cases.

## Modification

The proposed changes modify the image extraction process in magic_pdf/libs/pdf_image_tools.py to improve the resolution and quality of extracted images:

Increased the zoom factor from 3x to 5x to capture more details from the original PDF figures
Added an option to use PNG format (lossless) for image extraction when highest quality is required

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.


My Personal Suggestion: please support server mode officially just like `marker_server`, which can return images, markdown. 
