### PR TITLE
fix ES Module syntax

### DIFF
--- a/projects/web/tailwind.config.js
+++ b/projects/web/tailwind.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
   ],


### PR DESCRIPTION
# Fix: Convert tailwind.config.js to ES Module syntax

## Problem
When running `pnpm build`, Node.js throws a warning about loading ES Module in require() context. This is because the project is configured to use ES Modules (package.json has `"type": "module"`), but tailwind.config.js was using CommonJS syntax (`module.exports`).
### Error Example
```bash
(node:22748) ExperimentalWarning: CommonJS module /Users/vlou/apps/MinerU/projects/web/node_modules/.pnpm/tailwindcss@3.4.10/node_modules/tailwindcss/lib/lib/load-config.js is loading ES Module /Users/vlou/apps/MinerU/projects/web/tailwind.config.js using require().
Support for loading ES Module in require() is an experimental feature and might change at any time

file:///Users/vlou/apps/MinerU/projects/web/tailwind.config.js:1
module.exports = {
^

ReferenceError: module is not defined
```

## Solution
Convert tailwind.config.js from CommonJS to ES Module syntax by:
- Replacing `module.exports` with `export default`
- Keeping all other configurations unchanged

## Testing
- Run `pnpm build` to verify the warning is resolved
- Ensure all Tailwind CSS functionality works as expected

## Related Context
- Project uses Vite with ES Module configuration
- Node.js version: v23.2.0
- Tailwind CSS version: ^3.4.10

## Impact
This change ensures consistent module syntax across the project and resolves the Node.js warning during build.
