### PR TITLE
fix silent failure caused by router timeout

### DIFF
--- a/mineru/cli/api_client.py
+++ b/mineru/cli/api_client.py
@@ -635,7 +635,7 @@ class ReusableLocalAPIServer:
 
 
 def build_http_timeout() -> httpx.Timeout:
-    return httpx.Timeout(connect=10, read=60, write=300, pool=30)
+    return httpx.Timeout(connect=10, read=300, write=300, pool=30)
 
 
 def build_result_download_timeout() -> httpx.Timeout:


### PR DESCRIPTION
Router polls worker task status with a 60-second read timeout. When workers are busy processing PDFs (vLLM inference, model loading), HTTP responses can be delayed beyond 60s. After 3 consecutive upstream errors, the router marks the task as failed with an empty error string.

Increase the read timeout to 300s to give workers enough time to respond while processing heavy workloads.

## Motivation

Running `mineru-router` with 4 `fast_api` workers under 8-way concurrent load, roughly 50% of tasks finish with `status = "failed"` and an empty `error` string. The contradicting evidence: each worker's `/health` reports `failed_tasks = 0` and `completed_tasks = N`, meaning the worker actually processed the PDF successfully. The "failure" is entirely a router-side communication problem.

**Trigger conditions** (all required):

- **Topology**: `mineru-router` in front of one or more `fast_api` workers (this is the production deployment, not the in-process CLI mode).
- **Worker pool size ≤ concurrent task count**: with 4 workers and 8 in-flight tasks, every worker is mid-inference when polls arrive. Repro: `ls *.pdf | xargs -P 8 -I {} mineru-client --server <router-url> -p {}`.
- **Task duration > 60 s**: any PDF that takes a vLLM-backed worker more than ~60 s of wall time will hit the timeout. Real-world papers (10–30 pages) on the hybrid backend land in the 2–5 min range, so this is the common case, not the edge case.
- **Worker HTTP handler is delayed**: vLLM inference (or model load on the first task) blocks the worker's event loop / thread pool long enough that the status-poll response is delayed past 60 s.

Symptom from `mineru-client`:

```
status: failed
error: ""
```

while the worker log shows the task finishing normally a few seconds later.

**Root cause.** Router polls upstream worker task status with `fetch_router_task_status` → `client.get(url)`, using the timeout returned by `build_http_timeout()` in `api_client.py`: `read = 60 s`. When the worker is busy with vLLM inference, its HTTP response is delayed; if delay > 60 s the router sees `httpx.ReadTimeout` (or `ConnectTimeout`), increments `upstream_error_count`, and after 3 consecutive failures marks the task `failed` — with an empty error string, because the worker itself never returned an error payload.

```mermaid
sequenceDiagram
    participant CLI as mineru CLI
    participant Router as mineru-router
    participant Worker as fast_api worker
    participant GPU as vLLM / GPU

    CLI->>Router: POST /tasks (8 PDFs)
    Router->>Worker: forward task
    Worker->>GPU: start vLLM inference
    Note over GPU: inference takes 2-5 min
    CLI->>Router: GET /tasks/{id} (poll status)
    Router->>Worker: GET /tasks/{upstream_id}
    Note over Worker: HTTP handler delayed<br/>by blocked event loop
    Worker--xRouter: ❌ ReadTimeout (>60s)
    Router->>Router: upstream_error_count += 1
    Note over Router: repeat 2 more times...
    Router-->>CLI: status = "failed", error = ""
    Note over Worker: task actually completed
```

## Modification

Raise the router's HTTP read/write timeouts from 60 s to 300 s in `build_http_timeout()`:

```python
def build_http_timeout() -> httpx.Timeout:
    return httpx.Timeout(connect=10, read=300, write=300, pool=30)
```

`connect` and `pool` are unchanged — those failure modes (network unreachable, pool exhausted) are real bugs that should still surface fast. Only `read`/`write` are extended, which is the path that gets blocked by a worker busy with vLLM inference.

## BC-breaking (Optional)

NO

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.

