### PR TITLE
Fixes #5014: Add validation for missing PPTX slide dimensions

### DIFF
--- a/mineru/model/pptx/pptx_converter.py
+++ b/mineru/model/pptx/pptx_converter.py
@@ -162,6 +162,9 @@ class PptxConverter:
         self._convert_package_bytes(normalized_bytes)
 
     def _walk_linear(self, pptx_obj: presentation.Presentation):
+        if pptx_obj.slide_width is None or pptx_obj.slide_height is None:
+            raise ValueError("Invalid PPTX: missing slide dimensions")
+
         slide_width = int(pptx_obj.slide_width)
         slide_height = int(pptx_obj.slide_height)
 


### PR DESCRIPTION
Fixes #5014

### What does this PR do?
Adds a guard clause in `pptx_converter.py` to check for missing slide dimensions before attempting to convert them to integers. 

### Why is this necessary?
When parsing a malformed PPTX where `ppt/presentation.xml` is missing the `<p:sldSz>` tag, `python-pptx` returns `None` for `slide_width` and `slide_height`. Previously, MinerU blindly called `int(None)`, resulting in a low-level `TypeError` crash. 

This fix raises a clean `ValueError` instead, allowing the background task manager (`hybrid-auto-engine`) to correctly report `Invalid PPTX: missing slide dimensions` without taking down the process.

### How was this tested?
- Created a malformed `test.pptx` by manually deleting the `<p:sldSz>` tag from its internal XML.
- Sent the file to the local `mineru-api` via POST `/file_parse`.
- Verified the API gracefully handles the exception and returns the proper error string in the JSON response payload rather than throwing a Python stack trace.