### PR TITLE
fix windows nms cuda error

### DIFF
--- a/mineru/model/layout/doclayoutyolo.py
+++ b/mineru/model/layout/doclayoutyolo.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from typing import List, Dict, Union
 
 from doclayout_yolo import YOLOv10
@@ -46,13 +47,20 @@ class DocLayoutYOLOModel:
             })
         return layout_res
 
+    def _get_predict_device(self) -> str:
+        """获取预测设备：Windows 平台 CUDA 环境下使用 CPU 绕过 torchvision::nms 问题"""
+        if sys.platform == 'win32' and str(self.device).startswith('cuda'):
+            return 'cpu'
+        return self.device
+
     def predict(self, image: Union[np.ndarray, Image.Image]) -> List[Dict]:
         prediction = self.model.predict(
             image,
             imgsz=self.imgsz,
             conf=self.conf,
             iou=self.iou,
-            verbose=False
+            verbose=False,
+            device=self._get_predict_device()
         )[0]
         return self._parse_prediction(prediction)
 
@@ -75,6 +83,7 @@ class DocLayoutYOLOModel:
                     conf=conf,
                     iou=self.iou,
                     verbose=False,
+                    device=self._get_predict_device(),
                 )
                 for pred in predictions:
                     results.append(self._parse_prediction(pred))

--- a/mineru/model/mfd/yolo_v8.py
+++ b/mineru/model/mfd/yolo_v8.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from typing import List, Union
 
 import torch
@@ -32,13 +33,19 @@ class YOLOv8MFDModel:
         is_batch: bool = False,
         conf: float = None,
     ) -> List:
+        # Windows 平台下，强制使用 CPU 进行预测以绕过 torchvision::nms CUDA 问题
+        # 模型仍在 GPU 上，但预测在 CPU 上执行
+        if sys.platform == 'win32' and str(self.device).startswith('cuda'):
+            predict_device = 'cpu'
+        else:
+            predict_device = self.device
         preds = self.model.predict(
             inputs,
             imgsz=self.imgsz,
             conf=conf if conf is not None else self.conf,
             iou=self.iou,
             verbose=False,
-            device=self.device
+            device=predict_device
         )
         return [pred.cpu() for pred in preds] if is_batch else preds[0].cpu()
 


### PR DESCRIPTION
## Motivation

On Windows with CUDA-enabled PyTorch (e.g., PyTorch 2.10.0+cu128 / Torchvision 0.25.0+cu128), the `torchvision::nms` operator is not available for the CUDA backend, causing a runtime error when running YOLO-based models (`YOLOv8MFDModel` and `DocLayoutYOLOModel`) on GPU. This issue is specific to Windows and prevents users from using the `pipeline` and `hybrid` backends on Windows with CUDA.

## Modification

- **`mineru/model/mfd/yolo_v8.py`**: Added `import sys`. Modified `_run_predict` to force `device='cpu'` during inference when running on Windows with a CUDA device, while the model itself remains loaded on GPU.

- **`mineru/model/layout/doclayoutyolo.py`**: Added `import sys`. Introduced a helper method `_get_predict_device()` that returns `'cpu'` on Windows CUDA environments, otherwise returns the original device. Applied this helper to both `predict` and `batch_predict` methods.

The workaround only activates on `sys.platform == 'win32'` with a CUDA device, leaving Linux and macOS behavior completely unchanged.

## BC-breaking (Optional)

No backward compatibility is broken. The fix is platform-conditional and only affects inference device selection on Windows. Model loading, output format, and all downstream interfaces remain the same.

## Use cases (Optional)

Users running MinerU on Windows with NVIDIA GPU can now successfully use the `pipeline` and `hybrid` backends without encountering the `torchvision::nms CUDA backend not supported` error:

```bash
mineru convert input.pdf --output-dir output --backend hybrid-auto-engine
```