### PR TITLE
优化pytorch_paddle ocr的推理性性能，总体提升约400%

### DIFF
--- a/mineru/model/ocr/paddleocr2pytorch/pytorch_paddle.py
+++ b/mineru/model/ocr/paddleocr2pytorch/pytorch_paddle.py
@@ -12,9 +12,9 @@ from loguru import logger
 from mineru.utils.config_reader import get_device
 from mineru.utils.enum_class import ModelPath
 from mineru.utils.models_download_utils import auto_download_and_get_model_root_path
-from ....utils.ocr_utils import check_img, preprocess_image, sorted_boxes, merge_det_boxes, update_det_boxes, get_rotate_crop_image
-from .tools.infer.predict_system import TextSystem
-from .tools.infer import pytorchocr_utility as utility
+from mineru.utils.ocr_utils import check_img, preprocess_image, sorted_boxes, merge_det_boxes, update_det_boxes, get_rotate_crop_image
+from mineru.model.ocr.paddleocr2pytorch.tools.infer.predict_system import TextSystem
+from mineru.model.ocr.paddleocr2pytorch.tools.infer import pytorchocr_utility as utility
 import argparse
 
 

--- a/mineru/model/ocr/paddleocr2pytorch/pytorchocr/data/imaug/operators.py
+++ b/mineru/model/ocr/paddleocr2pytorch/pytorchocr/data/imaug/operators.py
@@ -23,6 +23,7 @@ import sys
 import six
 import cv2
 import numpy as np
+from PIL import Image
 
 
 class DecodeImage(object):
@@ -104,16 +105,15 @@ class NormalizeImage(object):
         shape = (3, 1, 1) if order == 'chw' else (1, 1, 3)
         self.mean = np.array(mean).reshape(shape).astype('float32')
         self.std = np.array(std).reshape(shape).astype('float32')
+        self.scale = self.scale / self.std
+        self.mean = self.mean / self.std
+
 
     def __call__(self, data):
         img = data['image']
-        from PIL import Image
         if isinstance(img, Image.Image):
             img = np.array(img)
-        assert isinstance(img,
-                          np.ndarray), "invalid input 'img' in NormalizeImage"
-        data['image'] = (
-            img.astype('float32') * self.scale - self.mean) / self.std
+        data['image'] = img.astype('float32') * self.scale - self.mean
         return data
 
 

--- a/mineru/model/ocr/paddleocr2pytorch/pytorchocr/modeling/backbones/rec_lcnetv3.py
+++ b/mineru/model/ocr/paddleocr2pytorch/pytorchocr/modeling/backbones/rec_lcnetv3.py
@@ -245,18 +245,18 @@ class LearnableRepLayer(nn.Module):
             return 0, 0
         elif isinstance(branch, ConvBNLayer):
             kernel = branch.conv.weight
-            running_mean = branch.bn._mean
-            running_var = branch.bn._variance
+            running_mean = branch.bn.running_mean
+            running_var = branch.bn.running_var
             gamma = branch.bn.weight
             beta = branch.bn.bias
-            eps = branch.bn._epsilon
+            eps = branch.bn.eps
         else:
             assert isinstance(branch, nn.BatchNorm2d)
             if not hasattr(self, "id_tensor"):
                 input_dim = self.in_channels // self.groups
                 kernel_value = torch.zeros(
                     (self.in_channels, input_dim, self.kernel_size, self.kernel_size),
-                    dtype=branch.weight.dtype,
+                    dtype=branch.weight.dtype,  device= branch.weight.device,
                 )
                 for i in range(self.in_channels):
                     kernel_value[
@@ -264,11 +264,11 @@ class LearnableRepLayer(nn.Module):
                     ] = 1
                 self.id_tensor = kernel_value
             kernel = self.id_tensor
-            running_mean = branch._mean
-            running_var = branch._variance
+            running_mean = branch.running_mean
+            running_var = branch.running_var
             gamma = branch.weight
             beta = branch.bias
-            eps = branch._epsilon
+            eps = branch.eps
         std = (running_var + eps).sqrt()
         t = (gamma / std).reshape((-1, 1, 1, 1))
         return kernel * t, beta - running_mean * gamma / std

