### PR TITLE
Add macOS smoke workflow and quick start notes

### DIFF
--- a/.github/workflows/macos-smoke.yml
+++ b/.github/workflows/macos-smoke.yml
@@ -1,0 +1,43 @@
+name: macos-smoke
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+  push:
+    branches:
+      - "master"
+      - "dev"
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  macos-install-smoke:
+    if: github.repository == 'opendatalab/MinerU'
+    runs-on: macos-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python 3.12 virtual environment
+        run: |
+          uv --version
+          uv venv --python 3.12
+
+      - name: Install MinerU core dependencies
+        run: |
+          source .venv/bin/activate
+          uv pip install .[core]
+
+      - name: Run macOS smoke checks
+        run: |
+          source .venv/bin/activate
+          mineru --version
+          mineru-models-download --help
+          mineru-api --help
+          mineru-gradio --help

--- a/docs/en/quick_start/index.md
+++ b/docs/en/quick_start/index.md
@@ -119,6 +119,24 @@ uv pip install -e .[all]
 > `mineru[all]` includes all core features, compatible with Windows / Linux / macOS systems, suitable for most users.
 > If you need to specify the inference framework for the VLM model, or only intend to install a lightweight client on an edge device, please refer to the documentation [Extension Modules Installation Guide](https://opendatalab.github.io/MinerU/quick_start/extension_modules/).
 
+> [!TIP]
+> On Apple Silicon, `uv` is the recommended installation path.
+> After installation, verify the local CLI entrypoints before running your first parse job:
+> ```bash
+> mineru --version
+> mineru-models-download --help
+> mineru-api --help
+> mineru-gradio --help
+> ```
+> If you are in a region where `huggingface` is unstable or inaccessible, switch the model source before your first real parse run:
+> ```bash
+> export MINERU_MODEL_SOURCE=modelscope
+> ```
+> The first successful parse may trigger model downloads. This is expected behavior, not an installation failure. If you want the most predictable first run on macOS, start with the `pipeline` backend:
+> ```bash
+> mineru -p <input_path> -o <output_path> -b pipeline
+> ```
+
 ---
  
 #### Deploy MinerU using Docker
@@ -133,6 +151,7 @@ If your device meets the GPU acceleration requirements in the table above, you c
 ```bash
 mineru -p <input_path> -o <output_path>
 ```
+
 If your device does not meet the GPU acceleration requirements, you can specify the backend as `pipeline` to run in a pure CPU environment:
 ```bash
 mineru -p <input_path> -o <output_path> -b pipeline

--- a/docs/zh/quick_start/index.md
+++ b/docs/zh/quick_start/index.md
@@ -124,6 +124,24 @@ uv pip install -e .[all] -i https://mirrors.aliyun.com/pypi/simple
 > `mineru[all]`包含所有核心功能，兼容Windows / Linux / macOS系统，适合绝大多数用户。
 > 如果您需要指定vlm模型的推理框架，或是仅准备在边缘设备安装轻量版client端，可以参考文档[扩展模块安装指南](https://opendatalab.github.io/MinerU/zh/quick_start/extension_modules/)。
 
+> [!TIP]
+> 在 Apple Silicon 上，推荐优先使用 `uv` 进行安装。
+> 安装完成后，建议先验证本地 CLI 入口是否可用，再开始首次解析：
+> ```bash
+> mineru --version
+> mineru-models-download --help
+> mineru-api --help
+> mineru-gradio --help
+> ```
+> 如果您所在网络环境访问 `huggingface` 不稳定，建议在首次真正解析前先切换模型源：
+> ```bash
+> export MINERU_MODEL_SOURCE=modelscope
+> ```
+> 首次成功解析时触发模型下载属于预期行为，并不代表安装失败。如果您希望在 macOS 上先走一条更稳妥的路径，建议从 `pipeline` 后端开始：
+> ```bash
+> mineru -p <input_path> -o <output_path> -b pipeline
+> ```
+
 ---
  
 #### 使用docker部署Mineru


### PR DESCRIPTION
## Motivation

MinerU already documents support for macOS 14+ and Apple Silicon, but the repository is still missing a lightweight macOS smoke check in CI and a macOS-first quick start path for first install / first run. This PR closes that gap with a minimal, low-maintenance change set.

Closes #4757

## Modification

This PR adds:
- a new GitHub Actions `macos-smoke` workflow running on `macos-latest`
- a lightweight install smoke path using `uv venv --python 3.12` and `uv pip install .[core]`
- smoke checks for the main local entrypoints:
  - `mineru --version`
  - `mineru-models-download --help`
  - `mineru-api --help`
  - `mineru-gradio --help`
- quick start updates in both English and Chinese docs for Apple Silicon / macOS users, including:
  - recommending `uv`
  - a suggested first verification sequence
  - `MINERU_MODEL_SOURCE=modelscope` guidance for unstable `huggingface` regions
  - clarification that the first real parse may trigger model downloads
  - recommending `-b pipeline` for the most predictable first run on macOS

## BC-breaking (Optional)

No.

## Use cases (Optional)

- Catch macOS installation regressions earlier in CI without downloading models or running long parse jobs.
- Give macOS / Apple Silicon users a clearer first-run path before they start real parsing workloads.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.

## Tests

Local validation completed on macOS / Apple Silicon:
- `mineru --version`
- `mineru-models-download --help`
- `mineru-api --help`
- `mineru-gradio --help`
- workflow YAML parsed successfully

This PR intentionally does not add model-download-based CI or long-running end-to-end parse coverage.
