### PR TITLE
fix web-api dockerfile build failed

### DIFF
--- a/projects/web_api/Dockerfile
+++ b/projects/web_api/Dockerfile
@@ -30,6 +30,7 @@ RUN python -m venv /app/venv && \
 
 # Download models
 COPY download_models.py .
+RUN sed -i 's/\r//' download_models.py
 RUN . /app/venv/bin/activate && \
     ./download_models.py
 


### PR DESCRIPTION
在web-api 中编译Dockerfile时会出现 /usr/bin/env: ‘python\r’: No such file or directory错误，在dockerfile文件中添加 RUN sed -i 's/\r//' download_models.py 来修复这个问题。