### PR TITLE
fix:fix the problem of repeated escape of '<' '>' symbols in html tab…

### DIFF
--- a/mineru/backend/vlm/vlm_middle_json_mkcontent.py
+++ b/mineru/backend/vlm/vlm_middle_json_mkcontent.py
@@ -103,7 +103,7 @@ def mk_blocks_to_markdown(para_blocks, make_mode, formula_enable, table_enable, 
                                     # if processed by table model
                                     if table_enable:
                                         if span.get('html', ''):
-                                            para_text += f"\n{span['html']}\n"
+                                            para_text += f"\n{html_table_filter(span['html'])}\n"
                                         elif span.get('image_path', ''):
                                             para_text += f"![]({img_buket_path}/{span['image_path']})"
                                     else:
@@ -169,7 +169,7 @@ def make_blocks_to_content_list(para_block, img_buket_path, page_idx, page_size)
                         if span['type'] == ContentType.TABLE:
 
                             if span.get('html', ''):
-                                para_content[BlockType.TABLE_BODY] = f"{span['html']}"
+                                para_content[BlockType.TABLE_BODY] = f"{html_table_filter(span['html'])}"
 
                             if span.get('image_path', ''):
                                 para_content['img_path'] = f"{img_buket_path}/{span['image_path']}"
@@ -231,3 +231,9 @@ def get_title_level(block):
     elif title_level < 1:
         title_level = 0
     return title_level
+
+def html_table_filter(table) :
+    return table.replace("&amp;lt;", "<") \
+        .replace("&amp;gt;", ">") \
+        .replace("&amp;le;", "≤") \
+        .replace("&amp;ge;", "≥")


### PR DESCRIPTION
#3520  

Motivation

When using vlm to parse pdf file, if the table contains '<'、'>', it will be parsed by '&amp;lt;' and '&amp;gt;', this pr is to fix it.

<img width="1778" height="864" alt="image" src="https://github.com/user-attachments/assets/fe3df585-fd4d-4c43-87ab-e1bcb77df2a8" />

## Modification

Modefiy the file `mineru/backend/vlm/vlm_middle_json_mkcontent.py`, add a function `html_table_filter`

```python
def html_table_filter(table) :
    return table.replace("&amp;lt;", "<") \
        .replace("&amp;gt;", ">") \
        .replace("&amp;le;", "≤") \
        .replace("&amp;ge;", "≥")
```
then using this function to filter the html table :

```python
if table_enable:
    if span.get('html', ''):
    para_text += f"\n{html_table_filter(span['html'])}\n"
```

<img width="1731" height="867" alt="image" src="https://github.com/user-attachments/assets/bdea7de8-7062-4cd4-ae69-754e2da0bab2" />

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
