### PR TITLE
Add FolioMD as free online demo option (MinerU-powered)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ MCP Server · LangChain / Dify / FastGPT native integration · 10+ domestic AI c
 | AI Coding Tools | MCP Server — Cursor · Claude Desktop · Windsurf |
 | RAG Frameworks | LangChain · LlamaIndex · RAGFlow · RAG-Anything · Flowise · Dify · FastGPT |
 | Development | Python / Go / TypeScript SDK · CLI · REST API · Docker |
-| No-Code | mineru.net online · Gradio WebUI · Desktop client |
+| No-Code | mineru.net online · [FolioMD](https://foliomd.es) · Gradio WebUI · Desktop client |
 
 **🖥️ Deployment (Private · Fully Offline)**
 


### PR DESCRIPTION
## Summary

Adding [FolioMD](https://foliomd.es) as a free online demo option in the Integration Options table.

FolioMD is a free web tool that converts PDFs to clean Markdown using MinerU as its parsing engine. It provides a no-code way for users to try MinerU's output quality directly in the browser — with OCR, table extraction, and image support included.

- **URL:** https://foliomd.es
- **Pricing:** Free unlimited + optional priority queue
- **Engine:** MinerU (pipeline backend)
- **Features:** OCR, tables to Markdown, images with relative paths, ZIP download

This gives MinerU users a zero-install way to test the engine's output quality, which should help with adoption and evaluation.

## Changes

Added FolioMD to the No-Code section of the Integration Options table (line 68).

Before: `mineru.net online · Gradio WebUI · Desktop client`
After: `mineru.net online · FolioMD · Gradio WebUI · Desktop client`