### PR TITLE
feat:1.add health check 2.solve run blocking task in async pipeline mode

### DIFF
--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -99,6 +99,16 @@ def get_infer_result(file_suffix_identifier: str, pdf_name: str, parse_dir: str)
     return None
 
 
+@app.get("/health")
+async def health_check():
+    """
+    Health check endpoint for Kubernetes liveness probes.
+    This endpoint is lightweight and doesn't rely on any business logic,
+    ensuring quick responses even when documents are being processed.
+    """
+    return {"status": "ok", "version": __version__}
+
+
 @app.post(path="/file_parse", dependencies=[Depends(limit_concurrency)])
 async def parse_pdf(
         files: List[UploadFile] = File(..., description="Upload pdf or image files for parsing"),

--- a/mineru/utils/os_env_config.py
+++ b/mineru/utils/os_env_config.py
@@ -11,6 +11,16 @@ def get_load_images_timeout() -> int:
     return get_value_from_string(env_value, 300)
 
 
+def get_load_images_process_num() -> int:
+    env_value = os.getenv('MINERU_PDF_LOAD_PROCESS_NUM', None)
+    return get_value_from_string(env_value, 1)
+
+
+def get_concurrent_request_num() -> int:
+    env_value = os.getenv('MINERU_CONCURRENT_REQUEST_NUM', None)
+    return get_value_from_string(env_value, 1)
+
+
 def get_value_from_string(env_value: str, default_value: int) -> int:
     if env_value is not None:
         try:
@@ -28,3 +38,5 @@ if __name__ == '__main__':
     print(get_value_from_string('-1', -1))
     print(get_value_from_string('abc', -1))
     print(get_load_images_timeout())
+    print(get_load_images_process_num())
+    print(get_concurrent_request_num())


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

Motivation
I’m running the MinerU API service on Kubernetes and found several issues:

There is no proper liveness/readiness probe endpoint.
When using the /docs page for API testing, calling parse_file blocks the entire event loop, causing all other endpoints to become unresponsive.

During testing, memory usage spikes when loading PDF images.
The service starts 4 worker processes by default, and memory usage doubles or even triples.
With Kubernetes memory limits, the container frequently gets OOMKilled.

Modification
Therefore, I made the following improvements:

Added a lightweight health check endpoint (/health)
More suitable for Kubernetes probes than /docs.

Refactored parse_file into a non-blocking API
It no longer blocks the async event loop.
To prevent request overload, I added a configurable concurrency limit: MINERU_CONCURRENT_REQUEST_NUM

Made the PDF image loading worker count configurable
The default is now 1 instead of 4, which prevents unnecessary memory duplication and avoids K8s OOM issues.I added a configurable env: MINERU_PDF_LOAD_PROCESS_NUM

BC-breaking (Optional)
Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

Use cases (Optional)
If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

Checklist
Before PR:

[ * ] Pre-commit or other linting tools are used to fix the potential lint issues.
[ * ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
[ * ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
[ * ] The documentation has been modified accordingly, like docstring or example tutorials.
After PR:

[ * ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
[ * ] CLA has been signed and all committers have signed the CLA in this PR.