### PR TITLE
fix: cast PDF /Rotate value to int to avoid IndirectObject type error

### DIFF
--- a/mineru/utils/draw_bbox.py
+++ b/mineru/utils/draw_bbox.py
@@ -25,7 +25,11 @@ def cal_canvas_rect(page, bbox):
     actual_height = page_height  # The height of the final PDF display
     
     rotation_obj = page.get("/Rotate", 0)
-    rotation = int(rotation_obj) % 360  # cast rotation to int to handle IndirectObject
+    try:
+        rotation = int(rotation_obj) % 360  # cast rotation to int to handle IndirectObject
+    except (ValueError, TypeError) as e:
+        logger.warning(f"Invalid /Rotate value {rotation_obj!r} on page; defaulting to 0. Error: {e}")
+        rotation = 0
     
     if rotation in [90, 270]:
         # PDF is rotated 90 degrees or 270 degrees, and the width and height need to be swapped

--- a/mineru/utils/draw_bbox.py
+++ b/mineru/utils/draw_bbox.py
@@ -91,7 +91,11 @@ def draw_bbox_with_number(i, bbox_list, page, c, rgb_config, fill_config, draw_b
         
         c.saveState()
         rotation_obj = page.get("/Rotate", 0)
-        rotation = int(rotation_obj) % 360  # cast rotation to int to handle IndirectObject
+        try:
+            rotation = int(rotation_obj) % 360  # cast rotation to int to handle IndirectObject
+        except (ValueError, TypeError):
+            logger.warning(f"Invalid /Rotate value: {rotation_obj!r}, defaulting to 0")
+            rotation = 0
 
         if rotation == 0:
             c.translate(rect[0] + rect[2] + 2, rect[1] + rect[3] - 10)

--- a/mineru/utils/draw_bbox.py
+++ b/mineru/utils/draw_bbox.py
@@ -24,8 +24,8 @@ def cal_canvas_rect(page, bbox):
     actual_width = page_width    # The width of the final PDF display
     actual_height = page_height  # The height of the final PDF display
     
-    rotation = page.get("/Rotate", 0)
-    rotation = rotation % 360
+    rotation_obj = page.get("/Rotate", 0)
+    rotation = int(rotation_obj) % 360  # cast rotation to int to handle IndirectObject
     
     if rotation in [90, 270]:
         # PDF is rotated 90 degrees or 270 degrees, and the width and height need to be swapped
@@ -35,19 +35,18 @@ def cal_canvas_rect(page, bbox):
     rect_w = abs(x1 - x0)
     rect_h = abs(y1 - y0)
     
-    if 270 == rotation:
+    if rotation == 270:
         rect_w, rect_h = rect_h, rect_w
         x0 = actual_height - y1
         y0 = actual_width - x1
-    elif 180 == rotation:
+    elif rotation == 180:
         x0 = page_width - x1
-        y0 = y0
-    elif 90 == rotation:
+        # y0 stays the same
+    elif rotation == 90:
         rect_w, rect_h = rect_h, rect_w
         x0, y0 = y0, x0 
     else:
-        # 0 == rotation:
-        x0 = x0
+        # rotation == 0
         y0 = page_height - y1
     
     rect = [x0, y0, rect_w, rect_h]        
@@ -91,16 +90,16 @@ def draw_bbox_with_number(i, bbox_list, page, c, rgb_config, fill_config, draw_b
         c.setFontSize(size=10)
         
         c.saveState()
-        rotation = page.get("/Rotate", 0)
-        rotation = rotation % 360
-    
-        if 0 == rotation:
+        rotation_obj = page.get("/Rotate", 0)
+        rotation = int(rotation_obj) % 360  # cast rotation to int to handle IndirectObject
+
+        if rotation == 0:
             c.translate(rect[0] + rect[2] + 2, rect[1] + rect[3] - 10)
-        elif 90 == rotation:
+        elif rotation == 90:
             c.translate(rect[0] + 10, rect[1] + rect[3] + 2)
-        elif 180 == rotation:
+        elif rotation == 180:
             c.translate(rect[0] - 2, rect[1] + 10)
-        elif 270 == rotation:
+        elif rotation == 270:
             c.translate(rect[0] + rect[2] - 10, rect[1] - 2)
             
         c.rotate(rotation)
@@ -114,8 +113,7 @@ def draw_layout_bbox(pdf_info, pdf_bytes, out_path, filename):
     dropped_bbox_list = []
     tables_list, tables_body_list = [], []
     tables_caption_list, tables_footnote_list = [], []
-    imgs_list, imgs_body_list, imgs_caption_list = [], [], []
-    imgs_footnote_list = []
+    imgs_list, imgs_body_list, imgs_caption_list, imgs_footnote_list = [], [], [], []
     titles_list = []
     texts_list = []
     interequations_list = []


### PR DESCRIPTION
## Motivation

Some PDFs store the page rotation entry `/Rotate` as an indirect reference. In such cases, `page.get("/Rotate", 0)` returns a `pypdf.generic.IndirectObject`. The current code performs `rotation % 360` directly on this object, which raises:

TypeError: unsupported operand type(s) for %: ‘IndirectObject’ and ‘int’

The goal of this PR is to make the drawing utilities robust to this case without changing behavior for normal PDFs.

## Modification

Minimal change in a single file: `mineru/utils/draw_bbox.py`.

After retrieving `/Rotate`, cast the value to `int` before applying modulo.

**Before:**
```python
rotation = page.get("/Rotate", 0)
rotation = rotation % 360
```

After:

```
rotation_obj = page.get("/Rotate", 0)
rotation = int(rotation_obj) % 360  # ensure rotation is an int even if it is an IndirectObject
```

This change is applied in two functions:
	1.	`cal_canvas_rect(...)`
	2.	`draw_bbox_with_number(...)`

There is no API change, no signature change, and no dependency change.

BC-breaking (Optional)

No. This fix only normalizes the type of the rotation value. Downstream projects should see identical behavior, except that previously failing PDFs will now process correctly.

Use cases (Optional)

PDFs whose /Rotate value is inherited or stored as an indirect object, such as scanned standards and technical documents generated by certain toolchains. With this fix, draw_layout_bbox and draw_span_bbox run without the TypeError.

Checklist

Before PR:
	•	Pre-commit or other linting tools are used to fix the potential lint issues.
	•	Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
	•	The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
	•	The documentation has been modified accordingly, like docstring or example tutorials.

After PR:
	•	If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
	•	CLA has been signed and all committers have signed the CLA in this PR.

Notes on tests (suggestion)

Add a regression test that loads a tiny PDF where /Rotate is an indirect reference (or mock page.get("/Rotate", 0) to return an object mimicking an IndirectObject). Assert that both cal_canvas_rect and draw_bbox_with_number complete without raising and produce numeric rotation handling.

