### PR TITLE
fix: duplicated removing high iou layout when scores are equal

### DIFF
--- a/mineru/backend/pipeline/pipeline_magic_model.py
+++ b/mineru/backend/pipeline/pipeline_magic_model.py
@@ -47,10 +47,10 @@ class MagicModel:
     def __fix_by_remove_high_iou_and_low_confidence(self):
         need_remove_list = []
         layout_dets = self.__page_model_info['layout_dets']
-        for layout_det1 in layout_dets:
-            for layout_det2 in layout_dets:
-                if layout_det1 == layout_det2:
-                    continue
+        for i in range(len(layout_dets)):
+            for j in range(i + 1, len(layout_dets)):
+                layout_det1 = layout_dets[i]
+                layout_det2 = layout_dets[j]
                 if layout_det1['category_id'] in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] and layout_det2['category_id'] in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]:
                     if (
                         calculate_iou(layout_det1['bbox'], layout_det2['bbox'])


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

在pipeline_magic_model.py:__fix_by_remove_high_iou_and_low_confidence函数中，由于内外循环均从头到尾遍历数组，导致当两个iou较高的layout score相等时，两个layout都会被删除。这个问题在下游项目（如MonkeyOCR）中很容易被触发，因为他们使用vlm而没有正确传递score。

## Modification

修改循环逻辑为外层0...n，内层i+1...n
## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
