### PR TITLE
Add an interface for obtaining more Mineru processing data

### DIFF
--- a/projects/mineru_tianshu/api_server.py
+++ b/projects/mineru_tianshu/api_server.py
@@ -11,11 +11,12 @@ import tempfile
 from pathlib import Path
 from loguru import logger
 import uvicorn
-from typing import Optional
+from typing import Optional, Dict, Any
 from datetime import datetime
 import os
 import re
 import uuid
+import json
 from minio import Minio
 
 from task_db import TaskDB
@@ -125,6 +126,108 @@ def process_markdown_images(md_content: str, image_dir: Path, upload_images: boo
         return md_content  # 出错时返回原内容
 
 
+def read_json_file(file_path: Path):
+    """
+    读取 JSON 文件
+
+    Args:
+        file_path: JSON 文件路径
+
+    Returns:
+        解析后的 JSON 数据，失败返回 None
+    """
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception as e:
+        logger.error(f"Failed to read JSON file {file_path}: {e}")
+        return None
+
+
+def get_file_metadata(file_path: Path):
+    """
+    获取文件元数据
+
+    Args:
+        file_path: 文件路径
+
+    Returns:
+        包含文件元数据的字典
+    """
+    if not file_path.exists():
+        return None
+
+    stat = file_path.stat()
+    return {
+        'size': stat.st_size,
+        'created_at': datetime.fromtimestamp(stat.st_ctime).isoformat(),
+        'modified_at': datetime.fromtimestamp(stat.st_mtime).isoformat()
+    }
+
+
+def get_images_info(image_dir: Path, upload_to_minio: bool = False):
+    """
+    获取图片目录信息
+
+    Args:
+        image_dir: 图片目录路径
+        upload_to_minio: 是否上传到 MinIO
+
+    Returns:
+        图片信息字典
+    """
+    if not image_dir.exists() or not image_dir.is_dir():
+        return {
+            'count': 0,
+            'list': [],
+            'uploaded_to_minio': False
+        }
+
+    # 支持的图片格式
+    image_extensions = {'.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp', '.svg'}
+    image_files = [f for f in image_dir.iterdir() if f.is_file() and f.suffix.lower() in image_extensions]
+
+    images_list = []
+
+    for img_file in sorted(image_files):
+        img_info = {
+            'name': img_file.name,
+            'size': img_file.stat().st_size,
+            'path': str(img_file.relative_to(image_dir.parent))
+        }
+
+        # 如果需要上传到 MinIO
+        if upload_to_minio:
+            try:
+                minio_client = get_minio_client()
+                bucket_name = MINIO_CONFIG['bucket_name']
+                minio_endpoint = MINIO_CONFIG['endpoint']
+
+                # 生成 UUID 作为新文件名
+                file_extension = img_file.suffix
+                new_filename = f"{uuid.uuid4()}{file_extension}"
+                object_name = f"images/{new_filename}"
+
+                # 上传到 MinIO
+                minio_client.fput_object(bucket_name, object_name, str(img_file))
+
+                # 生成访问 URL
+                scheme = 'https' if MINIO_CONFIG['secure'] else 'http'
+                img_info['url'] = f"{scheme}://{minio_endpoint}/{bucket_name}/{object_name}"
+
+            except Exception as e:
+                logger.error(f"Failed to upload image {img_file.name} to MinIO: {e}")
+                img_info['url'] = None
+
+        images_list.append(img_info)
+
+    return {
+        'count': len(images_list),
+        'list': images_list,
+        'uploaded_to_minio': upload_to_minio
+    }
+
+
 @app.get("/")
 async def root():
     """API根路径"""
@@ -192,6 +295,221 @@ async def submit_task(
     except Exception as e:
         logger.error(f"❌ Failed to submit task: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/api/v1/tasks/{task_id}/data")
+async def get_task_data(
+    task_id: str,
+    include_fields: str = Query(
+        "md,content_list,middle_json,model_output,images",
+        description="需要返回的字段，逗号分隔：md,content_list,middle_json,model_output,images,layout_pdf,span_pdf,origin_pdf"
+    ),
+    upload_images: bool = Query(False, description="是否上传图片到MinIO并返回URL"),
+    include_metadata: bool = Query(True, description="是否包含文件元数据")
+):
+    """
+    按需获取任务的解析数据
+
+    支持灵活获取 MinerU 解析后的数据，包括：
+    - Markdown 内容
+    - Content List JSON（结构化内容列表）
+    - Middle JSON（中间处理结果）
+    - Model Output JSON（模型原始输出）
+    - 图片列表
+    - 其他辅助文件（layout PDF、span PDF、origin PDF）
+
+    通过 include_fields 参数按需选择需要返回的字段
+    """
+    # 获取任务信息
+    task = db.get_task(task_id)
+
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    # 构建基础响应
+    response = {
+        'success': True,
+        'task_id': task_id,
+        'status': task['status'],
+        'file_name': task['file_name'],
+        'backend': task['backend'],
+        'created_at': task['created_at'],
+        'completed_at': task['completed_at']
+    }
+
+    # 如果任务未完成，直接返回状态
+    if task['status'] != 'completed':
+        response['message'] = f"Task is in {task['status']} status, data not available yet"
+        return response
+
+    # 检查结果路径
+    if not task['result_path']:
+        response['message'] = 'Task completed but result files have been cleaned up (older than retention period)'
+        return response
+
+    result_dir = Path(task['result_path'])
+    if not result_dir.exists():
+        response['message'] = 'Result directory does not exist'
+        return response
+
+    # 解析需要返回的字段
+    fields = [f.strip() for f in include_fields.split(',')]
+
+    # 初始化 data 字段
+    response['data'] = {}  # type: ignore
+
+    logger.info(f"📦 Getting complete data for task {task_id}, fields: {fields}")
+
+    # 查找文件（递归搜索，MinerU 输出结构：task_id/filename/auto/*.md）
+    try:
+        # 1. 处理 Markdown 文件
+        if 'md' in fields:
+            md_files = list(result_dir.rglob('*.md'))
+            # 排除带特殊后缀的 md 文件
+            md_files = [f for f in md_files if not any(suffix in f.stem for suffix in ['_layout', '_span', '_origin'])]
+
+            if md_files:
+                md_file = md_files[0]
+                logger.info(f"📄 Reading markdown file: {md_file}")
+
+                with open(md_file, 'r', encoding='utf-8') as f:
+                    md_content = f.read()
+
+                # 处理图片（如果需要上传）
+                image_dir = md_file.parent / 'images'
+                if upload_images and image_dir.exists():
+                    md_content = process_markdown_images(md_content, image_dir, upload_images)
+
+                response['data']['markdown'] = {
+                    'content': md_content,
+                    'file_name': md_file.name
+                }
+
+                if include_metadata:
+                    metadata = get_file_metadata(md_file)
+                    if metadata:
+                        response['data']['markdown']['metadata'] = metadata
+
+        # 2. 处理 Content List JSON
+        if 'content_list' in fields:
+            content_list_files = list(result_dir.rglob('*_content_list.json'))
+            if content_list_files:
+                content_list_file = content_list_files[0]
+                logger.info(f"📄 Reading content list file: {content_list_file}")
+
+                content_data = read_json_file(content_list_file)
+                if content_data is not None:
+                    response['data']['content_list'] = {
+                        'content': content_data,
+                        'file_name': content_list_file.name
+                    }
+
+                    if include_metadata:
+                        metadata = get_file_metadata(content_list_file)
+                        if metadata:
+                            response['data']['content_list']['metadata'] = metadata
+
+        # 3. 处理 Middle JSON
+        if 'middle_json' in fields:
+            middle_json_files = list(result_dir.rglob('*_middle.json'))
+            if middle_json_files:
+                middle_json_file = middle_json_files[0]
+                logger.info(f"📄 Reading middle json file: {middle_json_file}")
+
+                middle_data = read_json_file(middle_json_file)
+                if middle_data is not None:
+                    response['data']['middle_json'] = {
+                        'content': middle_data,
+                        'file_name': middle_json_file.name
+                    }
+
+                    if include_metadata:
+                        metadata = get_file_metadata(middle_json_file)
+                        if metadata:
+                            response['data']['middle_json']['metadata'] = metadata
+
+        # 4. 处理 Model Output JSON
+        if 'model_output' in fields:
+            model_output_files = list(result_dir.rglob('*_model.json'))
+            if model_output_files:
+                model_output_file = model_output_files[0]
+                logger.info(f"📄 Reading model output file: {model_output_file}")
+
+                model_data = read_json_file(model_output_file)
+                if model_data is not None:
+                    response['data']['model_output'] = {
+                        'content': model_data,
+                        'file_name': model_output_file.name
+                    }
+
+                    if include_metadata:
+                        metadata = get_file_metadata(model_output_file)
+                        if metadata:
+                            response['data']['model_output']['metadata'] = metadata
+
+        # 5. 处理图片
+        if 'images' in fields:
+            image_dirs = list(result_dir.rglob('images'))
+            if image_dirs:
+                image_dir = image_dirs[0]
+                logger.info(f"🖼️  Getting images info from: {image_dir}")
+
+                images_info = get_images_info(image_dir, upload_images)
+                response['data']['images'] = images_info
+
+        # 6. 处理 Layout PDF
+        if 'layout_pdf' in fields:
+            layout_pdf_files = list(result_dir.rglob('*_layout.pdf'))
+            if layout_pdf_files:
+                layout_pdf_file = layout_pdf_files[0]
+                response['data']['layout_pdf'] = {
+                    'file_name': layout_pdf_file.name,
+                    'path': str(layout_pdf_file.relative_to(result_dir))
+                }
+
+                if include_metadata:
+                    metadata = get_file_metadata(layout_pdf_file)
+                    if metadata:
+                        response['data']['layout_pdf']['metadata'] = metadata
+
+        # 7. 处理 Span PDF
+        if 'span_pdf' in fields:
+            span_pdf_files = list(result_dir.rglob('*_span.pdf'))
+            if span_pdf_files:
+                span_pdf_file = span_pdf_files[0]
+                response['data']['span_pdf'] = {
+                    'file_name': span_pdf_file.name,
+                    'path': str(span_pdf_file.relative_to(result_dir))
+                }
+
+                if include_metadata:
+                    metadata = get_file_metadata(span_pdf_file)
+                    if metadata:
+                        response['data']['span_pdf']['metadata'] = metadata
+
+        # 8. 处理 Origin PDF
+        if 'origin_pdf' in fields:
+            origin_pdf_files = list(result_dir.rglob('*_origin.pdf'))
+            if origin_pdf_files:
+                origin_pdf_file = origin_pdf_files[0]
+                response['data']['origin_pdf'] = {
+                    'file_name': origin_pdf_file.name,
+                    'path': str(origin_pdf_file.relative_to(result_dir))
+                }
+
+                if include_metadata:
+                    metadata = get_file_metadata(origin_pdf_file)
+                    if metadata:
+                        response['data']['origin_pdf']['metadata'] = metadata
+
+        logger.info(f"✅ Complete data retrieved successfully for task {task_id}")
+
+    except Exception as e:
+        logger.error(f"❌ Failed to get complete data for task {task_id}: {e}")
+        logger.exception(e)
+        response['error'] = str(e)
+
+    return response
 
 
 @app.get("/api/v1/tasks/{task_id}")

--- a/projects/mineru_tianshu/api_server.py
+++ b/projects/mineru_tianshu/api_server.py
@@ -11,7 +11,7 @@ import tempfile
 from pathlib import Path
 from loguru import logger
 import uvicorn
-from typing import Optional, Dict, Any
+from typing import Optional
 from datetime import datetime
 import os
 import re
@@ -57,7 +57,7 @@ MINIO_CONFIG = {
 def get_minio_client():
     """获取MinIO客户端实例"""
     return Minio(
-        MINIO_CONFIG['endpoint'],
+        endpoint=MINIO_CONFIG['endpoint'],
         access_key=MINIO_CONFIG['access_key'],
         secret_key=MINIO_CONFIG['secret_key'],
         secure=MINIO_CONFIG['secure']
@@ -103,7 +103,7 @@ def process_markdown_images(md_content: str, image_dir: Path, upload_images: boo
                 try:
                     # 上传到 MinIO
                     object_name = f"images/{new_filename}"
-                    minio_client.fput_object(bucket_name, object_name, str(full_image_path))
+                    minio_client.fput_object(bucket_name=bucket_name, object_name=bucket_name, file_path=str(full_image_path))
                     
                     # 生成 MinIO 访问 URL
                     scheme = 'https' if MINIO_CONFIG['secure'] else 'http'
@@ -209,7 +209,7 @@ def get_images_info(image_dir: Path, upload_to_minio: bool = False):
                 object_name = f"images/{new_filename}"
 
                 # 上传到 MinIO
-                minio_client.fput_object(bucket_name, object_name, str(img_file))
+                minio_client.fput_object(bucket_name=bucket_name, object_name=object_name, file_path=str(img_file))
 
                 # 生成访问 URL
                 scheme = 'https' if MINIO_CONFIG['secure'] else 'http'
@@ -366,7 +366,7 @@ async def get_task_data(
         if 'md' in fields:
             md_files = list(result_dir.rglob('*.md'))
             # 排除带特殊后缀的 md 文件
-            md_files = [f for f in md_files if not any(suffix in f.stem for suffix in ['_layout', '_span', '_origin'])]
+            md_files = [f for f in md_files if not any(f.stem.endswith(suffix) for suffix in ['_layout', '_span', '_origin'])] 
 
             if md_files:
                 md_file = md_files[0]
@@ -507,7 +507,7 @@ async def get_task_data(
     except Exception as e:
         logger.error(f"❌ Failed to get complete data for task {task_id}: {e}")
         logger.exception(e)
-        response['error'] = str(e)
+        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")  
 
     return response
 


### PR DESCRIPTION

Add an interface to obtain mineru processing data to adapt to the situations that the application side may use.

## Motivation

Add an interface to obtain mineru processing data to adapt to the situations that the application side may use.

## Modification

The /api/v1/tasks/submit interface of the tianshu solution only returns md files and cannot meet the usage scenarios of various situations，implement it by adding the /api/v1/tasks/{task_id}/data interface。

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
