### PR TITLE
docs: Clarify CLI output file formats for per-page text extraction

### DIFF
--- a/docs/en/reference/output_files.md
+++ b/docs/en/reference/output_files.md
@@ -54,11 +54,46 @@ The following sections provide detailed descriptions of each file's purpose and 
 > [!IMPORTANT]
 > The VLM backend output has significant changes in version 2.5 and is not backward-compatible with the pipeline backend. If you plan to build secondary development on structured outputs, please read this document carefully.
 
+### Quick Guide: Extracting Per-Page Text
+
+For downstream applications that need to extract text content organized by page:
+
+- **DO NOT use** `*_model.json` — this file contains only layout geometry (bounding boxes, categories, scores) with **no text content**
+- **USE** `*_content_list.json` — this file contains the actual text content along with the page index
+- **Page mapping**: Use the `page_idx` field (0-indexed) to group content blocks by page
+
+Example workflow:
+
+```python
+import json
+
+# Load content list
+with open('document_content_list.json') as f:
+    content_list = json.load(f)
+
+# Group by page
+pages = {}
+for block in content_list:
+    page_idx = block['page_idx']
+    if page_idx not in pages:
+        pages[page_idx] = []
+    pages[page_idx].append(block)
+
+# Extract text from page 0
+page_0_text = []
+for block in pages[0]:
+    if block['type'] == 'text':
+        page_0_text.append(block['text'])
+```
+
 ### Pipeline Backend Output Results
 
 #### Model Inference Results (model.json)
 
 **File naming format**: `{original_filename}_model.json`
+
+> [!NOTE]
+> This file contains **layout detection results only** (bounding boxes, categories, confidence scores). It does **not** contain extracted text content. For text extraction, use `*_content_list.json` instead.
 
 ##### Data Structure Definition
 
@@ -350,6 +385,9 @@ Level 1 blocks (table | image)
 #### Content List (content_list.json)
 
 **File naming format**: `{original_filename}_content_list.json`
+
+> [!TIP]
+> **This is the primary file for text extraction.** Unlike `*_model.json` (which only has geometry), `*_content_list.json` contains actual text content with page indices for easy per-page extraction.
 
 ##### Functionality
 

--- a/docs/zh/reference/output_files.md
+++ b/docs/zh/reference/output_files.md
@@ -54,11 +54,46 @@
 > [!IMPORTANT]
 > 2.5版本vlm后端的输出存在较大变化，与pipeline版本存在不兼容情况，如需基于结构化输出进行二次开发，请仔细阅读本文档内容。
 
+### 快速指南：提取分页文本
+
+对于需要按页面组织提取文本内容的下游应用：
+
+- **不要使用** `*_model.json` — 该文件仅包含布局几何信息（边界框、类别、置信度分数），**不包含文本内容**
+- **应使用** `*_content_list.json` — 该文件包含实际文本内容及页面索引
+- **页面映射**：使用 `page_idx` 字段（从0开始）按页面分组内容块
+
+示例代码：
+
+```python
+import json
+
+# 加载内容列表
+with open('document_content_list.json') as f:
+    content_list = json.load(f)
+
+# 按页面分组
+pages = {}
+for block in content_list:
+    page_idx = block['page_idx']
+    if page_idx not in pages:
+        pages[page_idx] = []
+    pages[page_idx].append(block)
+
+# 提取第0页的文本
+page_0_text = []
+for block in pages[0]:
+    if block['type'] == 'text':
+        page_0_text.append(block['text'])
+```
+
 ### pipeline 后端 输出结果
 
 #### 模型推理结果 (model.json)
 
 **文件命名格式**：`{原文件名}_model.json`
+
+> [!NOTE]
+> 该文件仅包含**布局检测结果**（边界框、类别、置信度分数），**不包含**提取的文本内容。如需提取文本，请使用 `*_content_list.json`。
 
 ##### 数据结构定义
 
@@ -350,6 +385,9 @@ inference_result: list[PageInferenceResults] = []
 #### 内容列表 (content_list.json)
 
 **文件命名格式**：`{原文件名}_content_list.json`
+
+> [!TIP]
+> **这是提取文本的主要文件。** 与 `*_model.json`（仅含几何信息）不同，`*_content_list.json` 包含实际文本内容和页面索引，便于按页提取。
 
 ##### 功能说明
 


### PR DESCRIPTION
Adds explicit guidance to help users correctly extract per-page text:

1. Quick reference section at top of structured data files
2. Clear note that model.json contains NO text (geometry only)
3. Highlight that content_list.json is the primary text extraction file
4. Example Python code showing how to group content by page_idx

This addresses confusion where users try to extract text from model.json (which only has layout geometry) instead of using content_list.json.

Fixes #4540

I have read the CLA Document and I hereby sign the CLA