### PR TITLE
Race Condition Under multi-concurrency & image loading

### DIFF
--- a/mineru/backend/hybrid/hybrid_analyze.py
+++ b/mineru/backend/hybrid/hybrid_analyze.py
@@ -598,7 +598,7 @@ def doc_analyze(
                     pdf_bytes=pdf_bytes,
                 )
                 try:
-                    images_pil_list = [image_dict["img_pil"] for image_dict in images_list]
+                    images_pil_list = [image_dict["img_pil"].copy() for image_dict in images_list]
                     logger.info(
                         f'Hybrid processing window {window_index + 1}/{total_windows}: '
                         f'pages {window_start + 1}-{window_end + 1}/{page_count} '
@@ -730,7 +730,7 @@ async def aio_doc_analyze(
                     image_type=ImageType.PIL,
                 )
                 try:
-                    images_pil_list = [image_dict["img_pil"] for image_dict in images_list]
+                    images_pil_list = [image_dict["img_pil"].copy() for image_dict in images_list]
                     logger.info(
                         f'Hybrid processing window {window_index + 1}/{total_windows}: '
                         f'pages {window_start + 1}-{window_end + 1}/{page_count} '


### PR DESCRIPTION
## Motivation

Under concurrent load, `hybrid-auto-engine` workers crash with `ValueError: Operation on closed image`, immediately followed by `EngineDeadError`. The crash kills the vLLM `EngineCore` worker process, and every subsequent task routed to that worker fails.

**Trigger conditions**:

- **Backend**: `hybrid-auto-engine` (the async path `aio_doc_analyze` in `mineru/backend/vlm/predict.py`).
- **Concurrency**: ≥ 2 PDFs being processed by the same worker simultaneously. **My trigger case: 8 concurrency PDFs via `xargs -P 8 -I {} mineru -p {} -b hybrid-auto-engine -o out/`.**
- **Per-task size**: PDFs large enough to cross at least one *processing window* (default window = 64 pages). The race is at the window boundary, so single-window PDFs almost never trip it.

Symptom on the worker log:

```
ValueError: Operation on closed image
...
vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue.
EngineCore_DP0 died
```

**Root cause.** `aio_doc_analyze` renders pages into PIL Images and passes them to `predictor.aio_batch_two_step_extract`. Inside that call, `mineru_vl_utils.gather_tasks` spawns one asyncio Task per page; each Task offloads `aio_prepare_for_layout` (which calls `image.resize()`) to a `ThreadPoolExecutor`. When the main coroutine finishes its window it runs the window's `finally` block, which calls `_close_images(images_list)`. `PIL.Image.close()` swaps `_im` for a `DeferredError(ValueError("Operation on closed image"))`.

At the window boundary, in-flight Tasks (retry logic, tqdm callbacks, plain thread scheduling delay) may still be calling `image.resize()` on the very objects that just got closed. The deferred error propagates up through `mineru_vl_utils`, into the vLLM `EngineCore` event loop, and takes the worker down.

```mermaid
sequenceDiagram
    participant Main as aio_doc_analyze<br/>(main asyncio loop)
    participant Gather as gather_tasks<br/>(mineru_vl_utils)
    participant TPool as ThreadPoolExecutor
    participant PIL as PIL.Image

    Main->>Main: render pages → images_list
    Main->>Gather: aio_batch_two_step_extract(images)
    loop per page
        Gather->>TPool: aio_prepare_for_layout(image)
        Note over TPool,PIL: image.resize() in thread
    end
    Note over Main,Gather: main coroutine returns
    Main->>PIL: _close_images() → pil_img.close()
    Note over PIL: _im = DeferredError("closed")
    TPool->>PIL: .resize() on closed image
    PIL--xTPool: ValueError: Operation on closed image
    TPool-->>Gather: exception propagates
    Gather-->>Main: unhandled exception
    Main-->>Worker: bubbles into vLLM EngineCore
    Worker->>Worker: EngineCore_DP0 dies
```

## Modification

Copy each PIL Image before handing it to the predictor. The predictor's worker threads operate on the copies, while `_close_images` continues to close the originals in `images_list`. The lifetime of the in-flight Tasks is now independent of the close.

```python
images_pil_list = [image_dict["img_pil"].copy() for image_dict in images_list]
```

Applied in two places in `mineru/backend/vlm/predict.py`:

- Sync path: `doc_analyze` (~line 601).
- Async path: `aio_doc_analyze` (~line 733).

`_close_images` itself is left unchanged — it still closes the originals, which is the desired behavior to free memory between windows.

## BC-breaking (Optional)

NO

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.

---
