### PR TITLE
Feature/parse file by path

### DIFF
--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -262,31 +262,22 @@ async def parse_pdf_by_path(
         return_model_output: bool = Form(False, description="是否生成模型输出文件"),
         return_content_list: bool = Form(False, description="是否生成内容列表文件"),
         return_images: bool = Form(True, description="是否提取图片"),
-        return_content: bool = Form(False, description="是否在响应中返回文件内容（会增加网络传输）"),
+        return_content: bool = Form(False, description="是否在响应中返回文件内容（默认只返回路径）"),
         start_page_id: int = Form(0, description="起始页码"),
         end_page_id: int = Form(99999, description="结束页码"),
 ):
     """
     基于路径的文件解析接口（仅支持服务器本地路径）
     
-    特点：
-    1. 无需上传文件，直接读取服务器本地文件系统
-    2. 结果写入共享存储路径，客户端可直接访问
-    3. 灵活控制生成哪些文件（Markdown、JSON、图片等）
-    4. 默认只返回元数据（路径、文件信息），最小化网络传输
-    5. 如果不指定output_dir，则在源文件同目录下生成结果
-    
+   
     使用示例：
     - 输入文件: /data/docs/report.pdf
     - 不指定output_dir: 结果在 /data/docs/mineru_output/report/auto/
     - 指定output_dir=/shared/results: 结果在 /shared/results/report/auto/
     
     参数说明：
-    - return_md/return_middle_json/return_model_output/return_content_list/return_images: 
-      控制是否生成对应的文件
-    - return_content: 控制是否在 HTTP 响应中返回文件内容
-      * False（默认）: 只返回文件路径和大小（轻量级）
-      * True: 在响应中包含文件内容（会增加网络传输）
+    - return_content=False (默认): 只返回文件路径和大小，客户端自行读取
+    - return_content=True: 在响应中返回文件内容，会增加网络传输
     
     注：auto 是解析方法目录（auto/txt/ocr），由 MinerU 内部结构决定
     """
