### PR TITLE
perf: Improve page distribution among threads when loading images from pdfs

### DIFF
--- a/mineru/utils/pdf_image_tools.py
+++ b/mineru/utils/pdf_image_tools.py
@@ -100,18 +100,18 @@ def load_images_from_pdf(
         actual_threads = min(os.cpu_count() or 1, threads, total_pages)
 
         # 根据实际进程数分组页面范围
-        pages_per_thread = max(1, total_pages // actual_threads)
+        quotient = total_pages // actual_threads
+        remainder = total_pages % actual_threads
+
         page_ranges = []
+        current_start_page_id = start_page_id
 
         for i in range(actual_threads):
-            range_start = start_page_id + i * pages_per_thread
-            if i == actual_threads - 1:
-                # 最后一个进程处理剩余所有页面
-                range_end = end_page_id
-            else:
-                range_end = start_page_id + (i + 1) * pages_per_thread - 1
-
+            pages_to_allocate = quotient + (1 if i < remainder else 0)
+            range_start = current_start_page_id
+            range_end = current_start_page_id + pages_to_allocate - 1
             page_ranges.append((range_start, range_end))
+            current_start_page_id = range_end + 1
 
         logger.debug(f"PDF to images using {actual_threads} processes, page ranges: {page_ranges}")
 


### PR DESCRIPTION
## Motivation

I aim to improve page distribution among worker processes when loading images from pdfs.

Current implementation assigns all remainder pages to the last worker when `total_pages % actual_threads != 0`. This results in workload imbalance.

## Modification

This change defines:
```
quotient = total_pages // actual_threads
remainder = total_pages % actual_threads
```
and then, inside the loop, computes
```
pages_to_allocate = quotient + (1 if i < remainder else 0)
```

This ensures that no two workers differ by more than 1 page allocation.

## BC-breaking (Optional)
None
## Use cases (Optional)
If pages with many images are concentrated in consecutive parts of a PDF, such as appendices in research papers, assigning all remainder pages to one worker can increase wall-clock time noticeably.
## Checklist

**Before PR**:
- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
