### PR TITLE
feat: add Intel XPU transformers support

### DIFF
--- a/mineru/backend/vlm/vlm_analyze.py
+++ b/mineru/backend/vlm/vlm_analyze.py
@@ -37,6 +37,51 @@ from mineru_vl_utils import MinerUClient
 from packaging import version
 
 
+def _load_transformers_model_and_processor(model_path: str):
+    try:
+        from transformers import (
+            AutoProcessor,
+            Qwen2VLForConditionalGeneration,
+        )
+        from transformers import __version__ as transformers_version
+    except ImportError:
+        raise ImportError("Please install transformers to use the transformers backend.")
+
+    if version.parse(transformers_version) >= version.parse("4.56.0"):
+        dtype_key = "dtype"
+    else:
+        dtype_key = "torch_dtype"
+
+    device = get_device()
+    processor = AutoProcessor.from_pretrained(
+        model_path,
+        use_fast=True,
+    )
+
+    model_load_kwargs = {
+        dtype_key: "auto",  # type: ignore
+    }
+    if device == "xpu":
+        import torch
+        if not hasattr(torch, "xpu") or not torch.xpu.is_available():
+            raise EnvironmentError("MINERU_DEVICE_MODE is set to xpu but torch.xpu is unavailable.")
+        model = Qwen2VLForConditionalGeneration.from_pretrained(
+            model_path,
+            low_cpu_mem_usage=False,
+            **model_load_kwargs,
+        )
+        model = model.to(device)
+    else:
+        model = Qwen2VLForConditionalGeneration.from_pretrained(
+            model_path,
+            device_map={"": device},
+            **model_load_kwargs,
+        )
+    model.eval()
+    logger.info(f"Loaded transformers VLM on device={device}")
+    return model, processor
+
+
 class ModelSingleton:
     _instance = None
     _models = {}
@@ -77,29 +122,7 @@ class ModelSingleton:
                 if backend not in ["http-client"] and not model_path:
                     model_path = auto_download_and_get_model_root_path("/","vlm")
                 if backend == "transformers":
-                    try:
-                        from transformers import (
-                            AutoProcessor,
-                            Qwen2VLForConditionalGeneration,
-                        )
-                        from transformers import __version__ as transformers_version
-                    except ImportError:
-                        raise ImportError("Please install transformers to use the transformers backend.")
-
-                    if version.parse(transformers_version) >= version.parse("4.56.0"):
-                        dtype_key = "dtype"
-                    else:
-                        dtype_key = "torch_dtype"
-                    device = get_device()
-                    model = Qwen2VLForConditionalGeneration.from_pretrained(
-                        model_path,
-                        device_map={"": device},
-                        **{dtype_key: "auto"},  # type: ignore
-                    )
-                    processor = AutoProcessor.from_pretrained(
-                        model_path,
-                        use_fast=True,
-                    )
+                    model, processor = _load_transformers_model_and_processor(model_path)
                     if batch_size == 0:
                         batch_size = set_default_batch_size()
                 elif backend == "mlx-engine":

--- a/mineru/utils/config_reader.py
+++ b/mineru/utils/config_reader.py
@@ -79,6 +79,8 @@ def get_device():
     else:
         if torch.cuda.is_available():
             return "cuda"
+        elif hasattr(torch, "xpu") and torch.xpu.is_available():
+            return "xpu"
         elif torch.backends.mps.is_available():
             return "mps"
         else:

--- a/mineru/utils/engine_utils.py
+++ b/mineru/utils/engine_utils.py
@@ -47,6 +47,13 @@ def _select_windows_engine() -> str:
 def _select_linux_engine(is_async: bool) -> str:
     """Linux 平台引擎选择"""
     try:
+        from mineru.utils.config_reader import get_device
+        if get_device() == "xpu":
+            logger.info("Intel XPU detected, prefer transformers backend on Linux.")
+            return "transformers"
+    except Exception:
+        pass
+    try:
         import vllm
         return 'vllm-async' if is_async else 'vllm'
     except ImportError:


### PR DESCRIPTION
## Summary

This PR adds a minimal Intel XPU path for the transformers backend on Linux.

Changes:
- detect `xpu` in `get_device()` when `torch.xpu.is_available()`
- prefer `transformers` over `vllm` on Linux when the selected device is `xpu`
- load `Qwen2VLForConditionalGeneration` on CPU first and then move it to `xpu`

## Why

On Intel Arc A750 with the current oneAPI / torch xpu stack, the default Linux auto-engine path selects `vllm`, but the end-to-end MinerU VLM service is not stable through that route. The transformers backend can work, but it needs two adjustments:

1. MinerU must recognize `xpu` as a device type.
2. Qwen2VL should avoid the standard `device_map={"": device}` loading path on XPU and instead load on CPU first, then call `.to("xpu")`.

## Validation

Validated on a private Intel Arc A750 deployment:
- `torch.xpu.is_available() == True`
- MinerU API service can parse PDF -> Markdown through the transformers backend on XPU
- basic syntax check: `python3 -m py_compile` on the touched files

## Scope

This PR intentionally stays small and does not add new deployment docs or packaging changes.
