### PR TITLE
improve the caption match algorithm

### DIFF
--- a/mineru/backend/pipeline/pipeline_magic_model.py
+++ b/mineru/backend/pipeline/pipeline_magic_model.py
@@ -275,7 +275,8 @@ class MagicModel:
 
 
             fst_idx, fst_kind, left_x, top_y = candidates[0]
-            candidates.sort(key=lambda x: (x[2] - left_x) ** 2 + (x[3] - top_y)**2)
+            fst_bbox = subjects[fst_idx]['bbox'] if fst_kind == SUB_BIT_KIND else objects[fst_idx - OBJ_IDX_OFFSET]['bbox']
+            candidates.sort(key=lambda x: bbox_distance(fst_bbox,subjects[x[0]]['bbox']) if x[1] == SUB_BIT_KIND else bbox_distance(fst_bbox, objects[x[0] - OBJ_IDX_OFFSET]['bbox']))
             nxt = None
 
             for i in range(1, len(candidates)):
@@ -294,7 +295,8 @@ class MagicModel:
             pair_dis = bbox_distance(subjects[sub_idx]['bbox'], objects[obj_idx]['bbox'])
             nearest_dis = float('inf')
             for i in range(N):
-                if i in seen_idx or i == sub_idx:continue
+                # 取消原先算法中 1对1 匹配的偏置
+                # if i in seen_idx or i == sub_idx:continue
                 nearest_dis = min(nearest_dis, bbox_distance(subjects[i]['bbox'], objects[obj_idx]['bbox']))
 
             if pair_dis >= 3*nearest_dis:


### PR DESCRIPTION
## Motivation
I will improve the caption & footnotes matching algorithm `__tie_up_category_by_distance_v3` in `mineru/backend/pipeline/pipeline_magic_model.py`. The original algorithm has two issues: 
1. It uses the Euclidean distance of the top-left fixed points when calculating distances, which can lead to incorrect caption matching for long images. 
2. The algorithm has a preset bias that images and captions are in a one-to-one correspondence, so the matching will fail if an image has two captions.

## Modification
1. Modified the distance algorithm in the code to fix the matching issue with long images.line278-279
2. For already matched images, they still participate in the filtering process, and the bias is removed.line299

## BC-breaking (Optional)
none

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.

I have read the CLA Document and I hereby sign the CLA