### PR TITLE
Reduce DOCX resource spikes for large image-heavy files

### DIFF
--- a/mineru/backend/office/docx_analyze.py
+++ b/mineru/backend/office/docx_analyze.py
@@ -15,7 +15,7 @@ def office_docx_analyze(
     infer_start = time.time()
 
     file_stream = BytesIO(file_bytes)
-    results = convert_binary(file_stream)
+    results = convert_binary(file_stream, image_writer=image_writer)
 
     infer_time = round(time.time() - infer_start, 2)
     safe_time = max(infer_time, 0.01)

--- a/mineru/backend/office/office_magic_model.py
+++ b/mineru/backend/office/office_magic_model.py
@@ -23,7 +23,11 @@ class MagicModel:
 
             block_type = block_info["type"]
             block_content = block_info.get("content", "")
-            if not block_content and block_type != BlockType.CHART:
+            if (
+                not block_content
+                and block_type != BlockType.CHART
+                and not block_info.get("image_path")
+            ):
                 continue
 
             if block_type in [
@@ -42,8 +46,11 @@ class MagicModel:
                 block_type = BlockType.IMAGE_BODY
                 span = {
                     "type": ContentType.IMAGE,
-                    "image_base64": block_content,
                 }
+                if block_info.get("image_path"):
+                    span["image_path"] = block_info["image_path"]
+                else:
+                    span["image_base64"] = block_content
             elif block_type in ["table"]:
                 block_type = BlockType.TABLE_BODY
                 span = {

--- a/mineru/backend/utils/office_image.py
+++ b/mineru/backend/utils/office_image.py
@@ -6,7 +6,7 @@ from PIL import Image, ImageDraw, ImageFont, UnidentifiedImageError
 from loguru import logger
 
 from mineru.utils.check_sys_env import is_windows_environment
-from mineru.utils.pdf_reader import image_to_b64str
+from mineru.utils.pdf_reader import image_to_b64str, image_to_bytes
 
 
 VECTOR_IMAGE_FORMATS = frozenset({"WMF", "EMF"})
@@ -171,6 +171,109 @@ def serialize_vector_part_with_placeholder(
         ],
     )
     return image_to_b64str(placeholder, image_format="JPEG")
+
+
+def serialize_vector_image_bytes_with_placeholder(
+    pil_image: Image.Image, image_format_override: str | None = None
+) -> tuple[bytes, str]:
+    image_format = (
+        image_format_override or getattr(pil_image, "format", None) or "WMF/EMF"
+    ).upper()
+
+    if is_windows_environment():
+        try:
+            pil_image.load()
+            return image_to_bytes(pil_image, image_format="PNG"), ".png"
+        except PIL_IMAGE_LOAD_ERRORS as e:
+            logger.warning(
+                f"Failed to render {image_format} image: {e}, size: {pil_image.size}. Using placeholder instead."
+            )
+            placeholder_lines = [
+                f"{image_format} placeholder",
+                "Windows rendering failed",
+            ]
+    else:
+        logger.warning(
+            f"Skipping {image_format} image on non-Windows environment, size: {pil_image.size}"
+        )
+        placeholder_lines = [
+            f"{image_format} placeholder",
+            "Use Windows to parse",
+            "the original image",
+        ]
+
+    placeholder = create_text_placeholder(pil_image.size, placeholder_lines)
+    return image_to_bytes(placeholder, image_format="JPEG"), ".jpg"
+
+
+def serialize_vector_part_bytes_with_placeholder(
+    part_name: object | None = None,
+    content_type: str | None = None,
+    size: tuple[int, int] = (320, 180),
+) -> tuple[bytes, str]:
+    image_format = _vector_image_format_label(part_name, content_type)
+    logger.warning(
+        f"Skipping {image_format} image part before Pillow load, "
+        f"part_name={part_name}, content_type={content_type}"
+    )
+    placeholder = create_text_placeholder(
+        size,
+        [
+            f"{image_format} placeholder",
+            "Use Windows to parse",
+            "the original image",
+        ],
+    )
+    return image_to_bytes(placeholder, image_format="JPEG"), ".jpg"
+
+
+def serialize_office_image_bytes(
+    image_data: bytes,
+    *,
+    part_name: object | None = None,
+    content_type: str | None = None,
+) -> tuple[bytes, str] | None:
+    if is_vector_image_part(part_name, content_type):
+        if not is_windows_environment():
+            return serialize_vector_part_bytes_with_placeholder(part_name, content_type)
+
+        try:
+            pil_image = Image.open(BytesIO(image_data))
+        except PIL_IMAGE_LOAD_ERRORS as e:
+            logger.warning(
+                f"Warning: vector image cannot be opened by Pillow: {e}, "
+                f"part_name={part_name}, content_type={content_type}. "
+                "Using placeholder instead."
+            )
+            return serialize_vector_part_bytes_with_placeholder(part_name, content_type)
+
+        return serialize_vector_image_bytes_with_placeholder(
+            pil_image,
+            image_format_override=_vector_image_format_label(part_name, content_type),
+        )
+
+    try:
+        pil_image = Image.open(BytesIO(image_data))
+        pil_image.load()
+    except PIL_IMAGE_LOAD_ERRORS as e:
+        logger.warning(
+            f"Warning: image cannot be loaded by Pillow: {e}, "
+            f"part_name={part_name}, content_type={content_type}"
+        )
+        return None
+
+    if is_vector_image(pil_image):
+        return serialize_vector_image_bytes_with_placeholder(pil_image)
+
+    if pil_image.mode == "RGB":
+        return image_to_bytes(pil_image, image_format="JPEG"), ".jpg"
+
+    if pil_image.mode in {"RGBA", "LA"} or (
+        pil_image.mode == "P" and "transparency" in pil_image.info
+    ):
+        return image_to_bytes(pil_image.convert("RGBA"), image_format="PNG"), ".png"
+
+    return image_to_bytes(pil_image.convert("RGB"), image_format="JPEG"), ".jpg"
 
 
 def serialize_office_image(

--- a/mineru/cli/common.py
+++ b/mineru/cli/common.py
@@ -737,14 +737,14 @@ async def aio_do_parse(
     need_remove_index = await asyncio.to_thread(
         _process_office_doc,
         output_dir,
-        pdf_file_names=pdf_file_names,
-        pdf_bytes_list=pdf_bytes_list,
-        f_dump_md=f_dump_md,
-        f_dump_middle_json=f_dump_middle_json,
-        f_dump_model_output=f_dump_model_output,
-        f_dump_orig_file=f_dump_orig_pdf,
-        f_dump_content_list=f_dump_content_list,
-        f_make_md_mode=f_make_md_mode,
+        pdf_file_names,
+        pdf_bytes_list,
+        f_dump_md,
+        f_dump_middle_json,
+        f_dump_model_output,
+        f_dump_orig_pdf,
+        f_dump_content_list,
+        f_make_md_mode,
     )
     for index in sorted(need_remove_index, reverse=True):
         del pdf_bytes_list[index]

--- a/mineru/model/docx/docx_converter.py
+++ b/mineru/model/docx/docx_converter.py
@@ -1,4 +1,6 @@
 # Copyright (c) Opendatalab. All rights reserved.
+import hashlib
+import mimetypes
 import re
 from io import BytesIO
 from pathlib import Path
@@ -36,6 +38,7 @@ from mineru.utils.office_rich_text import (
 )
 from mineru.backend.utils.office_image import (
     serialize_office_image,
+    serialize_office_image_bytes,
 )
 from mineru.backend.utils.office_chart import extract_chart_html_from_ooxml
 
@@ -76,7 +79,7 @@ class DocxConverter:
     - a14: Office 2010 Drawing 命名空间
     """
 
-    def __init__(self):
+    def __init__(self, image_writer: Any | None = None):
         self.XML_KEY = (
             "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}val"
         )
@@ -92,6 +95,7 @@ class DocxConverter:
         self.cur_page = []
         self._mammoth_tables_html: list = []   # 完整文档 mammoth 预解析的表格 HTML 列表
         self._mammoth_table_idx: int = 0       # 当前预解析表格游标
+        self.image_writer = image_writer
         self.pre_num_id: int = -1  # 上一个处理元素的 numId
         self.pre_ilevel: int = -1  # 上一个处理元素的缩进等级, 用于判断列表层级
         self.list_block_stack: list = []  # 列表块堆栈
@@ -863,6 +867,72 @@ class DocxConverter:
             ]
         )
 
+    @staticmethod
+    def _mammoth_image_extension(content_type: str | None) -> str:
+        normalized = (content_type or "").split(";", 1)[0].strip().lower()
+        explicit_extensions = {
+            "image/jpeg": ".jpg",
+            "image/jpg": ".jpg",
+            "image/png": ".png",
+            "image/gif": ".gif",
+            "image/bmp": ".bmp",
+            "image/tiff": ".tiff",
+            "image/svg+xml": ".svg",
+            "image/x-wmf": ".wmf",
+            "image/wmf": ".wmf",
+            "image/x-emf": ".emf",
+            "image/emf": ".emf",
+        }
+        if normalized in explicit_extensions:
+            return explicit_extensions[normalized]
+
+        guessed = mimetypes.guess_extension(normalized) if normalized else None
+        if guessed in {".jpe", ".jpeg"}:
+            return ".jpg"
+        return guessed or ".bin"
+
+    def _build_mammoth_table_image_converter(self):
+        import mammoth as _mammoth
+
+        @_mammoth.images.img_element
+        def convert_image(image):
+            if self.image_writer is None:
+                return {}
+
+            with image.open() as image_bytes:
+                image_data = image_bytes.read()
+            extension = self._mammoth_image_extension(image.content_type)
+            image_path = self._write_image_data(image_data, extension)
+            return {"src": image_path}
+
+        return convert_image
+
+    def _write_image_data(self, image_data: bytes, extension: str) -> str:
+        if self.image_writer is None:
+            raise RuntimeError("image_writer is required to write DOCX images")
+
+        normalized_extension = extension if extension.startswith(".") else f".{extension}"
+        image_path = f"{hashlib.sha256(image_data).hexdigest()}{normalized_extension}"
+        self.image_writer.write(image_path, image_data)
+        return image_path
+
+    def _write_serialized_office_image(
+        self,
+        image_data: bytes,
+        *,
+        part_name: object | None = None,
+        content_type: str | None = None,
+    ) -> str | None:
+        serialized = serialize_office_image_bytes(
+            image_data,
+            part_name=part_name,
+            content_type=content_type,
+        )
+        if serialized is None:
+            return None
+        serialized_image, extension = serialized
+        return self._write_image_data(serialized_image, extension)
+
     def _preparse_tables_with_mammoth(self, file_bytes: bytes) -> list:
         """
         使用 mammoth 在完整 DOCX 上下文中预解析所有顶层表格的 HTML。
@@ -874,7 +944,8 @@ class DocxConverter:
         包上下文，但通过 transform_document 只转换顶层表格节点，避免把
         非表格正文转换成巨大的 HTML 字符串。
 
-        图片会被 mammoth 转换为内联 data-URI base64 格式（<img src="data:...">）。
+        表格图片不再由 mammoth 转换为内联 data-URI base64。API/CLI 路径
+        提供 image_writer 时会直接落盘，并在 HTML 中保留相对路径。
 
         注意：mammoth 不支持 OMML（Office Math Markup Language）公式，会静默丢弃
         表格单元格内的公式。本方法在获取 mammoth HTML 后，会同步遍历原始 DOCX XML，
@@ -890,6 +961,7 @@ class DocxConverter:
             result = _mammoth.convert_to_html(
                 BytesIO(file_bytes),
                 transform_document=self._mammoth_top_level_table_document,
+                convert_image=self._build_mammoth_table_image_converter(),
             )
             soup = _BeautifulSoup(result.value, 'html.parser')
 
@@ -1442,18 +1514,30 @@ class DocxConverter:
                 logger.warning("Warning: image cannot be found")
                 continue
 
-            img_base64 = serialize_office_image(
-                image_part.blob,
-                part_name=getattr(image_part, "partname", None),
-                content_type=getattr(image_part, "content_type", None),
-            )
-            if img_base64 is None:
-                continue
-
-            image_block = {
-                "type": BlockType.IMAGE,
-                "content": img_base64,
-            }
+            if self.image_writer is not None:
+                image_path = self._write_serialized_office_image(
+                    image_part.blob,
+                    part_name=getattr(image_part, "partname", None),
+                    content_type=getattr(image_part, "content_type", None),
+                )
+                if image_path is None:
+                    continue
+                image_block = {
+                    "type": BlockType.IMAGE,
+                    "image_path": image_path,
+                }
+            else:
+                img_base64 = serialize_office_image(
+                    image_part.blob,
+                    part_name=getattr(image_part, "partname", None),
+                    content_type=getattr(image_part, "content_type", None),
+                )
+                if img_base64 is None:
+                    continue
+                image_block = {
+                    "type": BlockType.IMAGE,
+                    "content": img_base64,
+                }
             self.cur_page.append(image_block)
 
     def _get_paragraph_elements(self, paragraph: Paragraph):

--- a/mineru/model/docx/main.py
+++ b/mineru/model/docx/main.py
@@ -9,8 +9,8 @@ def convert_path(file_path: str):
         return convert_binary(fh)
 
 
-def convert_binary(file_binary: BinaryIO):
-    converter = DocxConverter()
+def convert_binary(file_binary: BinaryIO, image_writer=None):
+    converter = DocxConverter(image_writer=image_writer)
     converter.convert(file_binary)
     return converter.pages
 

--- a/tests/unittest/test_docx_converter.py
+++ b/tests/unittest/test_docx_converter.py
@@ -1,0 +1,97 @@
+from io import BytesIO
+import re
+
+from docx import Document
+from PIL import Image
+
+from mineru.backend.office.docx_analyze import office_docx_analyze
+from mineru.model.docx.main import convert_binary
+from mineru.utils.enum_class import BlockType
+
+
+class RecordingImageWriter:
+    def __init__(self):
+        self.files = {}
+
+    def write(self, path: str, data: bytes) -> None:
+        self.files[path] = data
+
+
+def _write_png(path, color: tuple[int, int, int]) -> bytes:
+    image = Image.new("RGB", (24, 24), color)
+    image.save(path, format="PNG")
+    return path.read_bytes()
+
+
+def _build_docx_with_body_and_table_images(tmp_path) -> tuple[bytes, bytes]:
+    body_image_path = tmp_path / "body.png"
+    table_image_path = tmp_path / "table.png"
+    _write_png(body_image_path, (255, 0, 0))
+    table_image_bytes = _write_png(table_image_path, (0, 255, 0))
+
+    document = Document()
+    document.add_paragraph("body image:")
+    document.add_picture(str(body_image_path))
+
+    table = document.add_table(rows=1, cols=1)
+    cell = table.cell(0, 0)
+    cell.text = "table image:"
+    cell.add_paragraph().add_run().add_picture(str(table_image_path))
+
+    output = BytesIO()
+    document.save(output)
+    return output.getvalue(), table_image_bytes
+
+
+def test_docx_table_preparse_writes_table_images_without_base64(tmp_path):
+    docx_bytes, table_image_bytes = _build_docx_with_body_and_table_images(tmp_path)
+    image_writer = RecordingImageWriter()
+
+    pages = convert_binary(BytesIO(docx_bytes), image_writer=image_writer)
+
+    table_html = next(
+        block["content"]
+        for page in pages
+        for block in page
+        if block["type"] == BlockType.TABLE
+    )
+    image_block = next(
+        block
+        for page in pages
+        for block in page
+        if block["type"] == BlockType.IMAGE
+    )
+    src_match = re.search(r'src="([^"]+)"', table_html)
+
+    assert "base64," not in table_html
+    assert src_match is not None
+    assert src_match.group(1) in image_writer.files
+    assert image_writer.files[src_match.group(1)] == table_image_bytes
+    assert "content" not in image_block
+    assert image_block["image_path"] in image_writer.files
+    assert len(image_writer.files) == 2
+
+
+def test_docx_office_middle_json_keeps_image_paths_without_base64(tmp_path):
+    docx_bytes, _ = _build_docx_with_body_and_table_images(tmp_path)
+    image_writer = RecordingImageWriter()
+
+    middle_json, _ = office_docx_analyze(docx_bytes, image_writer=image_writer)
+
+    image_spans = []
+    table_spans = []
+    for page_info in middle_json["pdf_info"]:
+        for block in page_info["para_blocks"]:
+            for sub_block in block.get("blocks", []):
+                for line in sub_block.get("lines", []):
+                    for span in line.get("spans", []):
+                        if span["type"] == "image":
+                            image_spans.append(span)
+                        if span["type"] == "table":
+                            table_spans.append(span)
+
+    assert image_spans
+    assert table_spans
+    assert all("image_base64" not in span for span in image_spans)
+    assert all(span.get("image_path") in image_writer.files for span in image_spans)
+    assert all("base64," not in span["html"] for span in table_spans)

--- a/tests/unittest/test_office_async.py
+++ b/tests/unittest/test_office_async.py
@@ -1,0 +1,29 @@
+import asyncio
+import threading
+
+from mineru.cli import common
+
+
+def test_aio_do_parse_runs_office_preprocessing_off_event_loop(monkeypatch, tmp_path):
+    event_loop_thread_id = threading.get_ident()
+    worker_thread_id = None
+
+    def fake_process_office_doc(*args, **kwargs):
+        nonlocal worker_thread_id
+        worker_thread_id = threading.get_ident()
+        return [0]
+
+    monkeypatch.setattr(common, "_process_office_doc", fake_process_office_doc)
+
+    asyncio.run(
+        common.aio_do_parse(
+            output_dir=str(tmp_path),
+            pdf_file_names=["doc"],
+            pdf_bytes_list=[b"docx"],
+            p_lang_list=["ch"],
+            backend="vlm-http-client",
+        )
+    )
+
+    assert worker_thread_id is not None
+    assert worker_thread_id != event_loop_thread_id


### PR DESCRIPTION
## Motivation

Large DOCX files with many tables and embedded images can force the DOCX converter to render the whole document through Mammoth and materialize image data URIs before the office pipeline writes assets out. In router/API task mode this creates large CPU/memory spikes and can starve health checks, causing the router to mark the upstream mineru-api unhealthy.

## Modification

- Limit Mammoth DOCX table preparse to top-level table nodes via `transform_document`, while still letting Mammoth read the full DOCX package so numbering, styles, relationships, nested table context, and OMML reinjection keep working.
- Add DOCX image-writer support so API/CLI office parsing writes body/table images directly to the task image directory and stores image paths instead of keeping image base64 in parse blocks.
- Preserve downstream office middle-json handling for image path spans.
- Move Office preprocessing in `aio_do_parse` to `asyncio.to_thread` so non-pipeline backends such as `vlm-http-client` do not block the FastAPI event loop during DOCX preprocessing.
- Add unit coverage for DOCX table/body images without base64 and for async Office preprocessing off the event loop.

## BC-breaking (Optional)

No intended API/CLI response contract break. API/CLI DOCX outputs continue to expose extracted image paths and files. Low-level direct callers of `convert_binary(..., image_writer=None)` should pass an image writer when they need table images preserved without data URI inflation.

## Use cases (Optional)

- Parsing large DOCX files through `mineru-router /tasks` with `backend=pipeline`.
- Parsing DOCX files through `backend=vlm-http-client`; DOCX preprocessing happens before VLM/PDF backend selection and now avoids event-loop starvation.

## Validation

- `pytest tests/unittest/test_docx_converter.py tests/unittest/test_office_async.py -q`: 3 passed.
- `python -m compileall -q` on touched modules and new tests: passed.
- `git diff --check` and `git diff --cached --check`: passed.
- Large local DOCX benchmark on an image-heavy file with many tables: table preparse completed quickly and produced compact table HTML with `contains_base64=False`.
- macOS native smoke: started `mineru-api` and `mineru-router` from a local venv, submitted DOCX tasks through router for both `backend=pipeline` and `backend=vlm-http-client`; both completed and router health remained healthy.

Not tested: full large-DOCX end-to-end conversion was not completed locally because it exceeded the practical PR validation window.

## macOS build notes

For this PR I validated on macOS using the native Python package path because Docker Desktop on macOS still builds Linux container images. The existing local Docker setup already contains Linux `amd64` and `arm64` build paths with project-local model cache reuse, so no separate macOS Dockerfile was needed for this DOCX/API validation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues. (Used `git diff --check`, `git diff --cached --check`, and compile checks.)
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials. (Updated DOCX converter docstrings/comments for the new Mammoth path.)

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
