### PR TITLE
feat: make TASK_RESULT_TIMEOUT_SECONDS configurable via env var

### DIFF
--- a/mineru/cli/api_client.py
+++ b/mineru/cli/api_client.py
@@ -35,7 +35,6 @@ from mineru.utils.check_sys_env import is_linux_environment
 HEALTH_ENDPOINT = "/health"
 TASKS_ENDPOINT = "/tasks"
 TASK_STATUS_POLL_INTERVAL_SECONDS = 1.0
-TASK_RESULT_TIMEOUT_SECONDS = 3600
 LOCAL_API_SHUTDOWN_TIMEOUT_SECONDS = 10
 LOCAL_API_CLEANUP_RETRIES = 8
 LOCAL_API_CLEANUP_RETRY_INTERVAL_SECONDS = 0.25
@@ -84,6 +83,17 @@ def get_local_api_startup_timeout_seconds(default: float = 300.0) -> float:
 
 
 LOCAL_API_STARTUP_TIMEOUT_SECONDS = get_local_api_startup_timeout_seconds()
+
+
+def get_task_result_timeout_seconds(default: float = 3600.0) -> float:
+    return get_float_env(
+        "MINERU_TASK_RESULT_TIMEOUT_SECONDS",
+        default,
+        minimum=1.0,
+    )
+
+
+TASK_RESULT_TIMEOUT_SECONDS = get_task_result_timeout_seconds()
 
 
 def get_local_api_launch_mode(default: str = LOCAL_API_LAUNCH_MODE_SUBPROCESS) -> str:


### PR DESCRIPTION
Resolves #4880.

## What

Make the CLI client's task-result wait timeout configurable through the
`MINERU_TASK_RESULT_TIMEOUT_SECONDS` environment variable. Default is unchanged
at 3600 s, so existing behavior is preserved.

## Why

`TASK_RESULT_TIMEOUT_SECONDS` is hardcoded at 3600 s. On legitimate long-running
local jobs (Apple-Silicon MLX engine on a 192-page datasheet, slower-but-supported
GPUs, large technical documents) the server keeps making progress but the client
gives up at 60 minutes and the user loses the partial output. See #4880 for a
full repro and the affected log output.

## How

Mirrors the existing `LOCAL_API_STARTUP_TIMEOUT_SECONDS` pattern in the same
file, so the contributor experience and the failure-mode handling are identical:

```python
def get_task_result_timeout_seconds(default: float = 3600.0) -> float:
    return get_float_env(
        "MINERU_TASK_RESULT_TIMEOUT_SECONDS",
        default,
        minimum=1.0,
    )

TASK_RESULT_TIMEOUT_SECONDS = get_task_result_timeout_seconds()
```

`get_float_env` already handles invalid values: non-numeric strings and values
below `minimum=1.0` log a warning and fall back to the default. No behavioral
change for users who don't set the variable.

## Smoke test

```
default:                              3600.0
MINERU_TASK_RESULT_TIMEOUT_SECONDS=14400  →  14400.0
MINERU_TASK_RESULT_TIMEOUT_SECONDS=abc    →  warning, 3600.0 (fallback)
MINERU_TASK_RESULT_TIMEOUT_SECONDS=-5     →  warning, 3600.0 (fallback)
```

End-to-end: re-ran the failing 192-page max20356 datasheet on M3 Max + MLX with
`MINERU_TASK_RESULT_TIMEOUT_SECONDS=14400`. Total time 63 min — completed
normally; output markdown + 583 image cuts + intermediate JSON files all written.
Without the change, the same input aborts at minute 60 with an empty output dir.

## Usage

```bash
export MINERU_TASK_RESULT_TIMEOUT_SECONDS=14400   # 4 hours, for very long jobs
mineru -p large.pdf -o ./out -b vlm-auto-engine
```

## Notes

- Diff is +11/-1 in a single file.
- No new dependencies.
- Default value, log messages, and error-handling style are all consistent with
  the sibling helper in the same module.
