### PR TITLE
docs: Fix outdated sample data for output reference

### DIFF
--- a/docs/en/reference/output_files.md
+++ b/docs/en/reference/output_files.md
@@ -397,10 +397,10 @@ Text levels are distinguished through the `text_level` field:
     {
         "type": "image",
         "img_path": "images/a8ecda1c69b27e4f79fce1589175a9d721cbdc1cf78b4cc06a015f3746f6b9d8.jpg",
-        "img_caption": [
+        "image_caption": [
             "Fig. 1. Annual flow duration curves of daily flows from Pine Creek, Australia, 1989–2000. "
         ],
-        "img_footnote": [],
+        "image_footnote": [],
         "bbox": [
             62,
             480,

--- a/docs/zh/reference/output_files.md
+++ b/docs/zh/reference/output_files.md
@@ -397,10 +397,10 @@ inference_result: list[PageInferenceResults] = []
     {
         "type": "image",
         "img_path": "images/a8ecda1c69b27e4f79fce1589175a9d721cbdc1cf78b4cc06a015f3746f6b9d8.jpg",
-        "img_caption": [
+        "image_caption": [
             "Fig. 1. Annual flow duration curves of daily flows from Pine Creek, Australia, 1989–2000. "
         ],
-        "img_footnote": [],
+        "image_footnote": [],
         "bbox": [
             62,
             480,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Outdated documentation.

## Modification

Wrong key for sample data section in [output_files.md](https://opendatalab.github.io/MinerU/reference/output_files/#sample-data_2)


## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
