### PR TITLE
chore: speed up "mineru --help"

### DIFF
--- a/mineru/cli/client.py
+++ b/mineru/cli/client.py
@@ -7,7 +7,6 @@ from loguru import logger
 from mineru.utils.config_reader import get_device
 from mineru.utils.model_utils import get_vram
 from ..version import __version__
-from .common import do_parse, read_fn, pdf_suffixes, image_suffixes
 
 
 @click.command()
@@ -138,6 +137,8 @@ from .common import do_parse, read_fn, pdf_suffixes, image_suffixes
 
 
 def main(input_path, output_dir, method, backend, lang, server_url, start_page_id, end_page_id, formula_enable, table_enable, device_mode, virtual_vram, model_source):
+
+    from .common import do_parse, read_fn, pdf_suffixes, image_suffixes
 
     def get_device_mode() -> str:
         if device_mode is not None:

--- a/mineru/utils/config_reader.py
+++ b/mineru/utils/config_reader.py
@@ -2,7 +2,6 @@
 import json
 import os
 
-import torch
 from loguru import logger
 
 # 定义配置文件名常量
@@ -72,6 +71,8 @@ def get_device():
     if device_mode is not None:
         return device_mode
     else:
+        import torch
+
         if torch.cuda.is_available():
             return "cuda"
         elif torch.backends.mps.is_available():

--- a/mineru/utils/model_utils.py
+++ b/mineru/utils/model_utils.py
@@ -1,5 +1,4 @@
 import time
-import torch
 import gc
 from PIL import Image
 from loguru import logger
@@ -298,6 +297,8 @@ def get_res_list_from_layout_res(layout_res, iou_threshold=0.7, overlap_threshol
 
 
 def clean_memory(device='cuda'):
+    import torch
+
     if device == 'cuda':
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
@@ -321,6 +322,8 @@ def clean_vram(device, vram_threshold=8):
 
 
 def get_vram(device):
+    import torch
+
     if torch.cuda.is_available() and str(device).startswith("cuda"):
         total_memory = torch.cuda.get_device_properties(device).total_memory / (1024 ** 3)  # 将字节转换为 GB
         return total_memory


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Running the `mineru --help` command takes a long time (5~6 seconds on my machine) for importing `torch` (or other time-consuming imports), but they are not necessary for just printing help messages.

This PR changes some modules to be imported lazily, now running `mineru --help` only takes a few hundred milliseconds.

## Modification

Lazily import some modules.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
