### PR TITLE
Automatically opens the app in the default web browser

### DIFF
--- a/mineru/cli/gradio_app.py
+++ b/mineru/cli/gradio_app.py
@@ -245,9 +245,17 @@ def update_interface(backend_choice):
          "'a' for type '$', 'b' for type '()[]', 'all' for both types.",
     default='all',
 )
+@click.option(
+    '--enable-browser',
+    'browser_enable',
+    type=bool,
+    help="It provides an easy way to launch Gradio apps locally without manually navigating to the browser."
+         "Automatically opens the app in the default web browser.",
+    default=False,
+)
 def main(ctx,
         example_enable, sglang_engine_enable, api_enable, max_convert_pages,
-        server_name, server_port, latex_delimiters_type, **kwargs
+        server_name, server_port, latex_delimiters_type, browser_enable, **kwargs
 ):
 
     kwargs.update(arg_parse(ctx))
@@ -356,7 +364,7 @@ def main(ctx,
             api_name=api_name
         )
 
-    demo.launch(server_name=server_name, server_port=server_port, show_api=api_enable)
+    demo.launch(server_name=server_name, server_port=server_port, show_api=api_enable, inbrowser=browser_enable)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Thank you for open-sourcing such an excellent project.

## Motivation

It provides an easy way to launch Gradio apps locally without manually navigating to the browser.

## Modification

set browser_enable option for open the app in your default web browser. Runs a Gradio web application as a desktop app.

eg1:

```bash
# It won't open automatically
(envs) D:\MinerU>python D:\MinerU\mineru\cli\gradio_app.py --server-name 127.0.0.1 --server-port 7861 --enable-browser false
```

eg2:
```bash
# It will open automatically
(envs) D:\MinerU>python D:\MinerU\mineru\cli\gradio_app.py --server-name 127.0.0.1 --server-port 7861 --enable-browser true
```


eg3:
```bash
# It won't open automatically
(envs) D:\MinerU>python D:\MinerU\mineru\cli\gradio_app.py --server-name 127.0.0.1 --server-port 7861
```


## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