--- a/mineru/model/ocr/paddleocr2pytorch/tools/infer/predict_det.py
+++ b/mineru/model/ocr/paddleocr2pytorch/tools/infer/predict_det.py
@@ -116,6 +116,9 @@ class TextDetector(BaseOCRV20):
         self.load_pytorch_weights(self.weights_path)
         self.net.eval()
         self.net.to(self.device)
+        for module in self.net.modules():
+            if hasattr(module, 'rep'):
+                module.rep()
 
     def _batch_process_same_size(self, img_list):
         """
@@ -293,7 +296,7 @@ class TextDetector(BaseOCRV20):
         return dt_boxes
 
     def __call__(self, img):
-        ori_im = img.copy()
+        ori_shape = img.shape
         data = {'image': img}
         data = transform(data, self.preprocess_op)
         img, shape_list = data
@@ -331,9 +334,9 @@ class TextDetector(BaseOCRV20):
         if (self.det_algorithm == "SAST" and
             self.det_sast_polygon) or (self.det_algorithm in ["PSE", "FCE"] and
                                        self.postprocess_op.box_type == 'poly'):
-            dt_boxes = self.filter_tag_det_res_only_clip(dt_boxes, ori_im.shape)
+            dt_boxes = self.filter_tag_det_res_only_clip(dt_boxes, ori_shape)
         else:
-            dt_boxes = self.filter_tag_det_res(dt_boxes, ori_im.shape)
+            dt_boxes = self.filter_tag_det_res(dt_boxes, ori_shape)
 
         elapse = time.time() - starttime
         return dt_boxes, elapse

--- a/mineru/utils/ocr_utils.py
+++ b/mineru/utils/ocr_utils.py
@@ -406,6 +406,12 @@ def calculate_is_angle(poly):
         # logger.info((p3[1] - p1[1])/height)
         return True
 
+def is_bbox_aligned_rect(points):
+    x_coords = points[:, 0]
+    y_coords = points[:, 1]
+    unique_x = np.unique(x_coords)
+    unique_y = np.unique(y_coords)
+    return len(unique_x) == 2 and len(unique_y) == 2
 
 def get_rotate_crop_image(img, points):
     '''
@@ -419,6 +425,16 @@ def get_rotate_crop_image(img, points):
     points[:, 1] = points[:, 1] - top
     '''
     assert len(points) == 4, "shape of points must be 4*2"
+
+    if is_bbox_aligned_rect(points):
+        xmin = int(np.min(points[:, 0]))
+        xmax = int(np.max(points[:, 0]))
+        ymin = int(np.min(points[:, 1]))
+        ymax = int(np.max(points[:, 1]))
+        new_img = img[ymin:ymax, xmin:xmax].copy()
+        if new_img.shape[0] > 0 and new_img.shape[1] > 0:
+            return new_img
+
     img_crop_width = int(
         max(
             np.linalg.norm(points[0] - points[1]),


### PR DESCRIPTION
优化pytorch_paddle ocr的推理性能，主要优化点：
-   1. LearnableRepLayer推理时启用 rep()合并不同size的小卷积
-   2. Conv,BN, 激活函数的算子融合
-   3. 向量化CTC解码过程
-   4. get_rotate_crop_image 添加bbox是对齐的矩形时直接切片的短路逻辑，非规则四边形使用cv2.warpPerspective
-   5. 减少部分非必要的重复计算和拷贝

优化前推理消耗时间：
<img width="1798" height="336" alt="17a9f2ce-4239-482d-b420-f9909246b457" src="https://github.com/user-attachments/assets/066cac44-e0b9-4763-a65a-ce8d140adf1a" />

优化后消耗时间：
<img width="1772" height="238" alt="2d460620-7e34-4a98-b573-6274bcd87ac6" src="https://github.com/user-attachments/assets/31c082ee-bc79-48bc-85a7-ecba38e5e66f" />

测试使用图片：
<img width="1654" height="2339" alt="page" src="https://github.com/user-attachments/assets/883decc6-fa60-437a-bdb8-1bc943087325" />



