### PR TITLE
add background task for clean temp file in api

### DIFF
--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -195,7 +195,7 @@ async def parse_pdf(
     end_page_id: int = Form(
         99999, description="The ending page for PDF parsing, beginning from 0"
     ),
-    background_tasks: BackgroundTasks = BackgroundTasks(),
+    background_tasks: BackgroundTasks,
 ):
     # 获取命令行配置参数
     config = getattr(app.state, "config", {})

--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -16,17 +16,17 @@ from fastapi.responses import JSONResponse, FileResponse
 from typing import List, Optional
 from loguru import logger
 from fastapi import BackgroundTasks
-
-log_level = os.getenv("MINERU_LOG_LEVEL", "INFO").upper()
-logger.remove()  # 移除默认handler
-logger.add(sys.stderr, level=log_level)  # 添加新handler
-
 from base64 import b64encode
 
 from mineru.cli.common import aio_do_parse, read_fn, pdf_suffixes, image_suffixes
 from mineru.utils.cli_parser import arg_parse
 from mineru.utils.guess_suffix_or_lang import guess_suffix_by_path
 from mineru.version import __version__
+
+log_level = os.getenv("MINERU_LOG_LEVEL", "INFO").upper()
+logger.remove()  # 移除默认handler
+logger.add(sys.stderr, level=log_level)  # 添加新handler
+
 
 # 并发控制器
 _request_semaphore: Optional[asyncio.Semaphore] = None
@@ -124,6 +124,7 @@ def get_infer_result(
 
 @app.post(path="/file_parse", dependencies=[Depends(limit_concurrency)])
 async def parse_pdf(
+    background_tasks: BackgroundTasks,
     files: List[UploadFile] = File(
         ..., description="Upload pdf or image files for parsing"
     ),
@@ -195,7 +196,6 @@ async def parse_pdf(
     end_page_id: int = Form(
         99999, description="The ending page for PDF parsing, beginning from 0"
     ),
-    background_tasks: BackgroundTasks,
 ):
     # 获取命令行配置参数
     config = getattr(app.state, "config", {})

--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -4,7 +4,6 @@ import os
 import re
 import tempfile
 import asyncio
-import fastapi
 import uvicorn
 import click
 import zipfile

--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -13,7 +13,6 @@ import glob
 from fastapi import Depends, FastAPI, HTTPException, UploadFile, File, Form
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse, FileResponse
-from starlette.background import BackgroundTask
 from typing import List, Optional
 from loguru import logger
 from fastapi import BackgroundTasks

--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -94,7 +94,7 @@ def sanitize_filename(filename: str) -> str:
 
 
 def cleanup_file(file_path: str) -> None:
-    """清理临时 zip 文件"""
+    """清理临时文件或目录"""
     try:
         if os.path.exists(file_path):
             if os.path.isfile(file_path):


### PR DESCRIPTION
## Motivation

Currently, MinerU does not delete the temporary files in `outputs/<uuid>` after processing a file. This can cause a significant increase in disk usage after prolonged operation.

## Modification

- Using the background_task mechanism in FastAPI, the corresponding folder is automatically deleted after the request returns. Ref: https://fastapi.tiangolo.com/tutorial/background-tasks/#background-tasks
- use black to format `fast_api.py`

## BC-breaking (Optional)

no

## Use cases (Optional)

no

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