@@ -295,78 +286,22 @@ async def parse_pdf_by_path(
     config = getattr(app.state, "config", {})
     
     try:
-        # 验证本地文件路径
-        file_path_obj = Path(file_path)
-        if not file_path_obj.exists():
-            return JSONResponse(
-                status_code=400,
-                content={"error": f"文件不存在: {file_path}"}
-            )
-        
-        if not file_path_obj.is_file():
-            return JSONResponse(
-                status_code=400,
-                content={"error": f"路径不是文件: {file_path}"}
-            )
-        
-        # 检查文件类型
-        file_suffix = guess_suffix_by_path(file_path_obj)
-        if file_suffix not in pdf_suffixes + image_suffixes:
-            return JSONResponse(
-                status_code=400,
-                content={"error": f"不支持的文件类型: {file_suffix}，仅支持PDF和图片格式"}
-            )
-        
         # 读取文件
+        file_path_obj = Path(file_path)
         logger.info(f"开始处理文件: {file_path}")
-        file_name = str(file_path_obj.stem)
+        
         pdf_bytes = read_fn(file_path_obj)
+        file_name = file_path_obj.stem
         
         # 确定输出目录
-        user_specified_output = output_dir is not None and output_dir.strip() != ""
-        default_output_dir = str(file_path_obj.parent / "mineru_output")
+        if not output_dir:
+            output_dir = str(file_path_obj.parent / "mineru_output")
         
-        if not user_specified_output:
-            # 未指定，使用默认路径
-            output_dir = default_output_dir
-            logger.info(f"未指定输出目录，使用默认路径: {output_dir}")
+        os.makedirs(output_dir, exist_ok=True)
         
-        # 检查输出目录的可写性
-        def check_writable(path: str) -> bool:
-            """检查目录是否可写"""
-            try:
-                # 如果目录不存在，尝试创建
-                os.makedirs(path, exist_ok=True)
-                # 尝试创建测试文件
-                test_file = Path(path) / f".mineru_write_test_{uuid.uuid4().hex[:8]}"
-                test_file.touch()
-                test_file.unlink()
-                return True
-            except (OSError, PermissionError) as e:
-                logger.warning(f"目录 {path} 不可写: {e}")
-                return False
-        
-        # 如果用户指定的目录不可写，尝试回退到默认路径
-        if user_specified_output and not check_writable(output_dir):
-            logger.warning(f"指定的输出目录 {output_dir} 无写权限，回退到默认路径")
-            output_dir = default_output_dir
-            
-            # 检查默认路径是否可写
-            if not check_writable(output_dir):
-                return JSONResponse(
-                    status_code=500,
-                    content={
-                        "error": f"输出目录无写权限，包括默认路径 {output_dir}",
-                        "suggestion": "请检查文件系统权限或指定其他输出目录"
-                    }
-                )
-            logger.info(f"使用默认输出路径: {output_dir}")
-        
-        logger.info(f"最终输出目录: {output_dir}")
-        
-        # 调用解析函数（结果直接写入output_dir）
+        # 调用解析函数
         await aio_do_parse(
-            output_dir=output_dir,  # 用户指定的路径，不添加UUID
+            output_dir=output_dir,
             pdf_file_names=[file_name],
             pdf_bytes_list=[pdf_bytes],
             p_lang_list=[lang],
@@ -387,115 +322,73 @@ async def parse_pdf_by_path(
             **config
         )
         
-        # 9. 确定输出路径
+        # 确定解析结果目录
         if backend.startswith("pipeline"):
             parse_dir = os.path.join(output_dir, file_name, parse_method)
         else:
             parse_dir = os.path.join(output_dir, file_name, "vlm")
         
-        # 构建轻量级响应（只包含元数据）
-        response_data = {
-            "status": "success",
-            "backend": backend,
-            "version": __version__,
-            "file_info": {
-                "input_file": str(file_path),
-                "file_name": file_name,
-                "file_size": file_path_obj.stat().st_size,
-            },
-            "output_info": {
-                "output_dir": output_dir,
-                "parse_dir": parse_dir,
-                "files": {}  # 只列出生成的文件路径，不包含内容
-            }
+        # 构建响应数据
+        result_dict = {
+            "output_dir": output_dir,
+            "parse_dir": parse_dir
         }
         
-        # 列出生成的文件（不读取内容）
+        # 默认：只返回文件路径和大小（轻量级）
         if os.path.exists(parse_dir):
-            # Markdown 文件
-            if return_md:
-                md_file = os.path.join(parse_dir, f"{file_name}.md")
-                if os.path.exists(md_file):
-                    response_data["output_info"]["files"]["markdown"] = md_file
-                    response_data["output_info"]["files"]["markdown_size"] = os.path.getsize(md_file)
+            # 定义文件配置：(return参数, 文件后缀, 结果key前缀)
+            file_configs = [
+                (return_md, ".md", "markdown"),
+                (return_middle_json, "_middle.json", "middle_json"),
+                (return_model_output, "_model.json", "model_output"),
+                (return_content_list, "_content_list.json", "content_list"),
+            ]
             
-            # 中间 JSON 文件
-            if return_middle_json:
-                json_file = os.path.join(parse_dir, f"{file_name}_middle.json")
-                if os.path.exists(json_file):
-                    response_data["output_info"]["files"]["middle_json"] = json_file
-                    response_data["output_info"]["files"]["middle_json_size"] = os.path.getsize(json_file)
+            # 统一处理所有文件
+            for should_return, suffix, key_prefix in file_configs:
+                if should_return:
+                    file_path = os.path.join(parse_dir, f"{file_name}{suffix}")
+                    if os.path.exists(file_path):
+                        result_dict[f"{key_prefix}_path"] = file_path
+                        result_dict[f"{key_prefix}_size"] = os.path.getsize(file_path)
             
-            # 模型输出文件
-            if return_model_output:
-                model_file = os.path.join(parse_dir, f"{file_name}_model.json")
-                if os.path.exists(model_file):
-                    response_data["output_info"]["files"]["model_output"] = model_file
-                    response_data["output_info"]["files"]["model_output_size"] = os.path.getsize(model_file)
-            
-            # 内容列表文件
-            if return_content_list:
-                content_list_file = os.path.join(parse_dir, f"{file_name}_content_list.json")
-                if os.path.exists(content_list_file):
-                    response_data["output_info"]["files"]["content_list"] = content_list_file
-                    response_data["output_info"]["files"]["content_list_size"] = os.path.getsize(content_list_file)
-            
-            # 图片目录
+            # images 特殊处理（目录而非文件）
             if return_images:
                 images_dir = os.path.join(parse_dir, "images")
                 if os.path.exists(images_dir):
                     image_files = glob.glob(os.path.join(glob.escape(images_dir), "*.jpg"))
-                    response_data["output_info"]["files"]["images_dir"] = images_dir
-                    response_data["output_info"]["files"]["images_count"] = len(image_files)
+                    result_dict["images_dir"] = images_dir
+                    result_dict["images_count"] = len(image_files)
         
-        # 可选：如果用户明确要求，才返回文件内容（在响应中包含实际内容）
-        if return_content:
-            logger.warning("return_content=True，将增加网络传输量")
-            response_data["content"] = {}
+        # 可选：返回文件内容（return_content=True 时）
+        if return_content and os.path.exists(parse_dir):
+            result_dict["content"] = {}
             
-            # 返回 Markdown 内容
             if return_md:
-                md_file = response_data["output_info"]["files"].get("markdown")
-                if md_file and os.path.exists(md_file):
-                    with open(md_file, 'r', encoding='utf-8') as f:
-                        response_data["content"]["markdown"] = f.read()
-            
-            # 返回中间 JSON 内容
+                result_dict["content"]["md_content"] = get_infer_result(".md", file_name, parse_dir)
             if return_middle_json:
-                json_file = response_data["output_info"]["files"].get("middle_json")
-                if json_file and os.path.exists(json_file):
-                    with open(json_file, 'r', encoding='utf-8') as f:
-                        response_data["content"]["middle_json"] = f.read()
-            
-            # 返回模型输出内容
+                result_dict["content"]["middle_json"] = get_infer_result("_middle.json", file_name, parse_dir)
             if return_model_output:
-                model_file = response_data["output_info"]["files"].get("model_output")
-                if model_file and os.path.exists(model_file):
-                    with open(model_file, 'r', encoding='utf-8') as f:
-                        response_data["content"]["model_output"] = f.read()
-            
-            # 返回内容列表
+                result_dict["content"]["model_output"] = get_infer_result("_model.json", file_name, parse_dir)
             if return_content_list:
-                content_list_file = response_data["output_info"]["files"].get("content_list")
-                if content_list_file and os.path.exists(content_list_file):
-                    with open(content_list_file, 'r', encoding='utf-8') as f:
-                        response_data["content"]["content_list"] = f.read()
-            
-            # 返回图片（Base64 编码）
+                result_dict["content"]["content_list"] = get_infer_result("_content_list.json", file_name, parse_dir)
             if return_images:
-                images_dir = response_data["output_info"]["files"].get("images_dir")
-                if images_dir and os.path.exists(images_dir):
-                    image_files = glob.glob(os.path.join(glob.escape(images_dir), "*.jpg"))
-                    response_data["content"]["images"] = {
-                        os.path.basename(img_path): f"data:image/jpeg;base64,{encode_image(img_path)}"
-                        for img_path in image_files
-                    }
+                images_dir = os.path.join(parse_dir, "images")
+                image_paths = glob.glob(os.path.join(glob.escape(images_dir), "*.jpg"))
+                result_dict["content"]["images"] = {
+                    os.path.basename(image_path): f"data:image/jpeg;base64,{encode_image(image_path)}"
+                    for image_path in image_paths
+                }
         
         logger.info(f"处理完成: {parse_dir}")
         
         return JSONResponse(
             status_code=200,
-            content=response_data
+            content={
+                "backend": backend,
+                "version": __version__,
+                "results": {file_name: result_dict}
+            }
         )
         
     except Exception as e:

--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -417,7 +417,6 @@ async def parse_pdf_by_path(
         
         # 构建响应（在上传/清理之前）
         storage_type = "s3" if is_s3_output else "local"
-        path_suffix = "_uri" if is_s3_output else "_path"
         
         # 计算最终路径
         if is_s3_output:
@@ -433,7 +432,7 @@ async def parse_pdf_by_path(
             "parse_dir": final_parse_dir
         }
         
-        # 添加文件路径和大小
+        # 添加文件路径和大小（统一使用 _path 字段，可能是 S3 URI 或本地路径）
         file_configs = [
             (return_md, ".md", "markdown"),
             (return_middle_json, "_middle.json", "middle_json"),
@@ -446,15 +445,15 @@ async def parse_pdf_by_path(
                 local_file = os.path.join(local_parse_dir, f"{file_name}{suffix}")
                 if os.path.exists(local_file):
                     file_location = f"{final_parse_dir.rstrip('/')}/{file_name}{suffix}"
-                    result_dict[f"{key_prefix}{path_suffix}"] = file_location
+                    result_dict[f"{key_prefix}_path"] = file_location
                     result_dict[f"{key_prefix}_size"] = os.path.getsize(local_file)
         
-        # 添加图片信息
+        # 添加图片信息（统一使用 _path 字段）
         if return_images:
             local_images_dir = os.path.join(local_parse_dir, "images")
             if os.path.exists(local_images_dir):
                 images_location = f"{final_parse_dir.rstrip('/')}/images/"
-                result_dict[f"images{path_suffix}"] = images_location
+                result_dict["images_path"] = images_location
                 result_dict["images_count"] = len(glob.glob(os.path.join(glob.escape(local_images_dir), "*.jpg")))
         
         # 读取内容（在上传/清理之前）


### PR DESCRIPTION
## PR Description

### Feature: File Parse by Path with S3 Support

This PR implements a new API endpoint that enables file parsing via file path (local or S3 URI), with optimized response strategies for different client needs.

---

## What Changed

### New API Endpoint
- **`POST /file_parse_by_path`** - New endpoint for parsing files by path (local or S3)

### New Functions
- **`read_file_with_s3_support()`** - Unified file reader supporting both local paths and S3 URIs (68 lines)

### Modified Files
- **`mineru/cli/fast_api.py`** - Added new endpoint and helper functions

**Total Changes:** +253 lines, -2 lines

---

## Key Features

### 1. Unified File Access

**Supports Multiple File Sources:**
- **Local Path**: `/data/docs/report.pdf`
- **S3 URI**: `s3://bucket-name/path/to/file.pdf`

**S3 Configuration Options:**
- **Option 1 (Recommended)**: Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `S3_ENDPOINT_URL`)
- **Option 2**: API parameters (`s3_ak`, `s3_sk`, `s3_endpoint`)

### 2. Optimized Response Strategy

**Lightweight Mode (default, `return_content=False`):**
- Returns only file paths and sizes
- Minimizes network overhead
- Client reads files locally

**Full Response Mode (`return_content=True`):**
- Returns file contents embedded in response
- Suitable for remote clients without file system access

### 3. Smart Output Directory Handling

- **Local Files**: Auto-generates output in source file directory if not specified
- **S3 Files**: Requires explicit `output_dir` parameter

### 4. Image-to-PDF Conversion

- Automatically converts image files (JPG, PNG, etc.) to PDF format
- Supports both local and S3 image sources

---

## Implementation Details

### File Reading Logic

```python
read_file_with_s3_support(file_path, s3_ak, s3_sk, s3_endpoint, s3_addressing_style)
```

1. **Path Detection**: Checks if path starts with `s3://` or `s3a://`
2. **S3 Handling**: Uses `S3Reader` to fetch file bytes from object storage
3. **Local Handling**: Uses existing `read_fn()` for local file system
4. **Format Detection**: Auto-detects file type via `guess_suffix_by_bytes()`
5. **Image Conversion**: Converts images to PDF using `images_bytes_to_pdf_bytes()`

### Response Structure

**Lightweight Response (default):**
```json
{
  "results": {
    "filename": {
      "output_dir": "/path/to/output",
      "parse_dir": "/path/to/output/filename/auto",
      "markdown_path": "/path/to/output/filename/auto/filename.md",
      "markdown_size": 12345,
      "images_dir": "/path/to/output/filename/auto/images",
      "images_count": 5
    }
  }
}
```

**Full Response (`return_content=True`):**
```json
{
  "results": {
    "filename": {
      "...paths and sizes...",
      "content": {
        "md_content": "...",
        "middle_json": {...},
        "images": {"image1.jpg": "data:image/jpeg;base64,..."}
      }
    }
  }
}
```

---

## New Dependencies

- `mineru.data.io.s3.S3Reader` - S3 file reader
- `mineru.data.utils.path_utils.parse_s3path` - S3 path parser
- `mineru.utils.guess_suffix_or_lang.guess_suffix_by_bytes` - Byte-based format detection
- `mineru.utils.pdf_image_tools.images_bytes_to_pdf_bytes` - Image-to-PDF converter

---

## API Usage Examples

### Example 1: Parse Local File (Auto Output Dir)
```bash
curl -X POST "http://localhost:8080/file_parse_by_path" \
  -F "file_path=/data/docs/report.pdf" \
  -F "lang=en"
```

### Example 2: Parse S3 File (With Credentials)
```bash
curl -X POST "http://localhost:8080/file_parse_by_path" \
  -F "file_path=s3://my-bucket/docs/report.pdf" \
  -F "output_dir=/tmp/mineru_output" \
  -F "s3_ak=YOUR_ACCESS_KEY" \
  -F "s3_sk=YOUR_SECRET_KEY" \
  -F "s3_endpoint=https://s3.amazonaws.com"
```

### Example 3: Parse S3 File (Using Env Variables)
```bash
export AWS_ACCESS_KEY_ID=your_key
export AWS_SECRET_ACCESS_KEY=your_secret
export S3_ENDPOINT_URL=https://s3.amazonaws.com

curl -X POST "http://localhost:8080/file_parse_by_path" \
  -F "file_path=s3://my-bucket/docs/report.pdf" \
  -F "output_dir=/tmp/mineru_output"
```

### Example 4: Get Full Response with Content
```bash
curl -X POST "http://localhost:8080/file_parse_by_path" \
  -F "file_path=/data/docs/report.pdf" \
  -F "return_content=true"
```

---

## Jira

-https://implustech.atlassian.net/browse/OZIM-729

---

## ✅ Checklist

### Code Quality
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] My changes generate no new warnings

### Testing
- [] I have tested local file parsing
- [] I have tested S3 file parsing with credentials
- [] I have tested S3 file parsing with environment variables
- [] I have tested both response modes (lightweight and full)


---

## 🧪 Testing Guide

### Test Scenario 1: Local File Parse
```bash
# Prepare test file
echo "test content" > /tmp/test.txt

# Call API
curl -X POST "http://localhost:8080/file_parse_by_path" \
  -F "file_path=/tmp/test.txt"

# Verify: Check response contains output_dir and parse_dir
```

### Test Scenario 2: S3 File Parse
```bash
# Set S3 credentials
export AWS_ACCESS_KEY_ID=your_key
export AWS_SECRET_ACCESS_KEY=your_secret
export S3_ENDPOINT_URL=https://s3.amazonaws.com

# Call API
curl -X POST "http://localhost:8080/file_parse_by_path" \
  -F "file_path=s3://test-bucket/sample.pdf" \
  -F "output_dir=/tmp/s3_output"

# Verify: Check file is downloaded and parsed correctly
```

### Test Scenario 3: Response Mode Comparison
```bash
# Lightweight mode (default)
time curl -X POST "http://localhost:8080/file_parse_by_path" \
  -F "file_path=/tmp/test.pdf" \
  -F "return_content=false"

# Full mode (with content)
time curl -X POST "http://localhost:8080/file_parse_by_path" \
  -F "file_path=/tmp/test.pdf" \
  -F "return_content=true"

# Verify: Full mode takes longer but returns content in response
```

### Expected Logs: