### PR TITLE
io: introduce URI-based IO layer with optional s3 backend

### DIFF
--- a/mineru/data/io/s3.py
+++ b/mineru/data/io/s3.py
@@ -1,5 +1,11 @@
-import boto3
-from botocore.config import Config
+try:
+    import boto3
+    from botocore.config import Config
+except ImportError as e:
+    raise ImportError(
+        "S3 support requires optional dependency 'boto3'. "
+        'Please install via `pip install \"mineru[s3]\"`.'
+    ) from e
 
 from ..io.base import IOReader, IOWriter
 

--- a/mineru/data/utils/uri_io.py
+++ b/mineru/data/utils/uri_io.py
@@ -1,0 +1,125 @@
+import os
+import tempfile
+import shutil
+from pathlib import Path
+from typing import Optional, Tuple, Dict, Any
+from loguru import logger
+
+from mineru.cli.common import read_fn
+from mineru.data.utils.path_utils import parse_s3path
+
+# ------- optional s3 backends (lazy import) -------
+try:
+    from mineru.data.io.s3 import S3Reader
+    from mineru.data.data_reader_writer.s3 import S3DataWriter
+except Exception:
+    S3Reader = None
+    S3DataWriter = None
+
+
+def _require_s3_backend():
+    if S3Reader is None or S3DataWriter is None:
+        raise ImportError(
+            "S3 backend not installed. Please run: pip install mineru[s3]"
+        )
+
+
+def get_s3_env_config() -> Dict[str, str]:
+    
+    ak = os.getenv("AWS_ACCESS_KEY_ID")
+    sk = os.getenv("AWS_SECRET_ACCESS_KEY")
+    endpoint = os.getenv("S3_ENDPOINT_URL")
+    addressing_style = os.getenv("S3_ADDRESSING_STYLE", "auto")
+
+    if not all([ak, sk, endpoint]):
+        raise ValueError(
+            "S3 credentials not configured. Please set: "
+            "AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, S3_ENDPOINT_URL"
+        )
+    return {"ak": ak, "sk": sk, "endpoint": endpoint, "addressing_style": addressing_style}
+
+
+def read_bytes_from_uri(input_uri: str) -> bytes:
+    """
+    读取输入资源。当前版本只支持本地路径和 s3:// / s3a://。
+    其他带 scheme 的 URI（如 http/https/file）如需支持可在此处拓展。
+    """
+    if input_uri.startswith(("s3://", "s3a://")):
+        _require_s3_backend()
+        cfg = get_s3_env_config()
+        bucket, key = parse_s3path(input_uri)
+        logger.info(f"Reading from S3: s3://{bucket}/{key}")
+        reader = S3Reader(
+            bucket=bucket,
+            ak=cfg["ak"],
+            sk=cfg["sk"],
+            endpoint_url=cfg["endpoint"],
+            addressing_style=cfg["addressing_style"],
+        )
+        return reader.read(key)
+
+    if "://" in input_uri:
+        # 非 s3 的 scheme，当前版本不支持（http/https/file 等可在后续扩展）
+        scheme = input_uri.split("://", 1)[0]
+        raise ValueError(
+            f"Unsupported URI scheme: {scheme}. Only local paths and s3:// are supported."
+        )
+
+    # local path
+    return read_fn(Path(input_uri))
+
+
+def prepare_output_dir(output_uri: Optional[str], fallback_local_dir: str) -> Tuple[str, bool, Optional[str]]:
+    """
+    根据 output_uri 决定实际写入目录：
+    - s3://...  => 写 temp dir，之后上传
+    - local/None => 写本地 fallback_local_dir
+    返回 (actual_output_dir, is_s3_output, normalized_output_uri)
+    """
+    if output_uri and output_uri.startswith(("s3://", "s3a://")):
+        tmp = tempfile.mkdtemp(prefix="mineru_")
+        return tmp, True, output_uri
+
+    # local
+    os.makedirs(fallback_local_dir, exist_ok=True)
+    return fallback_local_dir, False, output_uri or fallback_local_dir
+
+
+def upload_parse_dir_to_s3(local_parse_dir: str, output_uri: str) -> str:
+    """
+    把 local_parse_dir 整体上传到 output_uri 指定的 s3 prefix.
+    返回最终 s3 parse_dir（供 API 返回给客户端）
+    """
+    _require_s3_backend()
+    cfg = get_s3_env_config()
+    bucket, prefix = parse_s3path(output_uri)
+    prefix = prefix.rstrip("/")
+
+    writer = S3DataWriter(
+        default_prefix_without_bucket=prefix,
+        bucket=bucket,
+        ak=cfg["ak"],
+        sk=cfg["sk"],
+        endpoint_url=cfg["endpoint"],
+        addressing_style=cfg["addressing_style"],
+    )
+
+    count = 0
+    for root, _dirs, files in os.walk(local_parse_dir):
+        for f in files:
+            lp = os.path.join(root, f)
+            rel = os.path.relpath(lp, local_parse_dir).replace("\\", "/")
+            with open(lp, "rb") as fp:
+                writer.write(rel, fp.read())
+                count += 1
+
+    logger.info(f"Uploaded {count} files to {output_uri}")
+    # 返回 parse_dir（s3 语义）
+    return f"s3://{bucket}/{prefix}/"
+    
+
+def cleanup_temp_dir(tmp_dir: str):
+    try:
+        shutil.rmtree(tmp_dir)
+    except Exception as e:
+        logger.warning(f"cleanup temp dir failed: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "boto3>=1.28.43",
     "click>=8.1.7",
     "loguru>=0.7.2",
     "numpy>=1.21.6",
@@ -43,6 +42,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+s3 = [
+    "boto3>=1.28.43",
+]
 test = [
     "mineru[core]",
     "pytest",
@@ -90,6 +92,7 @@ core = [
     "mineru[pipeline]",
     "mineru[api]",
     "mineru[gradio]",
+    "mineru[s3]",
     "mineru[mlx] ; sys_platform == 'darwin'",
 ]
 all = [

--- a/tests/test_uri_io.py
+++ b/tests/test_uri_io.py
@@ -1,0 +1,75 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from mineru.data.utils.uri_io import (
+    read_bytes_from_uri,
+    prepare_output_dir,
+)
+
+
+def test_read_bytes_from_uri_local_pdf():
+    """本地 PDF 路径应能正常读取为 bytes。"""
+    pdf_path = Path(__file__).parent / "unittest" / "pdfs" / "test.pdf"
+    assert pdf_path.is_file()
+
+    data = read_bytes_from_uri(str(pdf_path))
+    assert isinstance(data, bytes)
+    assert len(data) > 0
+
+
+def test_read_bytes_from_uri_unsupported_scheme():
+    """非 s3 且带 scheme 的 URI 应抛出友好的错误。"""
+    with pytest.raises(ValueError) as exc_info:
+        read_bytes_from_uri("http://example.com/foo.pdf")
+
+    msg = str(exc_info.value)
+    assert "Unsupported URI scheme" in msg
+    assert "Only local paths and s3://" in msg
+
+
+def test_read_bytes_from_uri_s3_without_backend(monkeypatch):
+    """在未配置 S3 backend 时，访问 s3:// 应提示安装 mineru[s3]。"""
+    import mineru.data.utils.uri_io as uri_io_mod
+
+    # 强制模拟缺失 S3 backend
+    monkeypatch.setattr(uri_io_mod, "S3Reader", None)
+    monkeypatch.setattr(uri_io_mod, "S3DataWriter", None)
+
+    with pytest.raises(ImportError) as exc_info:
+        uri_io_mod.read_bytes_from_uri("s3://bucket/key")
+
+    msg = str(exc_info.value)
+    assert "mineru[s3]" in msg
+
+
+def test_prepare_output_dir_local(tmp_path):
+    """本地输出应使用 fallback_local_dir 并确保目录存在。"""
+    fallback_dir = tmp_path / "out"
+
+    actual_dir, is_s3_output, normalized = prepare_output_dir(
+        output_uri=None,
+        fallback_local_dir=str(fallback_dir),
+    )
+
+    assert is_s3_output is False
+    assert actual_dir == str(fallback_dir)
+    assert normalized == str(fallback_dir)
+    assert os.path.isdir(actual_dir)
+
+
+def test_prepare_output_dir_s3(tmp_path):
+    """s3 输出应返回临时目录并标记为 s3 输出。"""
+    output_uri = "s3://my-bucket/some/prefix"
+
+    actual_dir, is_s3_output, normalized = prepare_output_dir(
+        output_uri=output_uri,
+        fallback_local_dir=str(tmp_path),
+    )
+
+    assert is_s3_output is True
+    assert normalized == output_uri
+    assert os.path.isdir(actual_dir)
+
+


### PR DESCRIPTION
PR Description
Feature: URI-based I/O helpers with optional S3 backend
This PR introduces a URI-based I/O utility layer to support local and S3 storage in a reusable way, and makes the S3 backend an optional, lazily imported dependency. This is a pure infrastructure enhancement and does not change any FastAPI endpoints.
What Changed
New Files
mineru/data/utils/uri_io.py – Core URI-based helpers:
read_bytes_from_uri (local path + s3:// / s3a://)
prepare_output_dir
upload_parse_dir_to_s3
cleanup_temp_dir
tests/test_uri_io.py – Unit tests for local/S3 URI handling and output directory selection
Modified Files
pyproject.toml
Moved boto3 from core dependencies to an optional extra: mineru[s3]
Ensured mineru[core] pulls in mineru[s3] so the “full install” still has S3 support
mineru/data/io/s3.py
Wrapped boto3 import in a guarded lazy import with a clear error message:
If S3 is used without installing mineru[s3], users get a precise ImportError telling them how to enable it
URI I/O Logic
How It Works
URI-based reading (read_bytes_from_uri)
Local paths (no ://): use existing read_fn(Path(...)) to handle PDF/images as before
S3 URIs (s3:// / s3a://):
Validate S3 backend availability (_require_s3_backend)
Read bytes via S3Reader using env-based config (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, S3_ENDPOINT_URL, optional S3_ADDRESSING_STYLE)
Other schemes (http://, https://, file://, etc.):
Explicitly rejected with a ValueError("Unsupported URI scheme ... Only local paths and s3:// are supported.")
Output directory selection (prepare_output_dir)
S3 output (output_uri starts with s3:// / s3a://):
Allocate a temporary local directory with tempfile.mkdtemp
Return (temp_dir, is_s3_output=True, normalized_output_uri=output_uri)
Local output / no URI:
Ensure fallback_local_dir exists
Return (fallback_local_dir, is_s3_output=False, normalized_output_uri)
Uploading parse results to S3 (upload_parse_dir_to_s3)
Requires S3 backend (mineru[s3] installed)
Uses S3DataWriter to mirror the full subtree under local_parse_dir into the target S3 prefix
Returns the final S3 “parse_dir” URI (s3://bucket/prefix/) for use in API responses
Temp directory cleanup (cleanup_temp_dir)
Best-effort shutil.rmtree with warning logs on failure
Designed to be safe for use in FastAPI BackgroundTask
Key Components
mineru.data.utils.uri_io.read_bytes_from_uri:
Normalizes input handling for local paths and S3 URIs
Provides clear error messages for unsupported schemes and missing S3 backend
mineru.data.utils.uri_io.prepare_output_dir:
Centralizes decision “write to real local directory vs temp dir for S3 upload”
mineru.data.utils.uri_io.upload_parse_dir_to_s3:
Generic “upload a whole parse directory to S3” helper, independent of API layer
Optional S3 backend (mineru[s3]):
pyproject.toml defines s3 extra with boto3
mineru/data/io/s3.py guards imports and gives a direct hint: pip install "mineru[s3]"

Checklist
Code Quality
[x] Code follows existing project style and layout conventions
[x] Self-review performed for uri_io.py, s3.py, and pyproject.toml changes
[x] New helpers and edge cases are documented in code comments
[x] Changes introduce no new linter errors in touched files
Testing
[x] pytest tests/test_uri_io.py passes locally
[x] Verified local-path reading works against tests/unittest/pdfs/test.pdf
[x] Verified unsupported schemes (http://...) raise clear ValueError
[x] Verified S3 access without backend raises clear ImportError pointing to mineru[s3]
[x] Verified prepare_output_dir behavior for both local and S3 output modes
Documentation
[ ] (To be done in follow-up PR) Public docs/update for new URI-based behavior when integrating into /file_parse
[x] Internal behavior and expectations are documented in uri_io.py docstrings and tests
🧪 Testing Guide
Basic Tests:
Ensure mineru is installed in editable mode with test extras:
   pip install -e ".[test]"
Run the new tests:
   pytest tests/test_uri_io.py
Scenarios Covered:
Local read:
read_bytes_from_uri("tests/unittest/pdfs/test.pdf") returns non-empty bytes
Unsupported scheme:
read_bytes_from_uri("http://example.com/foo.pdf") raises ValueError with “Unsupported URI scheme” and “Only local paths and s3://”
Missing S3 backend:
With S3 backend disabled/missing, calling read_bytes_from_uri("s3://bucket/key") raises ImportError mentioning pip install "mineru[s3]".
Output dir selection:
prepare_output_dir(None, "./output") returns a real local directory
prepare_output_dir("s3://my-bucket/prefix", "./output") returns a temp dir with is_s3_output=True and normalized_output_uri unchanged