### PR TITLE
Loosen the version requirement for "dill" to be >=0.3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
                      "matplotlib>=3.10,<4",
                      "ultralytics>=8.3.48,<9",  # yolov8,公式检测
                      "doclayout_yolo==0.0.2b1",  # doclayout_yolo
-                     "dill>=0.3.9,<1",  # doclayout_yolo
+                     "dill>=0.3.8,<1",  # doclayout_yolo
                      "rapid_table>=1.0.5,<2.0.0",  # rapid_table
                      "PyYAML>=6.0.2,<7",  # yaml
                      "ftfy>=6.3.1,<7",  # unimernet_hf
@@ -56,7 +56,7 @@ if __name__ == '__main__':
                     "matplotlib>=3.10,<=3.10.1",
                     "ultralytics>=8.3.48,<=8.3.104",  # yolov8,公式检测
                     "doclayout_yolo==0.0.2b1",  # doclayout_yolo
-                    "dill==0.3.9",  # doclayout_yolo
+                    "dill>=0.3.8",  # doclayout_yolo
                     "PyYAML==6.0.2",  # yaml
                     "ftfy==6.3.1",  # unimernet_hf
                     "openai==1.71.0",  # openai SDK


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

Currently, MinerU explicitly depends on "dill==0.3.9", which conflicts with the "datasets" library (https://github.com/huggingface/datasets) because the latter requires "dill>=0.3.0,<0.3.9". The datasets library is widely used in AI projects (e.g., FlagEmbedding, text2vec, etc.). If a user's project depends on a library that uses "datasets", it cannot depend on MinerU at the same time. Therefore, it is hoped that MinerU can lower the version requirement of the "dill" library.

I have also checked whether the datasets project can raise the dill dependency version, but it seems that datasets will not upgrade this version in the short term. See https://github.com/huggingface/datasets/pull/7380#issuecomment-2720959036 for details.

## Modification

Updated the dependency version of "dill".

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
