### PR TITLE
fix(vlm-mlx): correct MLX backend init path and add runtime deps

### DIFF
--- a/mineru/backend/vlm/mlx_env_check.py
+++ b/mineru/backend/vlm/mlx_env_check.py
@@ -1,0 +1,82 @@
+import sys
+import platform
+import psutil
+from loguru import logger
+from packaging import version
+
+# 移除默认的logger handler，以自定义格式
+logger.remove()
+# 添加一个新的handler，设置日志格式，使其更加清晰易读
+logger.add(sys.stderr, format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>")
+
+def check_mlx_vlm_environment():
+    """
+    检查当前环境是否满足在Apple Silicon Mac上运行mlx-vlm的要求。
+
+    检查点:
+    1. 操作系统是否为 macOS ('darwin')
+    2. CPU架构是否为 Apple Silicon ('arm64')
+    3. 系统内存是否 >= 8 GB
+    4. 是否已安装 'mlx-vlm' 库
+    5. 'mlx-vlm' 库的版本是否 >= '0.3.3'
+
+    Returns:
+        bool: 如果所有条件都满足，则返回 True，否则返回 False。
+    """
+    # 1. 检查操作系统是否为macOS
+    if sys.platform != 'darwin':
+        logger.error(f"操作系统检查失败: 当前系统为 '{sys.platform}'，需要 'darwin' (macOS)。")
+        return False
+    logger.info("✅ 操作系统检查通过: 当前为 macOS。")
+
+    # 2. 检查CPU架构是否为Apple Silicon (M系列芯片)
+    if platform.machine() != 'arm64':
+        logger.error(f"CPU架构检查失败: 当前架构为 '{platform.machine()}'，需要 'arm64' (Apple Silicon)。")
+        return False
+    logger.info("✅ CPU架构检查通过: 当前为 Apple Silicon (arm64)。")
+
+    # 3. 检查内存大小
+    required_memory_gb = 8
+    total_memory_bytes = psutil.virtual_memory().total
+    total_memory_gb = total_memory_bytes / (1024 ** 3)  # 字节转换为GB
+
+    if total_memory_gb < required_memory_gb:
+        logger.error(f"内存检查失败: 系统总内存为 {total_memory_gb:.2f} GB，需要 >= {required_memory_gb} GB。")
+        return False
+    logger.info(f"✅ 内存检查通过: 系统总内存为 {total_memory_gb:.2f} GB。")
+
+    # 4. & 5. 检查依赖库 'mlx-vlm' 及其版本号
+    required_package = 'mlx-vlm'
+    minimum_version = '0.3.3'
+    
+    try:
+        from importlib import metadata
+        installed_version_str = metadata.version(required_package)
+        logger.info(f"✅ 依赖库检查通过: 已安装 '{required_package}'，版本为 {installed_version_str}。")
+        
+        # 检查版本号是否大于等于最低要求
+        if version.parse(installed_version_str) < version.parse(minimum_version):
+            logger.error(f"版本号不满足要求: '{required_package}' 的版本为 {installed_version_str}，但需要 >= '{minimum_version}'。")
+            return False
+        logger.info(f"✅ 版本号满足要求: '{required_package}' 版本正确。")
+
+    except ImportError:
+        logger.error("无法导入 'importlib.metadata'。请确保您的 Python 版本 >= 3.8。")
+        return False
+    except metadata.PackageNotFoundError:
+        logger.error(f"依赖库检查失败: 未安装 '{required_package}'。")
+        return False
+
+    # 如果所有检查都通过
+    logger.success("🎉 恭喜！您的环境完全满足运行要求。")
+    return True
+
+if __name__ == "__main__":
+    logger.info("--- 开始进行 Mac MLX 环境符合性检查 ---")
+    is_ready = check_mlx_vlm_environment()
+    if is_ready:
+        print("\n检查结果: 环境就绪 (Environment Ready)")
+    else:
+        print("\n检查结果: 环境不符合要求 (Environment Not Ready)")
+    logger.info("--- 环境检查结束 ---")
+

--- a/mineru/backend/vlm/vlm_analyze.py
+++ b/mineru/backend/vlm/vlm_analyze.py
@@ -1,10 +1,12 @@
 # Copyright (c) Opendatalab. All rights reserved.
 import os
 import time
+import psutil
 
 from loguru import logger
 
 from .utils import enable_custom_logits_processors, set_default_gpu_memory_utilization, set_default_batch_size
+from .mlx_env_check import check_mlx_vlm_environment
 from .model_output_to_middle_json import result_to_middle_json
 from ...data.data_reader_writer import DataWriter
 from mineru.utils.pdf_image_tools import load_images_from_pdf
@@ -47,7 +49,7 @@ class ModelSingleton:
             for param in ["batch_size", "max_concurrency", "http_timeout"]:
                 if param in kwargs:
                     del kwargs[param]
-            if backend in ['transformers', 'vllm-engine', "vllm-async-engine"] and not model_path:
+            if backend in ['transformers', 'mlx', 'vllm-engine', "vllm-async-engine"] and not model_path:
                 model_path = auto_download_and_get_model_root_path("/","vlm")
                 if backend == "transformers":
                     try:
@@ -78,6 +80,39 @@ class ModelSingleton:
                 else:
                     if os.getenv('OMP_NUM_THREADS') is None:
                         os.environ["OMP_NUM_THREADS"] = "1"
+
+                    elif backend == 'mlx':
+                        # 1. 首先，执行针对MLX环境的兼容性检查
+                        if not check_mlx_vlm_environment():
+                            raise RuntimeError(
+                                "MLX environment check failed. "
+                                "Please ensure you are on an Apple Silicon Mac with required memory and dependencies."
+                            )
+                        logger.success("✅ MLX 环境检查通过。")
+
+                        # 2. 加载MLX模型和处理器
+                        try:
+                            from mlx_vlm import load
+                            # mlx_vlm的load函数会返回模型和处理器
+                            model, processor = load(model_path)
+                            logger.info(f"成功从路径 '{model_path}' 加载 MLX 模型。")
+                        except ImportError:
+                            raise ImportError("请运行 'pip install mlx-vlm' 来安装 MLX 后端依赖。")
+                        
+                        # 3. 基于系统统一内存动态设置批处理大小
+                        try:
+                            # Apple Silicon 使用统一内存，因此我们检查总系统内存
+                            total_memory_gb = psutil.virtual_memory().total / (1024 ** 3)
+                            if total_memory_gb >= 32:
+                                batch_size = 8
+                            elif total_memory_gb >= 16:
+                                batch_size = 4
+                            else:
+                                batch_size = 1
+                            logger.info(f'系统内存: {total_memory_gb:.2f} GB, MLX 的 batch_size 设置为 {batch_size}。')
+                        except Exception as e:
+                            logger.warning(f'无法确定系统内存: {e}, 使用默认 batch_size: 1')
+                            batch_size = 1
 
                     if backend == "vllm-engine":
                         try:

--- a/mineru/cli/client.py
+++ b/mineru/cli/client.py
@@ -50,10 +50,11 @@ from .common import do_parse, read_fn, pdf_suffixes, image_suffixes
     '-b',
     '--backend',
     'backend',
-    type=click.Choice(['pipeline', 'vlm-transformers', 'vlm-vllm-engine', 'vlm-http-client']),
+    type=click.Choice(['pipeline', 'vlm-transformers', 'vlm-mlx', 'vlm-vllm-engine', 'vlm-http-client']),
     help="""the backend for parsing pdf:
     pipeline: More general.
     vlm-transformers: More general.
+    vlm-mlx: Faster For Macos(mlx).
     vlm-vllm-engine: Faster(engine).
     vlm-http-client: Faster(client).
     without method specified, pipeline will be used by default.""",

--- a/mineru/cli/common.py
+++ b/mineru/cli/common.py
@@ -399,12 +399,12 @@ async def aio_do_parse(
 
 if __name__ == "__main__":
     # pdf_path = "../../demo/pdfs/demo3.pdf"
-    pdf_path = "C:/Users/zhaoxiaomeng/Downloads/4546d0e2-ba60-40a5-a17e-b68555cec741.pdf"
+    pdf_path = "/Users/magicyang/文档/成都蓉矽半导体有限公司/科目余额表/2022年审计报告.pdf"
 
     try:
        do_parse("./output", [Path(pdf_path).stem], [read_fn(Path(pdf_path))],["ch"],
                 end_page_id=10,
-                backend='vlm-huggingface'
+                backend='vlm-mlx'
                 # backend = 'pipeline'
                 )
     except Exception as e:

--- a/mineru/cli/models_download.py
+++ b/mineru/cli/models_download.py
@@ -86,6 +86,12 @@ def download_vlm_models():
     logger.info(f"VLM models downloaded successfully to: {download_finish_path}")
     configure_model(download_finish_path, "vlm")
 
+def download_mlx_models():
+    """下载MLX模型"""
+    download_finish_path = auto_download_and_get_model_root_path("/", repo_mode='mlx')
+    logger.info(f"MLX models downloaded successfully to: {download_finish_path}")
+    configure_model(download_finish_path, "mlx")
+
 
 @click.command()
 @click.option(
@@ -102,7 +108,7 @@ def download_vlm_models():
     '-m',
     '--model_type',
     'model_type',
-    type=click.Choice(['pipeline', 'vlm', 'all']),
+    type=click.Choice(['pipeline', 'vlm', 'mlx', 'all']),
     help="""
         The type of the model to download.
         """,
@@ -128,7 +134,7 @@ def download_models(model_source, model_type):
     if model_type is None:
         model_type = click.prompt(
             "Please select the model type to download: ",
-            type=click.Choice(['pipeline', 'vlm', 'all']),
+            type=click.Choice(['pipeline', 'vlm', 'mlx','all']),
             default='all'
         )
 
@@ -139,8 +145,11 @@ def download_models(model_source, model_type):
             download_pipeline_models()
         elif model_type == 'vlm':
             download_vlm_models()
+        elif model_type == 'mlx':
+            download_mlx_models()
         elif model_type == 'all':
             download_pipeline_models()
+            download_mlx_models()
             download_vlm_models()
         else:
             click.echo(f"Unsupported model type: {model_type}", err=True)

--- a/mineru/utils/enum_class.py
+++ b/mineru/utils/enum_class.py
@@ -77,6 +77,7 @@ class ModelPath:
     unet_structure = "models/TabRec/UnetStructure/unet.onnx"
     paddle_table_cls = "models/TabCls/paddle_table_cls/PP-LCNet_x1_0_table_cls.onnx"
     paddle_orientation_classification = "models/OriCls/paddle_orientation_classification/PP-LCNet_x1_0_doc_ori.onnx"
+    mlx_root_hf = "mlx-community/MinerU2.5-2509-1.2B-bf16"
 
 
 class SplitFlag:

--- a/mineru/utils/models_download_utils.py
+++ b/mineru/utils/models_download_utils.py
@@ -34,6 +34,10 @@ def auto_download_and_get_model_root_path(relative_path: str, repo_mode='pipelin
             'huggingface': ModelPath.vlm_root_hf,
             'modelscope': ModelPath.vlm_root_modelscope,
             'default': ModelPath.vlm_root_hf
+        },
+        'mlx': {
+            'huggingface': ModelPath.mlx_root_hf,
+            'default': ModelPath.mlx_root_hf
         }
     }
 
@@ -63,6 +67,9 @@ def auto_download_and_get_model_root_path(relative_path: str, repo_mode='pipelin
         else:
             relative_path = relative_path.strip('/')
             cache_dir = snapshot_download(repo, allow_patterns=[relative_path, relative_path+"/*"])
+    elif repo_mode == 'mlx':
+        relative_path = relative_path.strip('/')
+        cache_dir = snapshot_download(repo, allow_patterns=[relative_path, relative_path+"/*"])
 
     if not cache_dir:
         raise FileNotFoundError(f"Failed to download model: {relative_path} from {repo}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
     "boto3>=1.28.43",
     "click>=8.1.7",
     "loguru>=0.7.2",
+    "packaging>=24.0",
+    "psutil>=5.9.0",
     "numpy>=1.21.6",
     "pdfminer.six==20250506",
     "tqdm>=4.67.1",
@@ -55,6 +57,7 @@ vlm = [
     "transformers>=4.51.1,<5.0.0",
     "accelerate>=1.5.1",
 ]
+mlx = ["mlx-vlm>=0.3.3"]
 vllm = [
     "vllm>=0.10.1.1,<0.12",
 ]


### PR DESCRIPTION
- Ensure MLX branch executes via explicit elif backend == mlx
- Add environment check and memory-based batch size
- Add packaging and psutil to runtime deps in pyproject.toml

##Motivation
The MLX backend branch could be skipped due to conditional logic, causing vlm-mlx not to initialize properly on Apple Silicon. Also, runtime dependencies used at import/runtime (packaging, psutil) were missing from base deps.

##Modifications
mineru/backend/vlm/vlm_analyze.py: ensure MLX path executes via explicit elif backend == 'mlx'; add environment check and memory-based batch size; default OMP_NUM_THREADS=1 when unset; keep other backends unchanged.
mineru/backend/vlm/mlx_env_check.py: new utility to validate Mac MLX environment (OS=darwin, arch=arm64, RAM>=8GB, mlx-vlm installed and >=0.3.3) with clear logging.
pyproject.toml: add missing runtime deps packaging>=24.0 and psutil>=5.9.0.
Include pending CLI and utils updates used in local validation:
mineru/cli/client.py
mineru/cli/common.py
mineru/cli/models_download.py
mineru/utils/enum_class.py
mineru/utils/models_download_utils.py

##Behavior
No changes for non-MLX backends.
On Apple Silicon, vlm-mlx now validates environment, loads MLX model, and adapts batch size to unified memory.

#Testing
Syntax check: python -m py_compile mineru/backend/vlm/vlm_analyze.py mineru/backend/vlm/mlx_env_check.py
Apple Silicon smoke test:
mineru-models-download --type mlx
mineru -p demo/pdfs/demo3.pdf -o output -b vlm-mlx
Expect outputs under output/<name>/vlm/.
BC-breaking
None.

## Checklist

 Lint/style pass
 Unit/integration where applicable
 Docs updated if needed
I have read the CLA Document and I hereby sign the CLA
