### PR TITLE
Fix draw bbox when pdf rotate.

### DIFF
--- a/mineru/utils/draw_bbox.py
+++ b/mineru/utils/draw_bbox.py
@@ -38,7 +38,7 @@ def cal_canvas_rect(page, bbox):
     if 270 == rotation:
         rect_w, rect_h = rect_h, rect_w
         x0 = actual_height - y1
-        y0 = actual_width  - x1
+        y0 = actual_width - x1
     elif 180 == rotation:
         x0 = page_width - x1
         y0 = y0

--- a/mineru/utils/draw_bbox.py
+++ b/mineru/utils/draw_bbox.py
@@ -93,15 +93,15 @@ def draw_bbox_with_number(i, bbox_list, page, c, rgb_config, fill_config, draw_b
         c.saveState()
         rotation = page.get("/Rotate", 0)
         rotation = rotation % 360
-        
+    
         if 0 == rotation:
-            c.translate(rect[0] + rect[2] + 2, rect[1] + rect[3] - 10)  
+            c.translate(rect[0] + rect[2] + 2, rect[1] + rect[3] - 10)
         elif 90 == rotation:
-            c.translate(rect[0] + 2, rect[1] + rect[3] - 10)  
+            c.translate(rect[0] + 10, rect[1] + rect[3] + 2)
         elif 180 == rotation:
-            c.translate(rect[0] + 2, rect[1] - 10)
+            c.translate(rect[0] - 2, rect[1] + 10)
         elif 270 == rotation:
-            c.translate(rect[0] + rect[2] + 2, rect[1] - 10)
+            c.translate(rect[0] + rect[2] - 10, rect[1] - 2)
             
         c.rotate(rotation)
         c.drawString(0, 0, str(j + 1))


### PR DESCRIPTION
Thank you for open-sourcing such an excellent project.

## Motivation

When the input PDF is rotated, the final output layout.pdf will not be aligned with the content. These issues appeared in #251, #304, #1020, #2619

## Modification

Fixed the problem of coordinate system alignment between canvas drawing and source PDF in reportlab pdfgen.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.

## Test Result
<img width="1057" height="1475" alt="117cce1c-5c73-49f0-b9fd-c29b5b254ae1" src="https://github.com/user-attachments/assets/04fdb269-bc02-4d16-b6f8-21ea961bbb71" />
## Test inputs

[potracelib_origin--90.pdf](https://github.com/user-attachments/files/21415419/potracelib_origin--90.pdf) rotation 90
[2022.16origin--270-180.pdf](https://github.com/user-attachments/files/21415429/2022.16origin--270-180.pdf) rotation 270&180
[2020.0912-69--270.pdf](https://github.com/user-attachments/files/21415432/2020.0912-69--270.pdf)  rotation 270
[2022_16origin--270-90.pdf](https://github.com/user-attachments/files/21415455/2022_16origin--270-90.pdf) rotation 270&90




