### PR TITLE
fix(utils): add boundary checks for 2D tokens access in count_down function

### DIFF
--- a/mineru/utils/format_utils.py
+++ b/mineru/utils/format_utils.py
@@ -145,11 +145,14 @@ def otsl_parse_texts(texts, tokens):
     def count_down(tokens, c_idx, r_idx, which_tokens):
         span = 0
         r_idx_iter = r_idx
-        while tokens[r_idx_iter][c_idx] in which_tokens:
-            r_idx_iter += 1
-            span += 1
-            if r_idx_iter >= len(tokens):
-                return span
+        while r_idx_iter < len(tokens):  
+            if c_idx >= len(tokens[r_idx_iter]): 
+                break
+            if tokens[r_idx_iter][c_idx] in which_tokens:
+                span += 1
+                r_idx_iter += 1
+            else:
+                break
         return span
 
     for i, text in enumerate(texts):


### PR DESCRIPTION
## Motivation
This PR resolves an `IndexError` in the `count_down` function of [mineru/utils/format_utils.py](https://github.com/opendatalab/MinerU/blob/master/mineru/utils/format_utils.py) (tracked in [Issue #2690](https://github.com/opendatalab/MinerU/issues/2690)). The error occurs when parsing tables with irregular 2D token arrays (e.g., rows of varying lengths) due to unchecked access to column indices. This fix improves the robustness of table structure detection during OTSL-to-HTML conversion, ensuring stability for edge cases like malformed or dynamically generated tables.  
Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification
Enhanced boundary checks in the `count_down` function to validate both row and column indices before accessing elements in the 2D token array.  

## BC-breaking
No backward compatibility breaks.