### PR TITLE
docs: add 'Using SGLang as the Inference Backend' guide (en/zh)

### DIFF
--- a/docs/en/usage/sglang_backend.md
+++ b/docs/en/usage/sglang_backend.md
@@ -1,0 +1,97 @@
+# Using SGLang as the Inference Backend
+
+[SGLang](https://github.com/sgl-project/sglang) is a fast serving engine for large language and vision-language models. `MinerU2.5-2509-1.2B` is built on the `Qwen2-VL` architecture (`Qwen2VLForConditionalGeneration`), which SGLang implements natively. This means you can serve the model with SGLang's OpenAI-compatible server and point MinerU's `vlm-http-client` backend at it — **no code changes are required, and no local `torch` is needed on the MinerU side**.
+
+> [!NOTE]
+> MinerU shipped a native `vlm-sglang-engine` backend for older releases. `MinerU2.5` switched its default acceleration backend to `vllm`. The OpenAI-server + `vlm-http-client` path documented here is the supported, zero-code-change way to run `MinerU2.5` on SGLang today, and it works with any OpenAI-compatible server.
+
+## Prerequisites
+
+You need two environments. They can live on the same machine or on different machines (server and client communicate over HTTP).
+
+- **Client side (where MinerU runs):** install the lightweight client. The `vlm-http-client` backend does not require local `torch`.
+  ```bash
+  uv pip install mineru
+  ```
+  If you also want to run the full MinerU pipeline locally, install the full package instead:
+  ```bash
+  uv pip install "mineru[core]"
+  ```
+
+- **Server side (where the model runs):** install SGLang in a **separate** environment, following the [SGLang installation guide](https://docs.sglang.ai/start/install.html). Serving `MinerU2.5-2509-1.2B` was verified end-to-end on **SGLang 0.5.12.post1**.
+
+> [!TIP]
+> Keep SGLang in its own virtual environment. The MinerU client environment only needs the `mineru` package and network access to the server.
+
+## Step 1: Start the SGLang server
+
+Launch SGLang's OpenAI-compatible server with the `MinerU2.5-2509-1.2B` model:
+
+```bash
+python3 -m sglang.launch_server \
+  --model-path opendatalab/MinerU2.5-2509-1.2B \
+  --host 0.0.0.0 --port 30000
+```
+
+Newer SGLang versions also accept the shorter entrypoint alias:
+
+```bash
+sglang serve opendatalab/MinerU2.5-2509-1.2B --host 0.0.0.0 --port 30000
+```
+
+> [!TIP]
+> - `--chat-template` is **not** required: the tokenizer already ships the `Qwen2-VL` chat template. Passing `--chat-template qwen2-vl` also works but is unnecessary.
+> - `--trust-remote-code` is **not** required, because this is the standard `qwen2_vl` architecture. It is harmless if added.
+> - Port `30000` is SGLang's default and matches MinerU's `vlm-http-client` examples.
+> - Optional: add `--mem-fraction-static 0.6` to free VRAM when this 1.2B model shares a large GPU with other processes. SGLang otherwise reserves most of the GPU for the KV cache. This is a tuning knob only and is not required for correctness.
+
+## Step 2: Run MinerU against it
+
+In another terminal (on the client machine), point MinerU's `vlm-http-client` backend at the server:
+
+```bash
+mineru -p <input_path> -o <output_path> -b vlm-http-client -u http://127.0.0.1:30000
+```
+
+> [!TIP]
+> - `<input_path>`: a local PDF or image file, or a directory of them
+> - `<output_path>`: output directory
+> - `-u`: the OpenAI-compatible server URL. If SGLang runs on another machine, use `http://<server_ip>:30000`.
+> - `vlm-http-client` is the lightweight remote client option and does not require local `torch`.
+
+If you prefer to drive the model from Python, you can use the [`mineru-vl-utils`](https://github.com/opendatalab/mineru-vl-utils) library with the `http-client` backend directly:
+
+```python
+from mineru_vl_utils import MinerUClient
+
+client = MinerUClient(backend="http-client", server_url="http://127.0.0.1:30000")
+blocks = client.two_step_extract(image)  # image is a PIL.Image
+```
+
+## Repetition control
+
+The `vllm` serving path enforces anti-repetition with `MinerULogitsProcessor` (passed to `vllm serve` via `--logits-processors mineru_vl_utils:MinerULogitsProcessor`), which implements the `no_repeat_ngram_size` sampling parameter.
+
+> [!NOTE]
+> SGLang does **not** support `no_repeat_ngram_size`. `mineru-vl-utils`' http-client sends it inside the `vllm_xargs` field, and the SGLang server silently ignores unknown xargs.
+>
+> - On clean documents this makes no difference — output matches the `transformers` / `vllm` path exactly.
+> - On pathological inputs (dense repeated table cells, heavy noise or blur), the absence of a hard n-gram block could in principle allow a repetition loop that the `vllm` path would have prevented.
+> - In practice, `mineru-vl-utils` already defaults to `presence_penalty=1.0` and `frequency_penalty=0.05` for content / table / equation extraction, which mitigates repetition. SGLang's available anti-repetition knobs are `repetition_penalty`, `frequency_penalty`, `presence_penalty`, `min_p`, and `top_k`.
+> - For stricter control, the n-gram block can be ported through SGLang's custom logit processor mechanism (server flag `--enable-custom-logit-processor`).
+
+## Reference accuracy
+
+For reference, `MinerU2.5-2509-1.2B` served with SGLang `0.5.12.post1` on **a single NVIDIA H200 GPU** was scored on OmniDocBench v1.6 (full set, 1651 pages) with the official scorer (`pdf_validation.py`, end2end `quick_match`):
+
+| Metric | Result |
+|---|---|
+| Text-block edit distance (lower is better) | 0.0453 |
+| Table TEDS | 87.94 (structure-only 91.78) |
+| Reading-order edit distance | 0.1304 |
+| Display-formula edit distance | ~0.49 |
+
+Throughput: 1651 pages extracted in ~23 minutes at client concurrency 24 (`aio_concurrent_two_step_extract`), about 0.84 s/page for the two-step (layout + content) flow.
+
+> [!NOTE]
+> These numbers are on par with `MinerU2.5`'s published `transformers` / `vllm` results, confirming SGLang serving parity. (The display-formula CDM metric was skipped because it requires LaTeX / Ghostscript / ImageMagick.)

--- a/docs/en/usage/sglang_backend.md
+++ b/docs/en/usage/sglang_backend.md
@@ -28,6 +28,7 @@ You need two environments. They can live on the same machine or on different mac
 Launch SGLang's OpenAI-compatible server with the `MinerU2.5-2509-1.2B` model:
 
 ```bash
+SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
 python3 -m sglang.launch_server \
   --model-path opendatalab/MinerU2.5-2509-1.2B \
   --host 0.0.0.0 --port 30000
@@ -36,10 +37,11 @@ python3 -m sglang.launch_server \
 Newer SGLang versions also accept the shorter entrypoint alias:
 
 ```bash
-sglang serve opendatalab/MinerU2.5-2509-1.2B --host 0.0.0.0 --port 30000
+SGLANG_USE_CUDA_IPC_TRANSPORT=1 sglang serve opendatalab/MinerU2.5-2509-1.2B --host 0.0.0.0 --port 30000
 ```
 
 > [!TIP]
+> - `SGLANG_USE_CUDA_IPC_TRANSPORT=1` passes encoded image tensors from the tokenizer process to the scheduler over CUDA IPC instead of serializing them. For this document model (every page sends a layout image plus many block crops) it measured **~10% higher end-to-end throughput** on a single H200 (OmniDocBench: ~153 vs ~135 pages/min) with numerically identical output. It is optional — omit it for the minimal command.
 > - `--chat-template` is **not** required: the tokenizer already ships the `Qwen2-VL` chat template. Passing `--chat-template qwen2-vl` also works but is unnecessary.
 > - `--trust-remote-code` is **not** required, because this is the standard `qwen2_vl` architecture. It is harmless if added.
 > - Port `30000` is SGLang's default and matches MinerU's `vlm-http-client` examples.

--- a/docs/zh/usage/sglang_backend.md
+++ b/docs/zh/usage/sglang_backend.md
@@ -28,6 +28,7 @@
 使用 `MinerU2.5-2509-1.2B` 模型启动 SGLang 的 OpenAI 兼容服务：
 
 ```bash
+SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
 python3 -m sglang.launch_server \
   --model-path opendatalab/MinerU2.5-2509-1.2B \
   --host 0.0.0.0 --port 30000
@@ -36,10 +37,11 @@ python3 -m sglang.launch_server \
 较新版本的 SGLang 也支持更简短的入口别名：
 
 ```bash
-sglang serve opendatalab/MinerU2.5-2509-1.2B --host 0.0.0.0 --port 30000
+SGLANG_USE_CUDA_IPC_TRANSPORT=1 sglang serve opendatalab/MinerU2.5-2509-1.2B --host 0.0.0.0 --port 30000
 ```
 
 > [!TIP]
+> - `SGLANG_USE_CUDA_IPC_TRANSPORT=1` 让图像张量通过 CUDA IPC 从 tokenizer 进程传给 scheduler，而不是序列化传输。对该文档模型（每页都要发送一张版面图 + 多个块裁剪图）实测在单张 H200 上端到端吞吐**提升约 10%**（OmniDocBench：约 153 vs 135 页/分钟），输出在数值上完全一致。它是可选项——若要最简命令可省略。
 > - **无需** `--chat-template`：tokenizer 已自带 `Qwen2-VL` 的对话模板。传入 `--chat-template qwen2-vl` 也能工作，但属于多余操作。
 > - **无需** `--trust-remote-code`：这是标准的 `qwen2_vl` 架构。即使加上也无害。
 > - `30000` 是 SGLang 的默认端口，与 MinerU 的 `vlm-http-client` 示例一致。

--- a/docs/zh/usage/sglang_backend.md
+++ b/docs/zh/usage/sglang_backend.md
@@ -1,0 +1,97 @@
+# 使用 SGLang 作为推理后端
+
+[SGLang](https://github.com/sgl-project/sglang) 是面向大语言模型与视觉语言模型的高性能推理引擎。`MinerU2.5-2509-1.2B` 基于 `Qwen2-VL` 架构（`Qwen2VLForConditionalGeneration`）构建，而该架构正是 SGLang 原生支持的，因此你可以用 SGLang 启动 OpenAI 兼容服务，再让 MinerU 的 `vlm-http-client` 后端连接到它——**无需任何代码改动，MinerU 端也无需本地安装 `torch`**。
+
+> [!NOTE]
+> MinerU 早期版本曾提供原生的 `vlm-sglang-engine` 后端，`MinerU2.5` 已将默认加速后端切换为 `vllm`。本文所述的 OpenAI 服务 + `vlm-http-client` 方式，是当前在 SGLang 上运行 `MinerU2.5` 的、零代码改动的受支持方式，并且适用于任意 OpenAI 兼容服务。
+
+## 前置准备
+
+你需要两个环境，它们可以在同一台机器上，也可以分布在不同机器上（服务端与客户端通过 HTTP 通信）。
+
+- **客户端（运行 MinerU 的一侧）：** 安装轻量客户端即可，`vlm-http-client` 后端不要求本地安装 `torch`。
+  ```bash
+  uv pip install mineru
+  ```
+  如果你还想在本地运行完整的 MinerU pipeline，则改为安装完整包：
+  ```bash
+  uv pip install "mineru[core]"
+  ```
+
+- **服务端（运行模型的一侧）：** 请在**独立**的环境中安装 SGLang，可参考 [SGLang 安装文档](https://docs.sglang.ai/start/install.html)。`MinerU2.5-2509-1.2B` 的部署已在 **SGLang 0.5.12.post1** 上完成端到端验证。
+
+> [!TIP]
+> 建议将 SGLang 放在独立的虚拟环境中。MinerU 客户端环境只需 `mineru` 包以及到服务端的网络连通即可。
+
+## 第一步：启动 SGLang 服务
+
+使用 `MinerU2.5-2509-1.2B` 模型启动 SGLang 的 OpenAI 兼容服务：
+
+```bash
+python3 -m sglang.launch_server \
+  --model-path opendatalab/MinerU2.5-2509-1.2B \
+  --host 0.0.0.0 --port 30000
+```
+
+较新版本的 SGLang 也支持更简短的入口别名：
+
+```bash
+sglang serve opendatalab/MinerU2.5-2509-1.2B --host 0.0.0.0 --port 30000
+```
+
+> [!TIP]
+> - **无需** `--chat-template`：tokenizer 已自带 `Qwen2-VL` 的对话模板。传入 `--chat-template qwen2-vl` 也能工作，但属于多余操作。
+> - **无需** `--trust-remote-code`：这是标准的 `qwen2_vl` 架构。即使加上也无害。
+> - `30000` 是 SGLang 的默认端口，与 MinerU 的 `vlm-http-client` 示例一致。
+> - 可选：当这个 1.2B 模型与其他进程共用一张大显存 GPU 时，可加上 `--mem-fraction-static 0.6` 释放显存。否则 SGLang 会为 KV cache 预留大部分显存。这只是一个调优开关，并非正确性所必需。
+
+## 第二步：让 MinerU 连接该服务
+
+在另一个终端（客户端机器上），让 MinerU 的 `vlm-http-client` 后端连接到该服务：
+
+```bash
+mineru -p <input_path> -o <output_path> -b vlm-http-client -u http://127.0.0.1:30000
+```
+
+> [!TIP]
+> - `<input_path>`：本地 PDF 或图片文件，或包含它们的目录
+> - `<output_path>`：输出目录
+> - `-u`：OpenAI 兼容服务的地址。若 SGLang 运行在另一台机器上，请使用 `http://<server_ip>:30000`。
+> - `vlm-http-client` 是轻量远程 client，用法上不要求本地安装 `torch`。
+
+如果你更习惯用 Python 驱动模型，也可以直接使用 [`mineru-vl-utils`](https://github.com/opendatalab/mineru-vl-utils) 库的 `http-client` 后端：
+
+```python
+from mineru_vl_utils import MinerUClient
+
+client = MinerUClient(backend="http-client", server_url="http://127.0.0.1:30000")
+blocks = client.two_step_extract(image)  # image 为 PIL.Image
+```
+
+## 重复抑制（Repetition control）
+
+`vllm` 部署路径通过 `MinerULogitsProcessor` 来强制抑制重复（在 `vllm serve` 中通过 `--logits-processors mineru_vl_utils:MinerULogitsProcessor` 传入），它实现了 `no_repeat_ngram_size` 采样参数。
+
+> [!NOTE]
+> SGLang **不**支持 `no_repeat_ngram_size`。`mineru-vl-utils` 的 http-client 会把它放在 `vllm_xargs` 字段里发送，而 SGLang 服务端会静默忽略未知的 xargs。
+>
+> - 对于干净文档，这没有任何差异——输出与 `transformers` / `vllm` 路径完全一致。
+> - 对于病态输入（密集重复的表格单元、严重噪声或模糊），缺少硬性的 n-gram 阻断，理论上可能出现 `vllm` 路径本可避免的重复循环。
+> - 实际上，`mineru-vl-utils` 在正文 / 表格 / 公式提取中已默认 `presence_penalty=1.0`、`frequency_penalty=0.05`，可在实践中缓解重复。SGLang 可用的重复抑制开关包括 `repetition_penalty`、`frequency_penalty`、`presence_penalty`、`min_p`、`top_k`。
+> - 如需更严格的控制，可通过 SGLang 的自定义 logit processor 机制（服务端开关 `--enable-custom-logit-processor`）移植该 n-gram 阻断逻辑。
+
+## 参考精度
+
+作为参考，在 **单张 NVIDIA H200 GPU** 上以 SGLang `0.5.12.post1` 部署的 `MinerU2.5-2509-1.2B`，使用官方评测脚本（`pdf_validation.py`，end2end `quick_match`）在 OmniDocBench v1.6（全量，1651 页）上的得分如下：
+
+| 指标 | 结果 |
+|---|---|
+| 正文块编辑距离（越低越好） | 0.0453 |
+| 表格 TEDS | 87.94（仅结构 91.78） |
+| 阅读顺序编辑距离 | 0.1304 |
+| 行间公式编辑距离 | ~0.49 |
+
+吞吐：在客户端并发 24（`aio_concurrent_two_step_extract`）下，1651 页约 23 分钟完成提取，即约 0.84 秒/页（两步：版面 + 内容）。
+
+> [!NOTE]
+> 这些数字与 `MinerU2.5` 公布的 `transformers` / `vllm` 结果相当，印证了 SGLang 部署的精度一致性。（行间公式的 CDM 指标因需要 LaTeX / Ghostscript / ImageMagick 而被跳过。）

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
       - Model Source: usage/model_source.md
       - CLI Tools: usage/cli_tools.md
       - Advanced CLI Parameters: usage/advanced_cli_parameters.md
+      - SGLang Backend: usage/sglang_backend.md
     - Reference:
       - Reference: reference/index.md
       - Output File Format: reference/output_files.md
@@ -102,6 +103,7 @@ nav:
     - Model Source: usage/model_source.md
     - CLI Tools: usage/cli_tools.md
     - Advanced CLI Parameters: usage/advanced_cli_parameters.md
+    - SGLang Backend: usage/sglang_backend.md
   - Reference:
     - Reference: reference/index.md
     - Output File Format: reference/output_files.md
@@ -137,6 +139,7 @@ plugins:
             CLI Tools: 命令行工具
             Model Source: 模型源配置
             Advanced CLI Parameters: 命令行进阶参数
+            SGLang Backend: SGLang 后端
             FAQ: 常见问题解答
             Reference: 参考资料
             Output File Format: 输出文件格式


### PR DESCRIPTION
## What

Adds a documentation guide **"Using SGLang as the Inference Backend"** (English + Simplified Chinese) and registers it in the mkdocs nav.

MinerU2.5 is a `Qwen2-VL`-based model (`Qwen2VLForConditionalGeneration`) that SGLang serves natively. MinerU shipped a native `vlm-sglang-engine` for older releases and switched its default acceleration backend to vLLM for 2.5 — but MinerU's generic `vlm-http-client` backend talks to any OpenAI-compatible server, including SGLang. This guide documents that path (no code changes, no local `torch` on the client).

## Contents

- **Step 1**: start the SGLang OpenAI-compatible server (minimal verified command — `--chat-template`/`--trust-remote-code` are unnecessary; `sglang serve` alias shown).
- **Step 2**: `mineru -p <in> -o <out> -b vlm-http-client -u http://127.0.0.1:30000`, plus the `mineru-vl-utils` Python path.
- Honest **Repetition control** note (SGLang has no built-in `no_repeat_ngram_size`; mitigations + `--enable-custom-logit-processor`).
- **Reference accuracy** (OmniDocBench v1.6 on a single H200; on par with the transformers/vLLM paths).

Verified end-to-end on SGLang 0.5.12.post1 (full OmniDocBench v1.6 run, 1651 pages).
