### PR TITLE
ci: add Ruff config, pre-commit hooks, and GitHub Actions lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Lint
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv python install 3.10
+      - run: uv pip install ruff
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.2
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/mineru/backend/hybrid/hybrid_analyze.py
+++ b/mineru/backend/hybrid/hybrid_analyze.py
@@ -16,20 +16,26 @@ from mineru.backend.hybrid.hybrid_model_output_to_middle_json import (
     finalize_middle_json,
     init_middle_json,
 )
-from mineru.backend.utils import exclude_progress_bar_idle_time
 from mineru.backend.pipeline.model_init import HybridModelSingleton
+from mineru.backend.utils import exclude_progress_bar_idle_time
 from mineru.backend.vlm.vlm_analyze import (
     ModelSingleton,
+    _maybe_enable_serial_execution,
     aio_predictor_execution_guard,
     predictor_execution_guard,
-    _maybe_enable_serial_execution,
 )
 from mineru.data.data_reader_writer import DataWriter
 from mineru.utils.config_reader import get_device, get_processing_window_size
 from mineru.utils.enum_class import ImageType, NotExtractType
-from mineru.utils.model_utils import crop_img, get_vram, clean_memory
-from mineru.utils.ocr_utils import get_adjusted_mfdetrec_res, get_ocr_result_list, sorted_boxes, merge_det_boxes, \
-    update_det_boxes, OcrConfidence
+from mineru.utils.model_utils import clean_memory, crop_img, get_vram
+from mineru.utils.ocr_utils import (
+    OcrConfidence,
+    get_adjusted_mfdetrec_res,
+    get_ocr_result_list,
+    merge_det_boxes,
+    sorted_boxes,
+    update_det_boxes,
+)
 from mineru.utils.pdf_classify import classify
 from mineru.utils.pdf_image_tools import load_images_from_pdf_doc
 from mineru.utils.pdfium_guard import (
@@ -161,7 +167,7 @@ def ocr_det(
             resolution_groups[group_key].append(crop_info)
 
         # 对每个分辨率组进行批处理
-        for (target_h, target_w), group_crops in tqdm(resolution_groups.items(), desc=f"OCR-det"):
+        for (target_h, target_w), group_crops in tqdm(resolution_groups.items(), desc="OCR-det"):
             # 对所有图像进行padding到统一尺寸
             batch_images = []
             for crop_info in group_crops:

--- a/mineru/backend/hybrid/hybrid_magic_model.py
+++ b/mineru/backend/hybrid/hybrid_magic_model.py
@@ -5,7 +5,7 @@ from typing import Literal
 from loguru import logger
 
 from mineru.utils.boxbase import calculate_overlap_area_in_bbox1_area_ratio
-from mineru.utils.enum_class import ContentType, BlockType, NotExtractType
+from mineru.utils.enum_class import BlockType, ContentType, NotExtractType
 from mineru.utils.guess_suffix_or_lang import guess_language_by_text
 from mineru.utils.magic_model_utils import reduct_overlap, tie_up_category_by_index
 from mineru.utils.span_block_fix import fix_text_block

--- a/mineru/backend/hybrid/hybrid_model_output_to_middle_json.py
+++ b/mineru/backend/hybrid/hybrid_model_output_to_middle_json.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 
 from mineru.backend.hybrid.hybrid_magic_model import MagicModel
 from mineru.backend.utils import cross_page_table_merge
-from mineru.utils.config_reader import get_table_enable, get_llm_aided_config
+from mineru.utils.config_reader import get_llm_aided_config, get_table_enable
 from mineru.utils.cut_image import cut_image_and_table
 from mineru.utils.enum_class import ContentType
 from mineru.utils.hash_utils import bytes_md5
@@ -19,15 +19,14 @@ from mineru.utils.pdf_image_tools import get_crop_img
 from mineru.utils.pdfium_guard import close_pdfium_document, pdfium_guard
 from mineru.version import __version__
 
-
 heading_level_import_success = False
 llm_aided_config = get_llm_aided_config()
 if llm_aided_config:
     title_aided_config = llm_aided_config.get('title_aided', {})
     if title_aided_config.get('enable', False):
         try:
-            from mineru.utils.llm_aided import llm_aided_title
             from mineru.backend.pipeline.model_init import AtomModelSingleton
+            from mineru.utils.llm_aided import llm_aided_title
             heading_level_import_success = True
         except Exception as e:
             logger.warning("The heading level feature cannot be used. If you need to use the heading level feature, "

--- a/mineru/backend/office/docx_analyze.py
+++ b/mineru/backend/office/docx_analyze.py
@@ -3,8 +3,8 @@ import time
 from io import BytesIO
 
 from loguru import logger
-from mineru.backend.office.model_output_to_middle_json import result_to_middle_json
 
+from mineru.backend.office.model_output_to_middle_json import result_to_middle_json
 from mineru.model.docx.main import convert_binary
 
 
@@ -33,8 +33,8 @@ if __name__ == '__main__':
     # works no matter what the current working directory is when the
     # module is executed.  Allow the user to override the path via a
     # command-line argument for even greater flexibility.
-    from pathlib import Path
     import argparse
+    from pathlib import Path
 
     script_root = Path(__file__).resolve().parent.parent.parent.parent
     default_docx = script_root / "demo" / "docx" / "demo1.docx"

--- a/mineru/backend/office/office_magic_model.py
+++ b/mineru/backend/office/office_magic_model.py
@@ -1,9 +1,7 @@
 import re
 from typing import Literal
 
-from loguru import logger
-
-from mineru.utils.enum_class import ContentType, BlockType
+from mineru.utils.enum_class import BlockType, ContentType
 from mineru.utils.magic_model_utils import tie_up_category_by_index
 
 

--- a/mineru/backend/office/office_middle_json_mkcontent.py
+++ b/mineru/backend/office/office_middle_json_mkcontent.py
@@ -6,7 +6,7 @@ from html import escape
 from loguru import logger
 
 from mineru.utils.config_reader import get_latex_delimiter_config
-from mineru.utils.enum_class import MakeMode, BlockType, ContentType, ContentTypeV2
+from mineru.utils.enum_class import BlockType, ContentType, ContentTypeV2, MakeMode
 
 latex_delimiters_config = get_latex_delimiter_config()
 

--- a/mineru/backend/pipeline/batch_analyze.py
+++ b/mineru/backend/pipeline/batch_analyze.py
@@ -1,29 +1,31 @@
 import base64
 import html
+from collections import defaultdict
 
 import cv2
+import numpy as np
 from loguru import logger
 from tqdm import tqdm
-from collections import defaultdict
-import numpy as np
 
-from .model_init import AtomModelSingleton
-from .model_list import AtomicModel
+from ...utils.bbox_utils import normalize_to_int_bbox
 from ...utils.config_reader import (
     get_formula_enable,
     get_ocr_det_mask_inline_formula_enable,
     get_table_enable,
 )
-from ...utils.bbox_utils import normalize_to_int_bbox
-from ...utils.model_utils import crop_img, get_res_list_from_layout_res, clean_vram
-from ...utils.ocr_utils import merge_det_boxes, update_det_boxes, sorted_boxes
+from ...utils.model_utils import clean_vram, crop_img, get_res_list_from_layout_res
 from ...utils.ocr_utils import (
+    OcrConfidence,
     get_adjusted_mfdetrec_res,
     get_ocr_result_list,
-    OcrConfidence,
     get_rotate_crop_image_for_text_rec,
+    merge_det_boxes,
+    sorted_boxes,
+    update_det_boxes,
 )
 from ...utils.pdf_image_tools import get_crop_np_img
+from .model_init import AtomModelSingleton
+from .model_list import AtomicModel
 
 LAYOUT_BASE_BATCH_SIZE = 1
 MFR_BASE_BATCH_SIZE = 16

--- a/mineru/backend/pipeline/model_init.py
+++ b/mineru/backend/pipeline/model_init.py
@@ -4,11 +4,11 @@ import threading
 import torch
 from loguru import logger
 
-from .model_list import AtomicModel
-from ...model.layout.pp_doclayoutv2 import PPDocLayoutV2LayoutModel
-from ...model.mfr.unimernet.Unimernet import UnimernetModel
-from ...model.mfr.pp_formulanet_plus_m.predict_formula import FormulaRecognizer
 from mineru.model.ocr.pytorch_paddle import PytorchPaddleOCR
+
+from ...model.layout.pp_doclayoutv2 import PPDocLayoutV2LayoutModel
+from ...model.mfr.pp_formulanet_plus_m.predict_formula import FormulaRecognizer
+from ...model.mfr.unimernet.Unimernet import UnimernetModel
 from ...model.ori_cls.paddle_ori_cls import PaddleOrientationClsModel
 from ...model.table.cls.paddle_table_cls import PaddleTableClsModel
 from ...model.table.rec.slanet_plus.main import PaddleTableModel
@@ -16,6 +16,7 @@ from ...model.table.rec.unet_table.main import UnetTableModel
 from ...utils.config_reader import get_device
 from ...utils.enum_class import ModelPath
 from ...utils.models_download_utils import auto_download_and_get_model_root_path
+from .model_list import AtomicModel
 
 PIPELINE_MODEL_INIT_LOCK = threading.RLock()
 

--- a/mineru/backend/pipeline/model_json_to_middle_json.py
+++ b/mineru/backend/pipeline/model_json_to_middle_json.py
@@ -8,20 +8,20 @@ import time
 from loguru import logger
 from tqdm import tqdm
 
-from mineru.backend.utils import cross_page_table_merge
-from mineru.utils.config_reader import get_device, get_llm_aided_config, get_formula_enable
 from mineru.backend.pipeline.model_init import AtomModelSingleton
 from mineru.backend.pipeline.para_split import para_split
+from mineru.backend.pipeline.pipeline_magic_model import MagicModel
+from mineru.backend.utils import cross_page_table_merge
 from mineru.utils.char_utils import full_to_half
+from mineru.utils.config_reader import get_device, get_llm_aided_config
 from mineru.utils.cut_image import cut_image_and_table
-from mineru.utils.enum_class import ContentType, BlockType
+from mineru.utils.enum_class import BlockType, ContentType
+from mineru.utils.hash_utils import bytes_md5, str_sha256
 from mineru.utils.llm_aided import llm_aided_title
 from mineru.utils.model_utils import clean_memory
-from mineru.backend.pipeline.pipeline_magic_model import MagicModel
 from mineru.utils.ocr_utils import OcrConfidence, rotate_vertical_crop_if_needed
-from mineru.version import __version__
-from mineru.utils.hash_utils import bytes_md5, str_sha256
 from mineru.utils.pdfium_guard import close_pdfium_document, pdfium_guard
+from mineru.version import __version__
 
 
 def _save_base64_image(b64_data_uri: str, image_writer, page_index: int):

--- a/mineru/backend/pipeline/para_split.py
+++ b/mineru/backend/pipeline/para_split.py
@@ -1,8 +1,7 @@
 import copy
-from loguru import logger
-from mineru.utils.enum_class import ContentType, BlockType, SplitFlag
-from mineru.utils.language import detect_lang
 
+from mineru.utils.enum_class import BlockType, ContentType, SplitFlag
+from mineru.utils.language import detect_lang
 
 LINE_STOP_FLAG = ('.', '!', '?', '。', '！', '？', ')', '）', '"', '”', ':', '：', ';', '；')
 LIST_END_FLAG = ('.', '。', ';', '；')

--- a/mineru/backend/pipeline/pipeline_analyze.py
+++ b/mineru/backend/pipeline/pipeline_analyze.py
@@ -3,28 +3,28 @@ import time
 from typing import List, Tuple
 
 import pypdfium2 as pdfium
-from PIL import Image
 from loguru import logger
+from PIL import Image
 from tqdm import tqdm
 
-from .model_init import MineruPipelineModel, PIPELINE_MODEL_INIT_LOCK
-from .model_json_to_middle_json import (
-    append_batch_results_to_middle_json,
-    finalize_middle_json,
-    init_middle_json,
-)
-from ..utils import exclude_progress_bar_idle_time
 from mineru.utils.config_reader import get_device, get_processing_window_size
+
 from ...utils.enum_class import ImageType
+from ...utils.model_utils import clean_memory, get_vram
 from ...utils.pdf_classify import classify
 from ...utils.pdf_image_tools import load_images_from_pdf_doc
-from ...utils.model_utils import get_vram, clean_memory
 from ...utils.pdfium_guard import (
     close_pdfium_document,
     get_pdfium_document_page_count,
     open_pdfium_document,
 )
-
+from ..utils import exclude_progress_bar_idle_time
+from .model_init import PIPELINE_MODEL_INIT_LOCK, MineruPipelineModel
+from .model_json_to_middle_json import (
+    append_batch_results_to_middle_json,
+    finalize_middle_json,
+    init_middle_json,
+)
 
 os.environ['PYTORCH_ENABLE_MPS_FALLBACK'] = '1'  # 让mps可以fallback
 os.environ['NO_ALBUMENTATIONS_UPDATE'] = '1'  # 禁止albumentations检查更新

--- a/mineru/backend/pipeline/pipeline_magic_model.py
+++ b/mineru/backend/pipeline/pipeline_magic_model.py
@@ -6,10 +6,14 @@ from mineru.utils.boxbase import (
     calculate_overlap_area_2_minbox_area_ratio,
     calculate_overlap_area_in_bbox1_area_ratio,
 )
-from mineru.utils.enum_class import ContentType, BlockType
+from mineru.utils.enum_class import BlockType, ContentType
 from mineru.utils.guess_suffix_or_lang import guess_language_by_text
-from mineru.utils.span_block_fix import merge_spans_to_vertical_line, vertical_line_sort_spans_from_top_to_bottom, \
-    merge_spans_to_line, line_sort_spans_by_left_to_right
+from mineru.utils.span_block_fix import (
+    line_sort_spans_by_left_to_right,
+    merge_spans_to_line,
+    merge_spans_to_vertical_line,
+    vertical_line_sort_spans_from_top_to_bottom,
+)
 from mineru.utils.span_pre_proc import txt_spans_extract
 
 

--- a/mineru/backend/pipeline/pipeline_middle_json_mkcontent.py
+++ b/mineru/backend/pipeline/pipeline_middle_json_mkcontent.py
@@ -3,9 +3,9 @@ from html import unescape
 
 from loguru import logger
 
+from mineru.backend.pipeline.para_split import ListLineTag
 from mineru.utils.char_utils import full_to_half_exclude_marks, is_hyphen_at_line_end
 from mineru.utils.config_reader import get_latex_delimiter_config
-from mineru.backend.pipeline.para_split import ListLineTag
 from mineru.utils.enum_class import BlockType, ContentType, ContentTypeV2, MakeMode
 from mineru.utils.language import detect_lang
 

--- a/mineru/backend/vlm/model_output_to_middle_json.py
+++ b/mineru/backend/vlm/model_output_to_middle_json.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 
 from mineru.backend.utils import cross_page_table_merge
 from mineru.backend.vlm.vlm_magic_model import MagicModel
-from mineru.utils.config_reader import get_table_enable, get_llm_aided_config
+from mineru.utils.config_reader import get_llm_aided_config, get_table_enable
 from mineru.utils.cut_image import cut_image_and_table
 from mineru.utils.enum_class import ContentType
 from mineru.utils.hash_utils import bytes_md5
@@ -16,15 +16,14 @@ from mineru.utils.pdf_image_tools import get_crop_img
 from mineru.utils.pdfium_guard import close_pdfium_document, pdfium_guard
 from mineru.version import __version__
 
-
 heading_level_import_success = False
 llm_aided_config = get_llm_aided_config()
 if llm_aided_config:
     title_aided_config = llm_aided_config.get('title_aided', {})
     if title_aided_config.get('enable', False):
         try:
-            from mineru.utils.llm_aided import llm_aided_title
             from mineru.backend.pipeline.model_init import AtomModelSingleton
+            from mineru.utils.llm_aided import llm_aided_title
             heading_level_import_success = True
         except Exception as e:
             logger.warning("The heading level feature cannot be used. If you need to use the heading level feature, "

--- a/mineru/backend/vlm/utils.py
+++ b/mineru/backend/vlm/utils.py
@@ -3,7 +3,7 @@ import os
 from loguru import logger
 from packaging import version
 
-from mineru.utils.check_sys_env import is_windows_environment, is_linux_environment
+from mineru.utils.check_sys_env import is_linux_environment, is_windows_environment
 from mineru.utils.config_reader import get_device
 from mineru.utils.model_utils import get_vram
 

--- a/mineru/backend/vlm/vlm_analyze.py
+++ b/mineru/backend/vlm/vlm_analyze.py
@@ -2,39 +2,43 @@
 import asyncio
 import atexit
 import gc
-import os
-import time
 import json
+import os
 import threading
+import time
 from contextlib import asynccontextmanager, contextmanager
 
 import pypdfium2 as pdfium
 from loguru import logger
+from mineru_vl_utils import MinerUClient
+from packaging import version
 from tqdm import tqdm
 
-from .utils import enable_custom_logits_processors, set_default_gpu_memory_utilization, set_default_batch_size, \
-    set_lmdeploy_backend, mod_kwargs_by_device_type
-from .model_output_to_middle_json import (
-    append_page_blocks_to_middle_json,
-    finalize_middle_json,
-    init_middle_json,
-)
 from mineru.backend.utils import exclude_progress_bar_idle_time
-from ...data.data_reader_writer import DataWriter
 from mineru.utils.pdf_image_tools import load_images_from_pdf_doc
+
+from ...data.data_reader_writer import DataWriter
 from ...utils.check_sys_env import is_mac_os_version_supported
 from ...utils.config_reader import get_device, get_processing_window_size
-
 from ...utils.enum_class import ImageType
+from ...utils.models_download_utils import auto_download_and_get_model_root_path
 from ...utils.pdfium_guard import (
     close_pdfium_document,
     get_pdfium_document_page_count,
     open_pdfium_document,
 )
-from ...utils.models_download_utils import auto_download_and_get_model_root_path
-
-from mineru_vl_utils import MinerUClient
-from packaging import version
+from .model_output_to_middle_json import (
+    append_page_blocks_to_middle_json,
+    finalize_middle_json,
+    init_middle_json,
+)
+from .utils import (
+    enable_custom_logits_processors,
+    mod_kwargs_by_device_type,
+    set_default_batch_size,
+    set_default_gpu_memory_utilization,
+    set_lmdeploy_backend,
+)
 
 
 class ModelSingleton:
@@ -142,9 +146,9 @@ class ModelSingleton:
                         vllm_llm = vllm.LLM(**kwargs)
                     elif backend == "vllm-async-engine":
                         try:
+                            from vllm.config import CompilationConfig
                             from vllm.engine.arg_utils import AsyncEngineArgs
                             from vllm.v1.engine.async_llm import AsyncLLM
-                            from vllm.config import CompilationConfig
                         except ImportError:
                             raise ImportError("Please install vllm to use the vllm-async-engine backend.")
 

--- a/mineru/backend/vlm/vlm_magic_model.py
+++ b/mineru/backend/vlm/vlm_magic_model.py
@@ -4,7 +4,7 @@ from typing import Literal
 from loguru import logger
 
 from mineru.utils.boxbase import calculate_overlap_area_in_bbox1_area_ratio
-from mineru.utils.enum_class import ContentType, BlockType
+from mineru.utils.enum_class import BlockType, ContentType
 from mineru.utils.guess_suffix_or_lang import guess_language_by_text
 from mineru.utils.magic_model_utils import reduct_overlap, tie_up_category_by_index
 

--- a/mineru/backend/vlm/vlm_middle_json_mkcontent.py
+++ b/mineru/backend/vlm/vlm_middle_json_mkcontent.py
@@ -3,8 +3,8 @@ import os
 from loguru import logger
 
 from mineru.utils.char_utils import full_to_half_exclude_marks, is_hyphen_at_line_end
-from mineru.utils.config_reader import get_latex_delimiter_config, get_formula_enable, get_table_enable
-from mineru.utils.enum_class import MakeMode, BlockType, ContentType, ContentTypeV2
+from mineru.utils.config_reader import get_formula_enable, get_latex_delimiter_config, get_table_enable
+from mineru.utils.enum_class import BlockType, ContentType, ContentTypeV2, MakeMode
 from mineru.utils.language import detect_lang
 
 latex_delimiters_config = get_latex_delimiter_config()

--- a/mineru/cli/client.py
+++ b/mineru/cli/client.py
@@ -13,9 +13,23 @@ import httpx
 import pypdfium2 as pdfium
 from loguru import logger
 
+from mineru.cli import api_client as _api_client
 from mineru.cli.api_protocol import (
     DEFAULT_MAX_CONCURRENT_REQUESTS,
     DEFAULT_PROCESSING_WINDOW_SIZE,
+)
+from mineru.cli.common import (
+    HybridDependencyError,
+    ensure_backend_dependencies,
+    image_suffixes,
+    office_suffixes,
+    pdf_suffixes,
+    uniquify_task_stems,
+)
+from mineru.cli.output_paths import resolve_parse_dir
+from mineru.cli.visualization import (
+    VisualizationJob,
+    run_visualization_job,
 )
 from mineru.utils.config_reader import (
     get_max_concurrent_requests as read_max_concurrent_requests,
@@ -27,22 +41,7 @@ from mineru.utils.pdfium_guard import (
     get_pdfium_document_page_count,
     open_pdfium_document,
 )
-
 from mineru.version import __version__
-from mineru.cli.common import (
-    HybridDependencyError,
-    ensure_backend_dependencies,
-    image_suffixes,
-    office_suffixes,
-    pdf_suffixes,
-    uniquify_task_stems,
-)
-from mineru.cli import api_client as _api_client
-from mineru.cli.output_paths import resolve_parse_dir
-from mineru.cli.visualization import (
-    VisualizationJob,
-    run_visualization_job,
-)
 
 os.environ["TORCH_CUDNN_V8_API_DISABLED"] = "1"
 log_level = os.getenv("MINERU_LOG_LEVEL", "INFO").upper()

--- a/mineru/cli/common.py
+++ b/mineru/cli/common.py
@@ -9,17 +9,17 @@ from typing import Sequence
 
 from loguru import logger
 
+from mineru.backend.office.docx_analyze import office_docx_analyze
+from mineru.backend.office.office_middle_json_mkcontent import union_make as office_union_make
+from mineru.backend.vlm.vlm_analyze import aio_doc_analyze as aio_vlm_doc_analyze
+from mineru.backend.vlm.vlm_analyze import doc_analyze as vlm_doc_analyze
+from mineru.backend.vlm.vlm_middle_json_mkcontent import union_make as vlm_union_make
 from mineru.data.data_reader_writer import FileBasedDataWriter
 from mineru.utils.draw_bbox import draw_layout_bbox, draw_span_bbox
 from mineru.utils.engine_utils import get_vlm_engine
 from mineru.utils.enum_class import MakeMode
 from mineru.utils.guess_suffix_or_lang import guess_suffix_by_bytes
 from mineru.utils.pdf_image_tools import images_bytes_to_pdf_bytes
-from mineru.backend.vlm.vlm_middle_json_mkcontent import union_make as vlm_union_make
-from mineru.backend.office.office_middle_json_mkcontent import union_make as office_union_make
-from mineru.backend.vlm.vlm_analyze import doc_analyze as vlm_doc_analyze
-from mineru.backend.vlm.vlm_analyze import aio_doc_analyze as aio_vlm_doc_analyze
-from mineru.backend.office.docx_analyze import office_docx_analyze
 from mineru.utils.pdfium_guard import rewrite_pdf_bytes_with_pdfium
 
 os.environ["TORCH_CUDNN_V8_API_DISABLED"] = "1"
@@ -583,7 +583,7 @@ def _process_office_doc(
 
             need_remove_index.append(i)
 
-            local_image_dir, local_md_dir = prepare_env(output_dir, pdf_file_name, f"office")
+            local_image_dir, local_md_dir = prepare_env(output_dir, pdf_file_name, "office")
             image_writer, md_writer = FileBasedDataWriter(local_image_dir), FileBasedDataWriter(local_md_dir)
             middle_json, infer_result = office_docx_analyze(
                 file_bytes,

--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -8,6 +8,7 @@ import tempfile
 import threading
 import uuid
 import zipfile
+from base64 import b64encode
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -30,34 +31,34 @@ from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse, JSONResponse, Response
 from loguru import logger
 
-from base64 import b64encode
-
-from mineru.cli.common import (
-    aio_do_parse,
-    do_parse,
-    image_suffixes,
-    normalize_upload_filename,
-    office_suffixes,
-    pdf_suffixes,
-    normalize_task_stem,
-    read_fn,
-    uniquify_task_stems,
-)
-from mineru.cli.output_paths import resolve_parse_dir
+from mineru.backend.vlm.vlm_analyze import shutdown_cached_models
 from mineru.cli.api_protocol import (
     API_PROTOCOL_VERSION,
     DEFAULT_MAX_CONCURRENT_REQUESTS,
     DEFAULT_PROCESSING_WINDOW_SIZE,
 )
+from mineru.cli.common import (
+    aio_do_parse,
+    do_parse,
+    image_suffixes,
+    normalize_task_stem,
+    normalize_upload_filename,
+    office_suffixes,
+    pdf_suffixes,
+    read_fn,
+    uniquify_task_stems,
+)
+from mineru.cli.output_paths import resolve_parse_dir
 from mineru.cli.vlm_preload import (
     maybe_preload_vlm_model,
     split_service_and_model_config,
 )
-from mineru.backend.vlm.vlm_analyze import shutdown_cached_models
-from mineru.utils.cli_parser import arg_parse
 from mineru.utils.check_sys_env import is_mac_environment
+from mineru.utils.cli_parser import arg_parse
 from mineru.utils.config_reader import (
     get_max_concurrent_requests as read_max_concurrent_requests,
+)
+from mineru.utils.config_reader import (
     get_processing_window_size,
 )
 from mineru.utils.guess_suffix_or_lang import guess_suffix_by_path

--- a/mineru/cli/gradio_app.py
+++ b/mineru/cli/gradio_app.py
@@ -1,8 +1,7 @@
 # Copyright (c) Opendatalab. All rights reserved.
 
-import base64
 import asyncio
-import httpx
+import base64
 import os
 import re
 import sys
@@ -17,6 +16,7 @@ from typing import Callable
 
 import click
 import gradio as gr
+import httpx
 from gradio_pdf import PDF
 from loguru import logger
 
@@ -29,6 +29,7 @@ log_level = os.getenv("MINERU_LOG_LEVEL", "INFO").upper()
 logger.remove()  # 移除默认handler
 logger.add(sys.stderr, level=log_level)  # 添加新handler
 
+from mineru.cli import api_client as _api_client
 from mineru.cli.common import (
     docx_suffixes,
     image_suffixes,
@@ -37,10 +38,9 @@ from mineru.cli.common import (
     pdf_suffixes,
     read_fn,
 )
-from mineru.cli import api_client as _api_client
 from mineru.cli.output_paths import resolve_parse_dir
-from mineru.cli.vlm_preload import resolve_gradio_local_api_cli_args
 from mineru.cli.visualization import VisualizationJob, run_visualization_job
+from mineru.cli.vlm_preload import resolve_gradio_local_api_cli_args
 
 _gradio_local_api_server = _api_client.ReusableLocalAPIServer()
 

--- a/mineru/cli/models_download.py
+++ b/mineru/cli/models_download.py
@@ -1,7 +1,8 @@
-from contextlib import contextmanager
 import json
 import os
 import sys
+from contextlib import contextmanager
+
 import click
 import requests
 from loguru import logger

--- a/mineru/cli/output_paths.py
+++ b/mineru/cli/output_paths.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 OFFICE_PARSE_DIR_NAME = "office"
 VLM_PARSE_DIR_NAME = "vlm"
 

--- a/mineru/cli/router.py
+++ b/mineru/cli/router.py
@@ -29,13 +29,13 @@ from mineru.cli.api_client import (
     LOCAL_API_STARTUP_TIMEOUT_SECONDS,
     TASK_RESULT_TIMEOUT_SECONDS,
     TASK_STATUS_POLL_INTERVAL_SECONDS,
-    build_managed_process_popen_kwargs,
     build_http_timeout,
+    build_managed_process_popen_kwargs,
     find_free_port,
     normalize_base_url,
+    response_detail,
     stop_managed_process,
     strip_local_api_network_args,
-    response_detail,
 )
 from mineru.cli.api_protocol import API_PROTOCOL_VERSION
 from mineru.cli.common import normalize_upload_filename

--- a/mineru/cli/visualization.py
+++ b/mineru/cli/visualization.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from mineru.utils.draw_bbox import draw_layout_bbox, draw_span_bbox
 
-
 VISUALIZATION_FINISHED = "finished"
 VISUALIZATION_SKIPPED = "skipped"
 

--- a/mineru/cli/vlm_server.py
+++ b/mineru/cli/vlm_server.py
@@ -1,6 +1,6 @@
-import click
 import sys
 
+import click
 from loguru import logger
 
 
@@ -44,14 +44,14 @@ def openai_server(ctx, inference_engine):
 
     if inference_engine == 'vllm':
         try:
-            import vllm
+            import vllm  # noqa: F401
         except ImportError:
             logger.error("vLLM is not installed. Please install vLLM or choose LMDeploy as the inference engine.")
             sys.exit(1)
         vllm_server()
     elif inference_engine == 'lmdeploy':
         try:
-            import lmdeploy
+            import lmdeploy  # noqa: F401
         except ImportError:
             logger.error("LMDeploy is not installed. Please install LMDeploy or choose vLLM as the inference engine.")
             sys.exit(1)

--- a/mineru/data/data_reader_writer/multi_bucket_s3.py
+++ b/mineru/data/data_reader_writer/multi_bucket_s3.py
@@ -1,9 +1,9 @@
 
-from ..utils.exceptions import InvalidConfig, InvalidParams
-from .base import DataReader, DataWriter
 from ..io.s3 import S3Reader, S3Writer
-from ..utils.schemas import S3Config
+from ..utils.exceptions import InvalidConfig, InvalidParams
 from ..utils.path_utils import parse_s3_range_params, parse_s3path, remove_non_official_s3_args
+from ..utils.schemas import S3Config
+from .base import DataReader, DataWriter
 
 
 class MultiS3Mixin:

--- a/mineru/data/data_reader_writer/s3.py
+++ b/mineru/data/data_reader_writer/s3.py
@@ -1,5 +1,5 @@
-from .multi_bucket_s3 import MultiBucketS3DataReader, MultiBucketS3DataWriter
 from ..utils.schemas import S3Config
+from .multi_bucket_s3 import MultiBucketS3DataReader, MultiBucketS3DataWriter
 
 
 class S3DataReader(MultiBucketS3DataReader):

--- a/mineru/model/docx/docx_converter.py
+++ b/mineru/model/docx/docx_converter.py
@@ -2,28 +2,29 @@ import re
 import zipfile
 from io import BytesIO
 from pathlib import Path
-from typing import BinaryIO, Optional, Union, Any, Final, Iterator
+from typing import Any, BinaryIO, Final, Iterator, Optional, Union
 
 import pandas as pd
-from PIL import Image, ImageDraw, ImageFont
-from loguru import logger
 from docx import Document
 from docx.document import Document as DocxDocument
 from docx.oxml.xmlchemy import BaseOxmlElement
-from docx.text.paragraph import Paragraph
 from docx.text.hyperlink import Hyperlink
+from docx.text.paragraph import Paragraph
 from docx.text.run import Run
+from loguru import logger
 from lxml import etree
-from pydantic import AnyUrl
 from mammoth.conversion import convert_document_element_to_html
 from mammoth.docx import body_xml
+from PIL import Image, ImageDraw, ImageFont
+from pydantic import AnyUrl
 
-from mineru.model.docx.tools.office_xml import read_str
 from mineru.model.docx.tools.math.omml import oMath2Latex
+from mineru.model.docx.tools.office_xml import read_str
 from mineru.utils.check_sys_env import is_windows_environment
 from mineru.utils.docx_formatting import Formatting, Script
-from mineru.utils.enum_class import BlockType, ContentType
+from mineru.utils.enum_class import BlockType
 from mineru.utils.pdf_reader import image_to_b64str
+
 
 class DocxConverter:
     _BLIP_NAMESPACES: Final = {
@@ -942,8 +943,9 @@ class DocxConverter:
             str: 修正后的 HTML 字符串
         """
         try:
-            from bs4 import BeautifulSoup
             from collections import Counter
+
+            from bs4 import BeautifulSoup
 
             soup = BeautifulSoup(html, 'html.parser')
             tables = soup.find_all('table')

--- a/mineru/model/docx/main.py
+++ b/mineru/model/docx/main.py
@@ -18,8 +18,8 @@ if __name__ == "__main__":
     # provide a more robust command-line interface and resolve the demo
     # document path relative to the project root instead of depending on
     # the current working directory.
-    from pathlib import Path
     import argparse
+    from pathlib import Path
 
     # climb up until we find pyproject.toml or reach a reasonable depth
     def find_project_root(start: Path) -> Path:

--- a/mineru/model/docx/tools/office_xml.py
+++ b/mineru/model/docx/tools/office_xml.py
@@ -1,7 +1,7 @@
 import xml.dom.minidom
 
-from mammoth.docx.xmlparser import XmlText, XmlElement
 from mammoth.docx.office_xml import _collapse_alternate_content, _namespaces
+from mammoth.docx.xmlparser import XmlElement, XmlText
 
 
 def parse_xml_str(xml_str, namespace_mapping=None):

--- a/mineru/model/layout/pp_doclayoutv2.py
+++ b/mineru/model/layout/pp_doclayoutv2.py
@@ -8,13 +8,12 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
+import torch
+import torchvision.transforms.v2.functional as tvF
 from PIL import Image, ImageDraw, ImageFont
 from torch import nn
-from tqdm import tqdm
-import torchvision.transforms.v2.functional as tvF
 from torchvision.transforms import InterpolationMode
-
-import torch
+from tqdm import tqdm
 from transformers import AutoConfig
 from transformers.activations import ACT2FN
 from transformers.configuration_utils import PretrainedConfig

--- a/mineru/model/mfr/pp_formulanet_plus_m/processors.py
+++ b/mineru/model/mfr/pp_formulanet_plus_m/processors.py
@@ -1,18 +1,20 @@
 import json
-import numpy as np
-import cv2
 import math
 import re
+from typing import Any, Dict, List, Optional, Tuple, Union
 
+import cv2
+import numpy as np
 from PIL import Image, ImageOps
-from typing import List, Optional, Tuple, Union, Dict, Any
-
-from loguru import logger
 from tokenizers import AddedToken
 from tokenizers import Tokenizer as TokenizerFast
 
-from mineru.model.mfr.utils import fix_latex_left_right, fix_latex_environments, remove_up_commands, \
-    remove_unsupported_commands
+from mineru.model.mfr.utils import (
+    fix_latex_environments,
+    fix_latex_left_right,
+    remove_unsupported_commands,
+    remove_up_commands,
+)
 
 
 class UniMERNetImgDecode(object):

--- a/mineru/model/mfr/unimernet/unimernet_hf/__init__.py
+++ b/mineru/model/mfr/unimernet/unimernet_hf/__init__.py
@@ -1,6 +1,6 @@
-from .unimer_swin import UnimerSwinConfig, UnimerSwinModel, UnimerSwinImageProcessor
-from .unimer_mbart import UnimerMBartConfig, UnimerMBartModel, UnimerMBartForCausalLM
 from .modeling_unimernet import UnimernetModel
+from .unimer_mbart import UnimerMBartConfig, UnimerMBartForCausalLM, UnimerMBartModel
+from .unimer_swin import UnimerSwinConfig, UnimerSwinImageProcessor, UnimerSwinModel
 
 __all__ = [
     "UnimerSwinConfig",

--- a/mineru/model/mfr/unimernet/unimernet_hf/modeling_unimernet.py
+++ b/mineru/model/mfr/unimernet/unimernet_hf/modeling_unimernet.py
@@ -4,15 +4,21 @@ from typing import Optional
 
 import torch
 from ftfy import fix_text
-from loguru import logger
-
-from transformers import AutoConfig, AutoModel, AutoModelForCausalLM, AutoTokenizer, PretrainedConfig, PreTrainedModel
-from transformers import VisionEncoderDecoderConfig, VisionEncoderDecoderModel
+from transformers import (
+    AutoConfig,
+    AutoModel,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    PretrainedConfig,
+    PreTrainedModel,
+    VisionEncoderDecoderConfig,
+    VisionEncoderDecoderModel,
+)
 from transformers.models.vision_encoder_decoder.modeling_vision_encoder_decoder import logger as base_model_logger
 
-from .unimer_swin import UnimerSwinConfig, UnimerSwinModel, UnimerSwinImageProcessor
-from .unimer_mbart import UnimerMBartConfig, UnimerMBartForCausalLM
 from ...utils import latex_rm_whitespace
+from .unimer_mbart import UnimerMBartConfig, UnimerMBartForCausalLM
+from .unimer_swin import UnimerSwinConfig, UnimerSwinImageProcessor, UnimerSwinModel
 
 AutoConfig.register(UnimerSwinConfig.model_type, UnimerSwinConfig)
 AutoConfig.register(UnimerMBartConfig.model_type, UnimerMBartConfig)

--- a/mineru/model/mfr/unimernet/unimernet_hf/unimer_mbart/__init__.py
+++ b/mineru/model/mfr/unimernet/unimernet_hf/unimer_mbart/__init__.py
@@ -1,5 +1,5 @@
 from .configuration_unimer_mbart import UnimerMBartConfig
-from .modeling_unimer_mbart import UnimerMBartModel, UnimerMBartForCausalLM
+from .modeling_unimer_mbart import UnimerMBartForCausalLM, UnimerMBartModel
 
 __all__ = [
     "UnimerMBartConfig",

--- a/mineru/model/mfr/unimernet/unimernet_hf/unimer_mbart/configuration_unimer_mbart.py
+++ b/mineru/model/mfr/unimernet/unimernet_hf/unimer_mbart/configuration_unimer_mbart.py
@@ -17,7 +17,6 @@
 from transformers.configuration_utils import PretrainedConfig
 from transformers.utils import logging
 
-
 logger = logging.get_logger(__name__)
 
 

--- a/mineru/model/mfr/unimernet/unimernet_hf/unimer_mbart/modeling_unimer_mbart.py
+++ b/mineru/model/mfr/unimernet/unimernet_hf/unimer_mbart/modeling_unimer_mbart.py
@@ -24,7 +24,7 @@ import torch.nn.functional as F
 import torch.utils.checkpoint
 from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
-
+from transformers import GenerationMixin, PreTrainedModel
 from transformers.activations import ACT2FN
 from transformers.modeling_attn_mask_utils import (
     _prepare_4d_attention_mask,
@@ -41,7 +41,6 @@ from transformers.modeling_outputs import (
     Seq2SeqQuestionAnsweringModelOutput,
     Seq2SeqSequenceClassifierOutput,
 )
-from transformers import GenerationMixin, PreTrainedModel
 from transformers.utils import (
     add_code_sample_docstrings,
     add_end_docstrings,
@@ -52,8 +51,8 @@ from transformers.utils import (
     logging,
     replace_return_docstrings,
 )
-from .configuration_unimer_mbart import UnimerMBartConfig
 
+from .configuration_unimer_mbart import UnimerMBartConfig
 
 if is_flash_attn_2_available():
     from flash_attn import flash_attn_func, flash_attn_varlen_func

--- a/mineru/model/mfr/unimernet/unimernet_hf/unimer_swin/__init__.py
+++ b/mineru/model/mfr/unimernet/unimernet_hf/unimer_swin/__init__.py
@@ -1,6 +1,6 @@
 from .configuration_unimer_swin import UnimerSwinConfig
-from .modeling_unimer_swin import UnimerSwinModel
 from .image_processing_unimer_swin import UnimerSwinImageProcessor
+from .modeling_unimer_swin import UnimerSwinModel
 
 __all__ = [
     "UnimerSwinConfig",

--- a/mineru/model/mfr/unimernet/unimernet_hf/unimer_swin/configuration_unimer_swin.py
+++ b/mineru/model/mfr/unimernet/unimernet_hf/unimer_swin/configuration_unimer_swin.py
@@ -17,7 +17,6 @@
 from transformers.configuration_utils import PretrainedConfig
 from transformers.utils import logging
 
-
 logger = logging.get_logger(__name__)
 
 

--- a/mineru/model/mfr/unimernet/unimernet_hf/unimer_swin/image_processing_unimer_swin.py
+++ b/mineru/model/mfr/unimernet/unimernet_hf/unimer_swin/image_processing_unimer_swin.py
@@ -1,10 +1,10 @@
-from PIL import Image, ImageOps
-from transformers.image_processing_utils import BaseImageProcessor
-import numpy as np
-import cv2
 import albumentations as alb
+import cv2
+import numpy as np
 from albumentations.pytorch import ToTensorV2
+from PIL import Image, ImageOps
 from torchvision.transforms.functional import resize
+from transformers.image_processing_utils import BaseImageProcessor
 
 
 # TODO: dereference cv2 if possible

--- a/mineru/model/mfr/unimernet/unimernet_hf/unimer_swin/modeling_unimer_swin.py
+++ b/mineru/model/mfr/unimernet/unimernet_hf/unimer_swin/modeling_unimer_swin.py
@@ -25,7 +25,6 @@ from typing import Optional, Tuple, Union
 import torch
 import torch.utils.checkpoint
 from torch import nn
-
 from transformers.activations import ACT2FN
 from transformers.modeling_utils import PreTrainedModel
 from transformers.pytorch_utils import find_pruneable_heads_and_indices, meshgrid, prune_linear_layer
@@ -37,8 +36,8 @@ from transformers.utils import (
     logging,
     torch_int,
 )
-from .configuration_unimer_swin import UnimerSwinConfig
 
+from .configuration_unimer_swin import UnimerSwinConfig
 
 logger = logging.get_logger(__name__)
 

--- a/mineru/model/ocr/pytorch_paddle.py
+++ b/mineru/model/ocr/pytorch_paddle.py
@@ -1,4 +1,5 @@
 # Copyright (c) Opendatalab. All rights reserved.
+import argparse
 import copy
 import json
 import os
@@ -11,21 +12,19 @@ import yaml
 from loguru import logger
 
 from mineru.model.ocr.seal_crop import CropByPolys, SortPolyBoxes
+from mineru.model.utils.tools.infer import pytorchocr_utility as utility
+from mineru.model.utils.tools.infer.predict_system import TextSystem
 from mineru.utils.config_reader import get_device
 from mineru.utils.enum_class import ModelPath
 from mineru.utils.models_download_utils import auto_download_and_get_model_root_path
 from mineru.utils.ocr_utils import (
     check_img,
+    get_rotate_crop_image_for_text_rec,
+    merge_det_boxes,
     preprocess_image,
     sorted_boxes,
-    merge_det_boxes,
     update_det_boxes,
-    get_rotate_crop_image_for_text_rec,
 )
-from mineru.model.utils.tools.infer.predict_system import TextSystem
-from mineru.model.utils.tools.infer import pytorchocr_utility as utility
-import argparse
-
 
 latin_lang = [
         "af",

--- a/mineru/model/ori_cls/paddle_ori_cls.py
+++ b/mineru/model/ori_cls/paddle_ori_cls.py
@@ -1,13 +1,13 @@
 # Copyright (c) Opendatalab. All rights reserved.
 import os
-
-from PIL import Image
 from collections import defaultdict
-from typing import List, Dict
-from tqdm import tqdm
+from typing import Dict, List
+
 import cv2
 import numpy as np
 import onnxruntime
+from PIL import Image
+from tqdm import tqdm
 
 from mineru.utils.enum_class import ModelPath
 from mineru.utils.models_download_utils import auto_download_and_get_model_root_path

--- a/mineru/model/pptx/pptx_converter.py
+++ b/mineru/model/pptx/pptx_converter.py
@@ -1,12 +1,12 @@
 from io import BytesIO
-from typing import Final, BinaryIO, Optional
+from typing import BinaryIO, Optional
 
+from loguru import logger
 from lxml import etree
+from PIL import Image, UnidentifiedImageError, WmfImagePlugin
 from pptx import Presentation, presentation
 from pptx.enum.shapes import MSO_SHAPE_TYPE, PP_PLACEHOLDER
 from pptx.oxml.text import CT_TextLineBreak
-from loguru import logger
-from PIL import Image, UnidentifiedImageError, WmfImagePlugin
 
 from mineru.utils.enum_class import BlockType
 from mineru.utils.pdf_reader import image_to_b64str

--- a/mineru/model/table/cls/paddle_table_cls.py
+++ b/mineru/model/table/cls/paddle_table_cls.py
@@ -1,10 +1,9 @@
 import os
 
-from PIL import Image
 import cv2
 import numpy as np
 import onnxruntime
-from loguru import logger
+from PIL import Image
 from tqdm import tqdm
 
 from mineru.backend.pipeline.model_list import AtomicModel

--- a/mineru/model/table/rec/slanet_plus/main.py
+++ b/mineru/model/table/rec/slanet_plus/main.py
@@ -1,7 +1,7 @@
-import os
 import copy
-import time
 import html
+import os
+import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
@@ -11,10 +11,11 @@ import numpy as np
 from loguru import logger
 from tqdm import tqdm
 
-from .matcher import TableMatch
-from .table_structure import TableStructurer
 from mineru.utils.enum_class import ModelPath
 from mineru.utils.models_download_utils import auto_download_and_get_model_root_path
+
+from .matcher import TableMatch
+from .table_structure import TableStructurer
 
 
 @dataclass

--- a/mineru/model/table/rec/slanet_plus/table_structure.py
+++ b/mineru/model/table/rec/slanet_plus/table_structure.py
@@ -17,11 +17,12 @@ from typing import Any, Dict, List, Tuple
 import numpy as np
 
 from mineru.utils.os_env_config import get_op_num_threads
+
 from .table_structure_utils import (
+    BatchTablePreprocess,
     OrtInferSession,
     TableLabelDecode,
     TablePreprocess,
-    BatchTablePreprocess,
 )
 
 

--- a/mineru/model/table/rec/slanet_plus/table_structure_utils.py
+++ b/mineru/model/table/rec/slanet_plus/table_structure_utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import platform
 import traceback
 from enum import Enum
 from pathlib import Path
@@ -20,15 +19,13 @@ from typing import Any, Dict, List, Tuple, Union
 
 import cv2
 import numpy as np
+from loguru import logger
 from onnxruntime import (
     GraphOptimizationLevel,
     InferenceSession,
     SessionOptions,
     get_available_providers,
-    get_device,
 )
-
-from loguru import logger
 
 
 class EP(Enum):

--- a/mineru/model/table/rec/unet_table/main.py
+++ b/mineru/model/table/rec/unet_table/main.py
@@ -3,28 +3,28 @@ import logging
 import os
 import time
 import traceback
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional, Union
 
-from typing import List, Optional, Union, Dict, Any
-import numpy as np
 import cv2
-from PIL import Image
-from loguru import logger
+import numpy as np
 from bs4 import BeautifulSoup
-
-from mineru.utils.span_pre_proc import calculate_contrast
-from .table_structure_unet import TSRUnet
+from loguru import logger
+from PIL import Image
 
 from mineru.utils.enum_class import ModelPath
 from mineru.utils.models_download_utils import auto_download_and_get_model_root_path
+from mineru.utils.span_pre_proc import calculate_contrast
+
 from .table_recover import TableRecover
-from .utils import InputType, LoadImage, VisTable
+from .table_structure_unet import TSRUnet
+from .utils import InputType, LoadImage
 from .utils_table_recover import (
+    box_4_2_poly_to_box_4_1,
+    gather_ocr_list_by_row,
     match_ocr_cell,
     plot_html_table,
-    box_4_2_poly_to_box_4_1,
     sorted_ocr_boxes,
-    gather_ocr_list_by_row,
 )
 
 

--- a/mineru/model/table/rec/unet_table/table_structure_unet.py
+++ b/mineru/model/table/rec/unet_table/table_structure_unet.py
@@ -1,23 +1,24 @@
 import copy
 import math
-from typing import Optional, Dict, Any, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import cv2
 import numpy as np
 from skimage import measure
 
 from mineru.utils.os_env_config import get_op_num_threads
+
 from .utils import OrtInferSession, resize_img
 from .utils_table_line_rec import (
-    get_table_line,
-    final_adjust_lines,
-    min_area_rect_box,
-    draw_lines,
     adjust_lines,
+    draw_lines,
+    final_adjust_lines,
+    get_table_line,
+    min_area_rect_box,
 )
-from.utils_table_recover import (
-    sorted_ocr_boxes,
+from .utils_table_recover import (
     box_4_2_poly_to_box_4_1,
+    sorted_ocr_boxes,
 )
 
 

--- a/mineru/model/table/rec/unet_table/utils.py
+++ b/mineru/model/table/rec/unet_table/utils.py
@@ -3,7 +3,7 @@ import traceback
 from enum import Enum
 from io import BytesIO
 from pathlib import Path
-from typing import List, Union, Dict, Any, Tuple, Optional
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import cv2
 import loguru
@@ -15,7 +15,6 @@ from onnxruntime import (
     get_available_providers,
 )
 from PIL import Image, UnidentifiedImageError
-
 
 root_dir = Path(__file__).resolve().parent
 InputType = Union[str, np.ndarray, bytes, Path]

--- a/mineru/model/table/rec/unet_table/utils_table_line_rec.py
+++ b/mineru/model/table/rec/unet_table/utils_table_line_rec.py
@@ -2,10 +2,10 @@ import math
 
 import cv2
 import numpy as np
-from scipy.spatial import distance as dist
-from skimage import measure
-from skimage import __version__ as skimage_version
 from packaging import version
+from scipy.spatial import distance as dist
+from skimage import __version__ as skimage_version
+from skimage import measure
 
 
 def transform_preds(coords, center, scale, output_size, rot=0):

--- a/mineru/model/table/rec/unet_table/utils_table_recover.py
+++ b/mineru/model/table/rec/unet_table/utils_table_recover.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union, Tuple
+from typing import Any, Dict, List, Tuple, Union
 
 import numpy as np
 

--- a/mineru/model/utils/pytorchocr/base_ocr_v20.py
+++ b/mineru/model/utils/pytorchocr/base_ocr_v20.py
@@ -1,6 +1,9 @@
 import os
+
 import torch
+
 from .modeling.architectures.base_model import BaseModel
+
 
 class BaseOCRV20:
     def __init__(self, config, **kwargs):

--- a/mineru/model/utils/pytorchocr/data/__init__.py
+++ b/mineru/model/utils/pytorchocr/data/__init__.py
@@ -1,8 +1,5 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-from .imaug import transform, create_operators
+from .imaug import create_operators, transform
 
 

--- a/mineru/model/utils/pytorchocr/data/imaug/__init__.py
+++ b/mineru/model/utils/pytorchocr/data/imaug/__init__.py
@@ -1,16 +1,13 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 # from .iaa_augment import IaaAugment
 # from .make_border_map import MakeBorderMap
 # from .make_shrink_map import MakeShrinkMap
 # from .random_crop_data import EastRandomCropData, PSERandomCrop
-
 # from .rec_img_aug import RecAug, RecResizeImg, ClsResizeImg
 # from .randaugment import RandAugment
 from .operators import *
+
 # from .label_ops import *
 
 # from .east_process import *

--- a/mineru/model/utils/pytorchocr/data/imaug/operators.py
+++ b/mineru/model/utils/pytorchocr/data/imaug/operators.py
@@ -14,15 +14,13 @@
 # limitations under the License.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
-import six
+
 import cv2
 import numpy as np
+import six
 from PIL import Image
 
 

--- a/mineru/model/utils/pytorchocr/modeling/backbones/__init__.py
+++ b/mineru/model/utils/pytorchocr/modeling/backbones/__init__.py
@@ -35,9 +35,9 @@ def build_backbone(config, model_type):
         from .rec_hgnet import PPHGNet_small
         from .rec_lcnetv3 import PPLCNetV3
         from .rec_mobilenet_v3 import MobileNetV3
-        from .rec_svtrnet import SVTRNet
         from .rec_mv1_enhance import MobileNetV1Enhance
         from .rec_pphgnetv2 import PPHGNetV2_B4, PPHGNetV2_B6_Formula
+        from .rec_svtrnet import SVTRNet
         support_dict = [
             "MobileNetV1Enhance",
             "MobileNetV3",

--- a/mineru/model/utils/pytorchocr/modeling/backbones/rec_donut_swin.py
+++ b/mineru/model/utils/pytorchocr/modeling/backbones/rec_donut_swin.py
@@ -1,6 +1,6 @@
 import collections.abc
-from collections import OrderedDict
 import math
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 

--- a/mineru/model/utils/pytorchocr/modeling/backbones/rec_mv1_enhance.py
+++ b/mineru/model/utils/pytorchocr/modeling/backbones/rec_mv1_enhance.py
@@ -1,4 +1,3 @@
-import os, sys
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/mineru/model/utils/pytorchocr/modeling/backbones/rec_pphgnetv2.py
+++ b/mineru/model/utils/pytorchocr/modeling/backbones/rec_pphgnetv2.py
@@ -1,10 +1,11 @@
-import math
+from typing import Callable, Dict, List, Union
+
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import numpy as np
+
 from .rec_donut_swin import DonutSwinModelOutput
-from typing import List, Dict, Union, Callable
 
 
 class IdentityBasedConv1x1(nn.Conv2d):
@@ -475,7 +476,7 @@ class TheseusLayer(nn.Module):
         # init the output of net
         if return_patterns or return_stages:
             if return_patterns and return_stages:
-                msg = f"The 'return_patterns' would be ignored when 'return_stages' is set."
+                msg = "The 'return_patterns' would be ignored when 'return_stages' is set."
 
                 return_stages = None
 

--- a/mineru/model/utils/pytorchocr/modeling/heads/__init__.py
+++ b/mineru/model/utils/pytorchocr/modeling/heads/__init__.py
@@ -17,15 +17,14 @@ __all__ = ["build_head"]
 
 def build_head(config, **kwargs):
     # det head
+    # cls head
+    from .cls_head import ClsHead
     from .det_db_head import DBHead, PFHeadLocal
 
     # rec head
     from .rec_ctc_head import CTCHead
     from .rec_multi_head import MultiHead
     from .rec_ppformulanet_head import PPFormulaNet_Head
-
-    # cls head
-    from .cls_head import ClsHead
 
     support_dict = [
         "DBHead",

--- a/mineru/model/utils/pytorchocr/modeling/heads/det_db_head.py
+++ b/mineru/model/utils/pytorchocr/modeling/heads/det_db_head.py
@@ -1,8 +1,10 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from ..common import Activation
+
 from ..backbones.det_mobilenet_v3 import ConvBNLayer
+from ..common import Activation
+
 
 class Head(nn.Module):
     def __init__(self, in_channels, **kwargs):

--- a/mineru/model/utils/pytorchocr/modeling/heads/rec_ppformulanet_head.py
+++ b/mineru/model/utils/pytorchocr/modeling/heads/rec_ppformulanet_head.py
@@ -13,27 +13,24 @@
 # limitations under the License.
 
 import math
-import re
-import numpy as np
-import inspect
+from dataclasses import dataclass
+from typing import Any, Dict
+
 import torch
 import torch.nn as nn
-from typing import Optional, Tuple, Union, List, Dict, Any
-from dataclasses import dataclass, fields, is_dataclass
-
-from sympy import totient
 
 from mineru.utils.config_reader import get_device
+
 from .rec_unimernet_head import (
-    MBartForCausalLM,
-    MBartDecoder,
-    MBartConfig,
-    ModelOutput,
     BaseModelOutputWithPastAndCrossAttentions,
-    Seq2SeqLMOutput,
     CausalLMOutputWithCrossAttentions,
-    LogitsProcessorList,
     ForcedEOSTokenLogitsProcessor,
+    LogitsProcessorList,
+    MBartConfig,
+    MBartDecoder,
+    MBartForCausalLM,
+    ModelOutput,
+    Seq2SeqLMOutput,
     UniMERNetHead,
 )
 

--- a/mineru/model/utils/pytorchocr/modeling/heads/rec_unimernet_head.py
+++ b/mineru/model/utils/pytorchocr/modeling/heads/rec_unimernet_head.py
@@ -1,17 +1,15 @@
 import copy
-import math
-import re
-import numpy as np
 import inspect
+import math
 import warnings
 from collections import OrderedDict
-from typing import Optional, Tuple, Union, List, Dict, Any
 from dataclasses import dataclass, fields, is_dataclass
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
-from torch import Tensor
 import torch.nn.functional as F
+from torch import Tensor
 from torch.nn import CrossEntropyLoss
 
 from mineru.utils.config_reader import get_device

--- a/mineru/model/utils/pytorchocr/postprocess/__init__.py
+++ b/mineru/model/utils/pytorchocr/postprocess/__init__.py
@@ -1,8 +1,5 @@
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import copy
 
@@ -10,11 +7,19 @@ __all__ = ['build_post_process']
 
 
 def build_post_process(config, global_config=None):
-    from .db_postprocess import DBPostProcess
-    from .rec_postprocess import CTCLabelDecode, AttnLabelDecode, SRNLabelDecode, TableLabelDecode, \
-        NRTRLabelDecode, SARLabelDecode, ViTSTRLabelDecode, RFLLabelDecode
     from .cls_postprocess import ClsPostProcess
-    from .rec_postprocess import CANLabelDecode
+    from .db_postprocess import DBPostProcess
+    from .rec_postprocess import (
+        AttnLabelDecode,
+        CANLabelDecode,
+        CTCLabelDecode,
+        NRTRLabelDecode,
+        RFLLabelDecode,
+        SARLabelDecode,
+        SRNLabelDecode,
+        TableLabelDecode,
+        ViTSTRLabelDecode,
+    )
 
     support_dict = [
         'DBPostProcess', 'CTCLabelDecode',

--- a/mineru/model/utils/pytorchocr/postprocess/db_postprocess.py
+++ b/mineru/model/utils/pytorchocr/postprocess/db_postprocess.py
@@ -2,15 +2,13 @@
 This code is refered from:
 https://github.com/WenmuZhou/DBNet.pytorch/blob/master/post_processing/seg_detector_representer.py
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-import numpy as np
 import cv2
+import numpy as np
+import pyclipper
 import torch
 from shapely.geometry import Polygon
-import pyclipper
 
 
 class DBPostProcess(object):

--- a/mineru/model/utils/pytorchocr/postprocess/rec_postprocess.py
+++ b/mineru/model/utils/pytorchocr/postprocess/rec_postprocess.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
+
 import numpy as np
 import torch
 

--- a/mineru/model/utils/tools/infer/predict_cls.py
+++ b/mineru/model/utils/tools/infer/predict_cls.py
@@ -1,12 +1,14 @@
-import cv2
 import copy
-import numpy as np
 import math
 import time
+
+import cv2
+import numpy as np
 import torch
+
 from ...pytorchocr.base_ocr_v20 import BaseOCRV20
-from . import pytorchocr_utility as utility
 from ...pytorchocr.postprocess import build_post_process
+from . import pytorchocr_utility as utility
 
 
 class TextClassifier(BaseOCRV20):

--- a/mineru/model/utils/tools/infer/predict_det.py
+++ b/mineru/model/utils/tools/infer/predict_det.py
@@ -1,12 +1,13 @@
 import sys
+import time
 
 import numpy as np
-import time
 import torch
+
 from ...pytorchocr.base_ocr_v20 import BaseOCRV20
-from . import pytorchocr_utility as utility
 from ...pytorchocr.data import create_operators, transform
 from ...pytorchocr.postprocess import build_post_process
+from . import pytorchocr_utility as utility
 
 
 class TextDetector(BaseOCRV20):

--- a/mineru/model/utils/tools/infer/predict_rec.py
+++ b/mineru/model/utils/tools/infer/predict_rec.py
@@ -1,15 +1,16 @@
-from PIL import Image
-import cv2
-import numpy as np
 import math
 import time
+
+import cv2
+import numpy as np
 import torch
+from PIL import Image
 from tqdm import tqdm
 
 from ...pytorchocr.base_ocr_v20 import BaseOCRV20
-from . import pytorchocr_utility as utility
-from ...pytorchocr.postprocess import build_post_process
 from ...pytorchocr.modeling.backbones.rec_hgnet import ConvBNAct
+from ...pytorchocr.postprocess import build_post_process
+from . import pytorchocr_utility as utility
 
 
 class TextRecognizer(BaseOCRV20):

--- a/mineru/model/utils/tools/infer/predict_system.py
+++ b/mineru/model/utils/tools/infer/predict_system.py
@@ -1,10 +1,9 @@
-import cv2
 import copy
+
+import cv2
 import numpy as np
 
-from . import predict_rec
-from . import  predict_det
-from . import  predict_cls
+from . import predict_cls, predict_det, predict_rec
 
 
 class TextSystem(object):

--- a/mineru/model/utils/tools/infer/pytorchocr_utility.py
+++ b/mineru/model/utils/tools/infer/pytorchocr_utility.py
@@ -1,10 +1,10 @@
-import os
-import math
-from pathlib import Path
-import numpy as np
-import cv2
 import argparse
+import math
+import os
+from pathlib import Path
 
+import cv2
+import numpy as np
 
 root_dir = Path(__file__).resolve().parent.parent.parent
 DEFAULT_CFG_PATH = root_dir / "pytorchocr" / "utils" / "resources" / "arch_config.yaml"

--- a/mineru/model/vlm/vllm_server.py
+++ b/mineru/model/vlm/vllm_server.py
@@ -1,11 +1,14 @@
 import os
 import sys
 
-from mineru.backend.vlm.utils import set_default_gpu_memory_utilization, enable_custom_logits_processors, \
-    mod_kwargs_by_device_type
-from mineru.utils.models_download_utils import auto_download_and_get_model_root_path
-
 from vllm.entrypoints.cli.main import main as vllm_main
+
+from mineru.backend.vlm.utils import (
+    enable_custom_logits_processors,
+    mod_kwargs_by_device_type,
+    set_default_gpu_memory_utilization,
+)
+from mineru.utils.models_download_utils import auto_download_and_get_model_root_path
 
 
 def main():

--- a/mineru/utils/config_reader.py
+++ b/mineru/utils/config_reader.py
@@ -1,6 +1,7 @@
 # Copyright (c) Opendatalab. All rights reserved.
 import json
 import os
+
 from loguru import logger
 
 try:

--- a/mineru/utils/draw_bbox.py
+++ b/mineru/utils/draw_bbox.py
@@ -2,7 +2,7 @@ import json
 from io import BytesIO
 
 from loguru import logger
-from pypdf import PdfReader, PdfWriter, PageObject
+from pypdf import PageObject, PdfReader, PdfWriter
 from reportlab.pdfgen import canvas
 
 from .enum_class import BlockType, ContentType, SplitFlag

--- a/mineru/utils/engine_utils.py
+++ b/mineru/utils/engine_utils.py
@@ -1,10 +1,13 @@
 #  Copyright (c) Opendatalab. All rights reserved.
-import os
 
 from loguru import logger
 
-from mineru.utils.check_sys_env import is_mac_os_version_supported, is_windows_environment, is_mac_environment, \
-    is_linux_environment
+from mineru.utils.check_sys_env import (
+    is_linux_environment,
+    is_mac_environment,
+    is_mac_os_version_supported,
+    is_windows_environment,
+)
 
 
 def get_vlm_engine(inference_engine: str, is_async: bool = False) -> str:
@@ -38,7 +41,7 @@ def get_vlm_engine(inference_engine: str, is_async: bool = False) -> str:
 def _select_windows_engine() -> str:
     """Windows 平台引擎选择"""
     try:
-        import lmdeploy
+        import lmdeploy  # noqa: F401
         return 'lmdeploy'
     except ImportError:
         return 'transformers'
@@ -47,11 +50,11 @@ def _select_windows_engine() -> str:
 def _select_linux_engine(is_async: bool) -> str:
     """Linux 平台引擎选择"""
     try:
-        import vllm
+        import vllm  # noqa: F401
         return 'vllm-async' if is_async else 'vllm'
     except ImportError:
         try:
-            import lmdeploy
+            import lmdeploy  # noqa: F401
             return 'lmdeploy'
         except ImportError:
             return 'transformers'
@@ -60,7 +63,7 @@ def _select_linux_engine(is_async: bool) -> str:
 def _select_mac_engine() -> str:
     """macOS 平台引擎选择"""
     try:
-        from mlx_vlm import load as mlx_load
+        from mlx_vlm import load as mlx_load  # noqa: F401
         if is_mac_os_version_supported():
             return 'mlx'
         else:

--- a/mineru/utils/enum_class.py
+++ b/mineru/utils/enum_class.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class BlockType:
     IMAGE = 'image'
     TABLE = 'table'

--- a/mineru/utils/guess_suffix_or_lang.py
+++ b/mineru/utils/guess_suffix_or_lang.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from loguru import logger
 from magika import Magika
 
-
 DEFAULT_LANG = "txt"
 PDF_SIG_BYTES = b'%PDF'
 magika = Magika()

--- a/mineru/utils/llm_aided.py
+++ b/mineru/utils/llm_aided.py
@@ -8,7 +8,6 @@ from openai import OpenAI
 from mineru.backend.pipeline.pipeline_middle_json_mkcontent import merge_para_with_text
 from mineru.utils.enum_class import BlockType
 
-
 TITLE_BLOCK_TYPES = {
     BlockType.TITLE,
     BlockType.DOC_TITLE,

--- a/mineru/utils/magic_model_utils.py
+++ b/mineru/utils/magic_model_utils.py
@@ -1,10 +1,11 @@
 """
 包含两个MagicModel类中重复使用的方法和逻辑
 """
-from typing import List, Dict, Any, Callable
+from typing import Any, Callable, Dict, List
 
 from loguru import logger
-from mineru.utils.boxbase import bbox_distance, bbox_center_distance, is_in
+
+from mineru.utils.boxbase import bbox_center_distance, bbox_distance, is_in
 
 
 def reduct_overlap(bboxes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/mineru/utils/model_utils.py
+++ b/mineru/utils/model_utils.py
@@ -1,10 +1,11 @@
+import gc
 import math
 import os
 import time
-import gc
-from PIL import Image
-from loguru import logger
+
 import numpy as np
+from loguru import logger
+from PIL import Image
 
 try:
     import torch

--- a/mineru/utils/models_download_utils.py
+++ b/mineru/utils/models_download_utils.py
@@ -1,9 +1,11 @@
 import os
+
 from huggingface_hub import snapshot_download as hf_snapshot_download
 from modelscope import snapshot_download as ms_snapshot_download
 
 from mineru.utils.config_reader import get_local_models_dir
 from mineru.utils.enum_class import ModelPath
+
 
 def auto_download_and_get_model_root_path(relative_path: str, repo_mode='pipeline') -> str:
     """

--- a/mineru/utils/ocr_utils.py
+++ b/mineru/utils/ocr_utils.py
@@ -1,5 +1,6 @@
 # Copyright (c) Opendatalab. All rights reserved.
 import copy
+
 import cv2
 import numpy as np
 

--- a/mineru/utils/pdf_classify.py
+++ b/mineru/utils/pdf_classify.py
@@ -7,7 +7,6 @@ import numpy as np
 import pypdfium2 as pdfium
 import pypdfium2.raw as pdfium_c
 from loguru import logger
-from pypdf import PdfReader
 from pdfminer.converter import PDFPageAggregator
 from pdfminer.high_level import extract_text
 from pdfminer.layout import LAParams, LTFigure, LTImage
@@ -15,6 +14,8 @@ from pdfminer.pdfdocument import PDFDocument
 from pdfminer.pdfinterp import PDFPageInterpreter, PDFResourceManager
 from pdfminer.pdfpage import PDFPage
 from pdfminer.pdfparser import PDFParser
+from pypdf import PdfReader
+
 from mineru.utils.pdfium_guard import (
     close_pdfium_document,
     open_pdfium_document,

--- a/mineru/utils/pdf_image_tools.py
+++ b/mineru/utils/pdf_image_tools.py
@@ -5,6 +5,8 @@ import os
 import signal
 import threading
 import time
+from concurrent.futures import ALL_COMPLETED, ProcessPoolExecutor, wait
+from concurrent.futures.process import BrokenProcessPool
 from io import BytesIO
 
 import numpy as np
@@ -13,23 +15,19 @@ from loguru import logger
 from PIL import Image, ImageOps
 
 from mineru.data.data_reader_writer import FileBasedDataWriter
-from mineru.utils.check_sys_env import is_windows_environment
 from mineru.utils.bbox_utils import normalize_to_int_bbox
-from mineru.utils.os_env_config import get_load_images_timeout, get_load_images_threads
-from mineru.utils.pdf_reader import image_to_b64str, image_to_bytes, page_to_image
+from mineru.utils.check_sys_env import is_windows_environment
 from mineru.utils.enum_class import ImageType
 from mineru.utils.hash_utils import str_sha256
+from mineru.utils.os_env_config import get_load_images_threads, get_load_images_timeout
 from mineru.utils.pdf_page_id import get_end_page_id
+from mineru.utils.pdf_reader import image_to_b64str, image_to_bytes, page_to_image
 from mineru.utils.pdfium_guard import (
     close_pdfium_document,
     get_pdfium_document_page_count,
     open_pdfium_document,
     pdfium_guard,
 )
-
-from concurrent.futures import ProcessPoolExecutor, wait, ALL_COMPLETED
-from concurrent.futures.process import BrokenProcessPool
-
 
 DEFAULT_PDF_IMAGE_DPI = 200
 # DEFAULT_PDF_IMAGE_DPI = 144

--- a/mineru/utils/pdf_reader.py
+++ b/mineru/utils/pdf_reader.py
@@ -5,6 +5,7 @@ from io import BytesIO
 from loguru import logger
 from PIL import Image
 from pypdfium2 import PdfBitmap, PdfPage
+
 from mineru.utils.pdfium_guard import pdfium_guard
 
 

--- a/mineru/utils/pdfium_guard.py
+++ b/mineru/utils/pdfium_guard.py
@@ -1,10 +1,9 @@
 import threading
-from io import BytesIO
 from contextlib import contextmanager
+from io import BytesIO
 from typing import Any, Callable, Sequence, TypeVar
 
 from mineru.utils.pdf_page_id import get_end_page_id
-
 
 _pdfium_lock = threading.RLock()
 

--- a/mineru/utils/span_block_fix.py
+++ b/mineru/utils/span_block_fix.py
@@ -1,6 +1,6 @@
 # Copyright (c) Opendatalab. All rights reserved.
 from mineru.utils.enum_class import ContentType
-from mineru.utils.ocr_utils import _is_overlaps_y_exceeds_threshold, _is_overlaps_x_exceeds_threshold
+from mineru.utils.ocr_utils import _is_overlaps_x_exceeds_threshold, _is_overlaps_y_exceeds_threshold
 
 VERTICAL_SPAN_HEIGHT_TO_WIDTH_RATIO_THRESHOLD = 2
 VERTICAL_SPAN_IN_BLOCK_THRESHOLD = 0.8

--- a/mineru/utils/table_merge.py
+++ b/mineru/utils/table_merge.py
@@ -9,7 +9,6 @@ from mineru.backend.vlm.vlm_middle_json_mkcontent import merge_para_with_text
 from mineru.utils.char_utils import full_to_half
 from mineru.utils.enum_class import BlockType, SplitFlag
 
-
 CONTINUATION_END_MARKERS = [
     "(续)",
     "(续表)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,3 +167,16 @@ exclude_also = [
     'class .*\bProtocol\):',
     '@(abc\.)?abstractmethod',
 ]
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+ignore = ["E501", "E402", "E731", "E722", "E741", "E712", "E711", "E701", "F841", "F403", "F405"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+
+[tool.uv]
+# Install with: uv sync --extra all

--- a/tests/clean_coverage.py
+++ b/tests/clean_coverage.py
@@ -4,6 +4,7 @@ clean coverage
 import os
 import shutil
 
+
 def delete_file(path):
     """delete file."""
     if not os.path.exists(path):

--- a/tests/get_coverage.py
+++ b/tests/get_coverage.py
@@ -1,8 +1,10 @@
 """
 get cov
 """
+
 from bs4 import BeautifulSoup
-import shutil
+
+
 def get_covrage():
     """get covrage"""
     # 发送请求获取网页内容

--- a/tests/unittest/test_e2e.py
+++ b/tests/unittest/test_e2e.py
@@ -2,9 +2,17 @@
 import json
 import os
 from pathlib import Path
-from loguru import logger
+
 from bs4 import BeautifulSoup
 from fuzzywuzzy import fuzz
+from loguru import logger
+
+from mineru.backend.pipeline.pipeline_analyze import (
+    doc_analyze_streaming as pipeline_doc_analyze_streaming,
+)
+from mineru.backend.pipeline.pipeline_middle_json_mkcontent import (
+    union_make as pipeline_union_make,
+)
 from mineru.cli.common import (
     convert_pdf_bytes_to_bytes,
     prepare_env,
@@ -12,12 +20,6 @@ from mineru.cli.common import (
 )
 from mineru.data.data_reader_writer import FileBasedDataWriter
 from mineru.utils.enum_class import MakeMode
-from mineru.backend.pipeline.pipeline_analyze import (
-    doc_analyze_streaming as pipeline_doc_analyze_streaming,
-)
-from mineru.backend.pipeline.pipeline_middle_json_mkcontent import (
-    union_make as pipeline_union_make,
-)
 
 
 def test_pipeline_with_two_config():


### PR DESCRIPTION
## Summary

- Add `[tool.ruff]` config to `pyproject.toml` (E/F/I rules, 120-char line length, per-file ignores for `__init__.py`)
- Add `.pre-commit-config.yaml` with Ruff lint + format hooks
- Add `.github/workflows/lint.yml` triggering on PRs and pushes to `master`
- Auto-fix 135 violations (unsorted imports, unused imports, f-string placeholders, multiple imports on one line)
- Add `# noqa: F401` to 6 intentional availability-probe imports (`vllm`, `lmdeploy`, `mlx_vlm`) in `vlm_server.py` and `engine_utils.py`

## Motivation

No linting or PR-level CI exists today — the existing workflows only trigger on release tags. This PR adds lightweight, zero-friction enforcement using Ruff (fast, no extra dependencies beyond `uv pip install ruff` in CI) and wires it up to run on every PR.

## What's not included

- No type checking — out of scope
- No new lint rules beyond the initial E/F/I selection
- No changes to existing test or release workflows

## Testing

Ran `ruff check .` and `ruff format --check .` locally — all checks pass.