### PR TITLE
feat: add optional external VLM visual details enrichment

### DIFF
--- a/docs/en/reference/output_files.md
+++ b/docs/en/reference/output_files.md
@@ -9,6 +9,21 @@ The exact set of generated files depends on the backend and the input document t
 - **Visual debugging files**: Help users intuitively understand the document parsing process and results
 - **Structured data files**: Contain detailed parsing data for secondary development
 - In multimodal markdown output, `image` / `chart` blocks render the screenshot first; when `content` exists, a collapsed HTML `<details>` block is appended after the image, using the block `sub_type` as the summary label when available and falling back to `image content` or `chart content`
+- When external visual details enrichment is enabled, MinerU keeps its original visual content and appends an additional `### Didactic interpretation` section inside the same `<details>` block. The external endpoint may receive cropped images and nearby context configured by the user.
+
+Example enriched visual block:
+
+```md
+![](images/xxx.jpg)
+<details>
+<summary>candlestick</summary>
+
+<MinerU visual content>
+
+### Didactic interpretation
+<external VLM enrichment>
+</details>
+```
 
 The following sections provide detailed descriptions of each file's purpose and format.
 

--- a/docs/en/usage/advanced_cli_parameters.md
+++ b/docs/en/usage/advanced_cli_parameters.md
@@ -1,5 +1,41 @@
 # Advanced Command Line Parameters
 
+## External VLM enrichment for visual details
+
+MinerU can optionally enrich existing `image` and `chart` details with an external OpenAI-compatible VLM endpoint. This is intended for RAG workflows where the visual data extracted by MinerU is useful, but an additional didactic interpretation can improve retrieval and downstream answers.
+
+This feature is disabled by default. When enabled, MinerU still performs the primary document parsing, layout detection, image cropping, table extraction, visual `sub_type` classification, and base visual content generation. The external VLM is called only for referenced `image` / `chart` blocks that already have MinerU-generated `content`, and its response is appended as a `### Didactic interpretation` section.
+
+Example:
+
+```bash
+mineru \
+  -p input.pdf \
+  -o output \
+  -b vlm-auto-engine \
+  --details-image-analysis true \
+  --details-vlm-url http://127.0.0.1:11434/v1 \
+  --details-vlm-model qwen-vl-model \
+  --details-vlm-timeout 180 \
+  --details-vlm-max-concurrency 2 \
+  --details-vlm-language en
+```
+
+Parameters:
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `--details-image-analysis` | `false` | Enable external VLM enrichment for referenced `image` / `chart` details. |
+| `--details-vlm-url` | unset | OpenAI-compatible base URL for the external VLM endpoint. Required when enrichment is enabled. |
+| `--details-vlm-model` | unset | Model name sent to the external VLM endpoint. Required when enrichment is enabled. |
+| `--details-vlm-api-key` | empty | Optional API key used as a bearer token for the external VLM endpoint. |
+| `--details-vlm-timeout` | `120` | Per-image request timeout in seconds. |
+| `--details-vlm-max-concurrency` | `1` | Maximum number of parallel external VLM requests. Increase carefully according to endpoint capacity and cost. |
+| `--details-vlm-language` | `auto` | Output language for the appended interpretation. Use `auto` to infer from the document when possible. |
+
+> [!IMPORTANT]
+> The configured external VLM endpoint may receive cropped visual images, captions, footnotes, and nearby document context. Only enable this feature with endpoints that match your privacy and data-governance requirements.
+
 ## Pass-through of inference engine parameters
 
 ### Parameter Passing Instructions

--- a/docs/zh/reference/output_files.md
+++ b/docs/zh/reference/output_files.md
@@ -9,6 +9,21 @@
 - **可视化调试文件**：帮助用户直观了解文档解析过程和结果
 - **结构化数据文件**：包含详细的解析数据，可用于二次开发
 - 多模态 markdown 输出中，`image` / `chart` 默认以截图为主；若块内存在 `content`，会在图片后追加一个默认折叠的 HTML `<details>` 内容块，其中折叠标题优先使用块的 `sub_type`，否则回退为 `image content` 或 `chart content`
+- 启用外部视觉详情增强后，MinerU 会保留原始视觉内容，并在同一个 `<details>` 块内追加 `### Didactic interpretation` 小节。外部 endpoint 可能会接收由用户配置发送的裁剪图片和附近上下文。
+
+增强后的视觉块示例：
+
+```md
+![](images/xxx.jpg)
+<details>
+<summary>candlestick</summary>
+
+<MinerU visual content>
+
+### Didactic interpretation
+<external VLM enrichment>
+</details>
+```
 
 下面将详细介绍每个文件的作用和格式。
 

--- a/docs/zh/usage/advanced_cli_parameters.md
+++ b/docs/zh/usage/advanced_cli_parameters.md
@@ -1,5 +1,41 @@
 # 命令行参数进阶
 
+## 使用外部 VLM 增强视觉详情
+
+MinerU 可以选择性地调用外部 OpenAI-compatible VLM endpoint，为已有的 `image` 和 `chart` 详情追加教学式解释。该功能主要面向 RAG 场景：MinerU 提取的视觉数据仍作为基础内容，外部 VLM 只补充更利于检索和问答的语义解释。
+
+该功能默认关闭。启用后，MinerU 仍负责主要的文档解析、版面识别、图片裁剪、表格提取、视觉 `sub_type` 分类以及基础视觉内容生成。外部 VLM 只会处理已经存在 MinerU `content` 的 `image` / `chart` 块，并将结果追加为 `### Didactic interpretation` 小节。
+
+示例：
+
+```bash
+mineru \
+  -p input.pdf \
+  -o output \
+  -b vlm-auto-engine \
+  --details-image-analysis true \
+  --details-vlm-url http://127.0.0.1:11434/v1 \
+  --details-vlm-model qwen-vl-model \
+  --details-vlm-timeout 180 \
+  --details-vlm-max-concurrency 2 \
+  --details-vlm-language zh
+```
+
+参数说明：
+
+| 参数 | 默认值 | 说明 |
+| --- | --- | --- |
+| `--details-image-analysis` | `false` | 启用外部 VLM 对已引用的 `image` / `chart` 详情进行增强。 |
+| `--details-vlm-url` | 未设置 | 外部 VLM 的 OpenAI-compatible base URL。启用增强时必填。 |
+| `--details-vlm-model` | 未设置 | 发送给外部 VLM endpoint 的模型名称。启用增强时必填。 |
+| `--details-vlm-api-key` | 空 | 可选 API key，会作为 bearer token 发送给外部 VLM endpoint。 |
+| `--details-vlm-timeout` | `120` | 单张图片请求超时时间，单位为秒。 |
+| `--details-vlm-max-concurrency` | `1` | 外部 VLM 并发请求数上限。请根据 endpoint 能力和调用成本谨慎调高。 |
+| `--details-vlm-language` | `auto` | 追加解释的输出语言。使用 `auto` 时会尽量根据文档语言自动判断。 |
+
+> [!IMPORTANT]
+> 配置的外部 VLM endpoint 可能会接收裁剪后的视觉图片、caption、footnote 以及附近正文上下文。请仅在符合隐私和数据治理要求的 endpoint 上启用该功能。
+
 ## 推理引擎参数透传
 
 ### 参数传递说明

--- a/mineru/backend/vlm/visual_details_enrichment.py
+++ b/mineru/backend/vlm/visual_details_enrichment.py
@@ -1,0 +1,576 @@
+# Copyright (c) Opendatalab. All rights reserved.
+import base64
+import mimetypes
+import os
+import re
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from mineru.utils.enum_class import BlockType, ContentType
+
+
+DEFAULT_DETAILS_VLM_TIMEOUT = 120
+DEFAULT_DETAILS_VLM_MAX_CONCURRENCY = 1
+DEFAULT_DETAILS_VLM_LANGUAGE = "auto"
+NEARBY_CONTEXT_CHAR_LIMIT = 800
+LIST_CONTEXT_CHAR_LIMIT = 800
+
+
+_TEXT_CONTEXT_BLOCK_TYPES = {
+    BlockType.TEXT,
+    BlockType.REF_TEXT,
+}
+
+_EXCLUDED_CONTEXT_BLOCK_TYPES = {
+    BlockType.IMAGE,
+    BlockType.IMAGE_BODY,
+    BlockType.CHART,
+    BlockType.CHART_BODY,
+    BlockType.TABLE,
+    BlockType.TABLE_BODY,
+    BlockType.CODE,
+    BlockType.CODE_BODY,
+    BlockType.ALGORITHM,
+    BlockType.INTERLINE_EQUATION,
+    BlockType.EQUATION,
+    BlockType.CAPTION,
+    BlockType.IMAGE_CAPTION,
+    BlockType.IMAGE_FOOTNOTE,
+    BlockType.CHART_CAPTION,
+    BlockType.CHART_FOOTNOTE,
+    BlockType.TABLE_CAPTION,
+    BlockType.TABLE_FOOTNOTE,
+    BlockType.CODE_CAPTION,
+    BlockType.CODE_FOOTNOTE,
+    BlockType.FOOTNOTE,
+    BlockType.HEADER,
+    BlockType.FOOTER,
+    BlockType.PAGE_NUMBER,
+    BlockType.ASIDE_TEXT,
+    BlockType.PAGE_FOOTNOTE,
+}
+
+_VISUAL_BLOCK_TYPES = {
+    BlockType.IMAGE: {
+        "body": BlockType.IMAGE_BODY,
+        "span": ContentType.IMAGE,
+        "caption": BlockType.IMAGE_CAPTION,
+        "footnote": BlockType.IMAGE_FOOTNOTE,
+    },
+    BlockType.CHART: {
+        "body": BlockType.CHART_BODY,
+        "span": ContentType.CHART,
+        "caption": BlockType.CHART_CAPTION,
+        "footnote": BlockType.CHART_FOOTNOTE,
+    },
+}
+
+
+@dataclass(frozen=True)
+class DetailsVlmConfig:
+    enabled: bool = False
+    url: str | None = None
+    model: str | None = None
+    api_key: str = ""
+    timeout: int = DEFAULT_DETAILS_VLM_TIMEOUT
+    max_concurrency: int = DEFAULT_DETAILS_VLM_MAX_CONCURRENCY
+    language: str = DEFAULT_DETAILS_VLM_LANGUAGE
+
+    def is_complete(self) -> bool:
+        return bool(self.enabled and self.url and self.model)
+
+
+def build_details_vlm_config(
+    *,
+    details_image_analysis: bool = False,
+    details_vlm_url: str | None = None,
+    details_vlm_model: str | None = None,
+    details_vlm_api_key: str = "",
+    details_vlm_timeout: int = DEFAULT_DETAILS_VLM_TIMEOUT,
+    details_vlm_max_concurrency: int = DEFAULT_DETAILS_VLM_MAX_CONCURRENCY,
+    details_vlm_language: str = DEFAULT_DETAILS_VLM_LANGUAGE,
+) -> DetailsVlmConfig:
+    return DetailsVlmConfig(
+        enabled=details_image_analysis,
+        url=(details_vlm_url or "").strip() or None,
+        model=(details_vlm_model or "").strip() or None,
+        api_key=details_vlm_api_key or "",
+        timeout=max(1, int(details_vlm_timeout or DEFAULT_DETAILS_VLM_TIMEOUT)),
+        max_concurrency=max(1, int(details_vlm_max_concurrency or DEFAULT_DETAILS_VLM_MAX_CONCURRENCY)),
+        language=(details_vlm_language or DEFAULT_DETAILS_VLM_LANGUAGE).strip() or DEFAULT_DETAILS_VLM_LANGUAGE,
+    )
+
+
+def validate_details_vlm_config(config: DetailsVlmConfig) -> None:
+    if not config.enabled:
+        return
+    missing = []
+    if not config.url:
+        missing.append("details_vlm_url")
+    if not config.model:
+        missing.append("details_vlm_model")
+    if missing:
+        raise ValueError(
+            "details image analysis requires: " + ", ".join(missing)
+        )
+
+
+def enrich_visual_details(
+    pdf_info: list[dict[str, Any]],
+    local_image_dir: str,
+    config: DetailsVlmConfig,
+    *,
+    document_name: str = "",
+) -> int:
+    if not config.enabled:
+        return 0
+    if not config.is_complete():
+        logger.warning(
+            "Skipping details image analysis for {} because VLM URL/model is missing.",
+            document_name or "document",
+        )
+        return 0
+
+    targets = list(_iter_referenced_visual_detail_targets(pdf_info, local_image_dir))
+    if not targets:
+        return 0
+
+    total_targets = len(targets)
+    logger.info(
+        "Details image analysis started for {}: {} visual detail(s), concurrency={}, model={}",
+        document_name or "document",
+        total_targets,
+        config.max_concurrency,
+        config.model,
+    )
+
+    enriched_count = 0
+    completed_count = 0
+    with ThreadPoolExecutor(max_workers=config.max_concurrency) as executor:
+        future_to_target = {
+            executor.submit(
+                _request_visual_description_with_progress,
+                target,
+                config,
+                document_name or "document",
+                index,
+                total_targets,
+            ): (index, target)
+            for index, target in enumerate(targets, start=1)
+        }
+        for future in as_completed(future_to_target):
+            index, target = future_to_target[future]
+            completed_count += 1
+            try:
+                enriched_content, elapsed, request_error = future.result()
+            except Exception as exc:
+                logger.warning(
+                    "Details image analysis request {}/{} failed for {} page={} image={}: {}",
+                    index,
+                    total_targets,
+                    document_name or "document",
+                    target["page_idx"],
+                    target["image_path"],
+                    exc,
+                )
+                continue
+            if request_error is not None:
+                logger.warning(
+                    "Details image analysis progress for {}: {}/{} complete, {} enriched; failed request #{} page={} image={} after {:.1f}s: {}",
+                    document_name or "document",
+                    completed_count,
+                    total_targets,
+                    enriched_count,
+                    index,
+                    target["page_idx"],
+                    target["image_path"],
+                    elapsed,
+                    request_error,
+                )
+                continue
+            if not enriched_content:
+                logger.warning(
+                    "Details image analysis progress for {}: {}/{} complete, {} enriched; empty response from request #{} page={} image={} after {:.1f}s",
+                    document_name or "document",
+                    completed_count,
+                    total_targets,
+                    enriched_count,
+                    index,
+                    target["page_idx"],
+                    target["image_path"],
+                    elapsed,
+                )
+                continue
+            target["span"]["content"] = _append_didactic_interpretation(
+                target["original_content"],
+                enriched_content,
+            )
+            target["span"]["details_source"] = "external_vlm"
+            target["span"]["details_model"] = config.model
+            enriched_count += 1
+            logger.info(
+                "Details image analysis progress for {}: {}/{} complete, {} enriched; request #{} page={} image={} took {:.1f}s",
+                document_name or "document",
+                completed_count,
+                total_targets,
+                enriched_count,
+                index,
+                target["page_idx"],
+                target["image_path"],
+                elapsed,
+            )
+
+    logger.info(
+        "Details image analysis finished for {}: {}/{} enriched.",
+        document_name or "document",
+        enriched_count,
+        total_targets,
+    )
+    return enriched_count
+
+
+def _request_visual_description_with_progress(
+    target: dict[str, Any],
+    config: DetailsVlmConfig,
+    document_name: str,
+    index: int,
+    total_targets: int,
+) -> tuple[str, float, Exception | None]:
+    logger.info(
+        "Details image analysis request {}/{} started for {} page={} image={}",
+        index,
+        total_targets,
+        document_name,
+        target["page_idx"],
+        target["image_path"],
+    )
+    started_at = time.monotonic()
+    try:
+        content = _request_visual_description(target, config)
+        return content, time.monotonic() - started_at, None
+    except Exception as exc:
+        return "", time.monotonic() - started_at, exc
+
+
+def _iter_referenced_visual_detail_targets(pdf_info, local_image_dir):
+    for page_info in pdf_info:
+        page_idx = page_info.get("page_idx", 0)
+        para_blocks = _get_blocks_in_index_order(page_info.get("para_blocks", []))
+        for block_index, para_block in enumerate(para_blocks):
+            para_type = para_block.get("type")
+            visual_config = _VISUAL_BLOCK_TYPES.get(para_type)
+            if visual_config is None:
+                continue
+            nearby_context = _collect_nearby_context(para_blocks, block_index)
+            visual_context = _collect_visual_context(para_block, visual_config)
+            yield from _iter_body_span_targets(
+                para_block,
+                visual_config["body"],
+                visual_config["span"],
+                local_image_dir,
+                page_idx,
+                visual_context,
+                nearby_context,
+            )
+
+
+def _get_blocks_in_index_order(blocks):
+    return [
+        block
+        for _, block in sorted(
+            enumerate(blocks or []),
+            key=lambda item: (item[1].get("index", float("inf")), item[0]),
+        )
+    ]
+
+
+def _iter_body_span_targets(
+    para_block,
+    body_type,
+    span_type,
+    local_image_dir,
+    page_idx,
+    visual_context,
+    nearby_context,
+):
+    for block in para_block.get("blocks", []):
+        if block.get("type") != body_type:
+            continue
+        for line in block.get("lines", []):
+            for span in line.get("spans", []):
+                if span.get("type") != span_type:
+                    continue
+                image_path = span.get("image_path", "")
+                content = span.get("content", "")
+                if not image_path or not isinstance(content, str) or not content.strip():
+                    continue
+                absolute_image_path = os.path.join(local_image_dir, image_path)
+                if not os.path.exists(absolute_image_path):
+                    logger.warning(
+                        "Skipping details image analysis because image file is missing: {}",
+                        absolute_image_path,
+                    )
+                    continue
+                yield {
+                    "span": span,
+                    "span_type": span_type,
+                    "image_path": image_path,
+                    "absolute_image_path": absolute_image_path,
+                    "page_idx": page_idx,
+                    "original_content": content,
+                    "sub_type": para_block.get("sub_type", ""),
+                    **visual_context,
+                    **nearby_context,
+                }
+
+
+def _collect_visual_context(para_block, visual_config):
+    captions = []
+    footnotes = []
+    for block in para_block.get("blocks", []):
+        block_type = block.get("type")
+        if block_type == visual_config["caption"]:
+            captions.append(_collapse_whitespace(_extract_text_from_block(block)))
+        elif block_type == visual_config["footnote"]:
+            footnotes.append(_collapse_whitespace(_extract_text_from_block(block)))
+
+    return {
+        "caption": "\n".join(text for text in captions if text),
+        "footnote": "\n".join(text for text in footnotes if text),
+    }
+
+
+def _collect_nearby_context(para_blocks, visual_block_index):
+    preceding_context = ""
+    following_context = ""
+
+    for block in reversed(para_blocks[:visual_block_index]):
+        preceding_context = _extract_nearby_context_text(block)
+        if preceding_context:
+            preceding_context = _truncate_context(preceding_context, keep_end=True)
+            break
+
+    for block in para_blocks[visual_block_index + 1:]:
+        following_context = _extract_nearby_context_text(block)
+        if following_context:
+            following_context = _truncate_context(following_context, keep_end=False)
+            break
+
+    return {
+        "preceding_context": preceding_context,
+        "following_context": following_context,
+    }
+
+
+def _extract_nearby_context_text(block):
+    block_type = block.get("type")
+    if block_type in _EXCLUDED_CONTEXT_BLOCK_TYPES:
+        return ""
+    if block_type in _TEXT_CONTEXT_BLOCK_TYPES:
+        return _collapse_whitespace(_extract_text_from_block(block))
+    if block_type == BlockType.LIST:
+        text = _collapse_whitespace(_extract_text_from_block(block))
+        if len(text) <= LIST_CONTEXT_CHAR_LIMIT:
+            return text
+    return ""
+
+
+def _extract_text_from_block(block):
+    text_parts = []
+    for line in block.get("lines", []):
+        for span in line.get("spans", []):
+            if span.get("type") == ContentType.TEXT:
+                content = span.get("content", "")
+                if isinstance(content, str) and content.strip():
+                    text_parts.append(content)
+
+    for child_block in block.get("blocks", []):
+        child_text = _extract_text_from_block(child_block)
+        if child_text:
+            text_parts.append(child_text)
+
+    return " ".join(text_parts)
+
+
+def _collapse_whitespace(text):
+    return re.sub(r"\s+", " ", text or "").strip()
+
+
+def _truncate_context(text, *, keep_end):
+    text = _collapse_whitespace(text)
+    if len(text) <= NEARBY_CONTEXT_CHAR_LIMIT:
+        return text
+    if keep_end:
+        return text[-NEARBY_CONTEXT_CHAR_LIMIT:].lstrip()
+    return text[:NEARBY_CONTEXT_CHAR_LIMIT].rstrip()
+
+
+def _request_visual_description(target: dict[str, Any], config: DetailsVlmConfig) -> str:
+    image_path = target["absolute_image_path"]
+    with open(image_path, "rb") as image_file:
+        image_bytes = image_file.read()
+    mime_type = mimetypes.guess_type(image_path)[0] or "image/jpeg"
+    image_data_uri = f"data:{mime_type};base64,{base64.b64encode(image_bytes).decode('ascii')}"
+
+    headers = {"Content-Type": "application/json"}
+    if config.api_key:
+        headers["Authorization"] = f"Bearer {config.api_key}"
+
+    payload = {
+        "model": config.model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": _build_visual_details_prompt(target, config.language)},
+                    {"type": "image_url", "image_url": {"url": image_data_uri}},
+                ],
+            }
+        ],
+        "temperature": 0.2,
+        "stream": False,
+    }
+    endpoint = f"{config.url.rstrip('/')}/chat/completions"
+    with httpx.Client(timeout=config.timeout) as client:
+        response = client.post(endpoint, headers=headers, json=payload)
+        response.raise_for_status()
+        data = response.json()
+    return _normalize_visual_details_content(_extract_chat_completion_content(data))
+
+
+def _build_visual_details_prompt(target: dict[str, Any], language: str) -> str:
+    visual_kind = "chart" if target["span_type"] == ContentType.CHART else "image"
+    if language and language.lower() != "auto":
+        language_instruction = f"Write the answer in this language: {language}."
+    else:
+        language_instruction = "Use the document's apparent language when inferable; otherwise write in English."
+
+    original_content = target.get("original_content", "").strip()
+    caption = target.get("caption", "").strip()
+    footnote = target.get("footnote", "").strip()
+    preceding_context = target.get("preceding_context", "").strip()
+    following_context = target.get("following_context", "").strip()
+    return f"""Analyze this referenced {visual_kind} from a document and write only the didactic interpretation to append to an existing Markdown <details> section.
+
+Goal: add concise, RAG-friendly teaching context without duplicating the visual data already extracted by MinerU.
+
+Instructions:
+- {language_instruction}
+- Do not include <details>, <summary>, HTML wrappers, or a top-level title.
+- Start exactly with a "### Didactic interpretation" heading.
+- Explain what the visual means, why it matters in the document context, and how a reader should reason about it.
+- Do not create a "### Visual data" section.
+- Do not repeat axes, labels, categories, values, legends, annotations, or raw data already present in the MinerU description unless a brief reference is needed to explain meaning.
+- Do not invent exact values that are not visible.
+- Use the caption and nearby context to explain relevance, but do not summarize unrelated surrounding text.
+
+Existing MinerU description, if useful:
+{original_content}
+
+Caption, if present:
+{caption or "(none)"}
+
+Footnote, if present:
+{footnote or "(none)"}
+
+Nearby text before the visual, if present:
+{preceding_context or "(none)"}
+
+Nearby text after the visual, if present:
+{following_context or "(none)"}
+
+Didactic interpretation to append:"""
+
+
+def _normalize_visual_details_content(content: str) -> str:
+    content = (content or "").strip()
+    if not content:
+        return ""
+
+    content = re.sub(
+        r"^#{1,6}\s+Visual data\b.*?(?=^#{1,6}\s+|\Z)",
+        "",
+        content,
+        flags=re.IGNORECASE | re.MULTILINE | re.DOTALL,
+    ).strip()
+    if not content:
+        return ""
+
+    has_didactic_heading = re.search(
+        r"^#{1,6}\s+Didactic interpretation\b",
+        content,
+        flags=re.IGNORECASE | re.MULTILINE,
+    )
+    if has_didactic_heading:
+        return content
+
+    content = re.sub(
+        r"^#{1,6}\s+(Interpretation|Meaning|Explanation)\b",
+        "### Didactic interpretation",
+        content,
+        count=1,
+        flags=re.IGNORECASE | re.MULTILINE,
+    )
+    if re.search(r"^#{1,6}\s+Didactic interpretation\b", content, flags=re.IGNORECASE | re.MULTILINE):
+        return content
+    return f"### Didactic interpretation\n{content}"
+
+
+def _append_didactic_interpretation(original_content: str, didactic_content: str) -> str:
+    original_content = (original_content or "").strip()
+    didactic_content = _normalize_visual_details_content(didactic_content)
+    if not didactic_content:
+        return original_content
+    if not original_content:
+        return didactic_content
+    return f"{original_content}\n\n{didactic_content}"
+
+
+def _extract_chat_completion_content(data: dict[str, Any]) -> str:
+    choices = data.get("choices") or []
+    if not choices:
+        return ""
+    message = choices[0].get("message") or {}
+    content = message.get("content", "")
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict):
+                parts.append(str(item.get("text", "") or ""))
+            else:
+                parts.append(str(item))
+        content = "\n".join(part for part in parts if part.strip())
+    if not isinstance(content, str):
+        return ""
+    content = _strip_response_wrappers(_strip_thinking_content(content)).strip()
+    return content
+
+
+def _strip_thinking_content(content: str) -> str:
+    if "</think>" in content:
+        return content.split("</think>", 1)[1]
+    return re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL)
+
+
+def _strip_response_wrappers(content: str) -> str:
+    content = content.strip()
+    fence_match = re.fullmatch(r"```[^\n]*\n?(.*?)\s*```", content, flags=re.DOTALL)
+    if fence_match:
+        content = fence_match.group(1).strip()
+
+    details_match = re.fullmatch(r"<details\b[^>]*>\s*(.*?)\s*</details>", content, flags=re.DOTALL | re.IGNORECASE)
+    if details_match:
+        content = details_match.group(1).strip()
+        content = re.sub(
+            r"^<summary\b[^>]*>.*?</summary>\s*",
+            "",
+            content,
+            flags=re.DOTALL | re.IGNORECASE,
+        ).strip()
+
+    return content

--- a/mineru/cli/api_client.py
+++ b/mineru/cli/api_client.py
@@ -812,6 +812,13 @@ def build_parse_request_form_data(
     end_page_id: Optional[int],
     *,
     image_analysis: bool = True,
+    details_image_analysis: bool = False,
+    details_vlm_url: Optional[str] = None,
+    details_vlm_model: Optional[str] = None,
+    details_vlm_api_key: str = "",
+    details_vlm_timeout: int = 120,
+    details_vlm_max_concurrency: int = 1,
+    details_vlm_language: str = "auto",
     return_md: bool,
     return_middle_json: bool,
     return_model_output: bool,
@@ -829,6 +836,11 @@ def build_parse_request_form_data(
         "formula_enable": str(formula_enable).lower(),
         "table_enable": str(table_enable).lower(),
         "image_analysis": str(image_analysis).lower(),
+        "details_image_analysis": str(details_image_analysis).lower(),
+        "details_vlm_api_key": details_vlm_api_key or "",
+        "details_vlm_timeout": str(details_vlm_timeout),
+        "details_vlm_max_concurrency": str(details_vlm_max_concurrency),
+        "details_vlm_language": details_vlm_language or "auto",
         "return_md": str(return_md).lower(),
         "return_middle_json": str(return_middle_json).lower(),
         "return_model_output": str(return_model_output).lower(),
@@ -842,6 +854,10 @@ def build_parse_request_form_data(
     }
     if server_url:
         data["server_url"] = server_url
+    if details_vlm_url:
+        data["details_vlm_url"] = details_vlm_url
+    if details_vlm_model:
+        data["details_vlm_model"] = details_vlm_model
     return data
 
 

--- a/mineru/cli/api_request.py
+++ b/mineru/cli/api_request.py
@@ -25,6 +25,13 @@ class ParseRequestOptions:
     formula_enable: bool
     table_enable: bool
     image_analysis: bool
+    details_image_analysis: bool
+    details_vlm_url: Optional[str]
+    details_vlm_model: Optional[str]
+    details_vlm_api_key: str
+    details_vlm_timeout: int
+    details_vlm_max_concurrency: int
+    details_vlm_language: str
     server_url: Optional[str]
     return_md: bool
     return_middle_json: bool
@@ -117,6 +124,34 @@ async def parse_request_form(
         bool,
         Form(description="Enable image/chart analysis for VLM and hybrid backends."),
     ] = True,
+    details_image_analysis: Annotated[
+        bool,
+        Form(description="Enable external VLM enrichment for referenced image/chart details."),
+    ] = False,
+    details_vlm_url: Annotated[
+        Optional[str],
+        Form(description="OpenAI-compatible base URL for details image analysis."),
+    ] = None,
+    details_vlm_model: Annotated[
+        Optional[str],
+        Form(description="Model name for details image analysis."),
+    ] = None,
+    details_vlm_api_key: Annotated[
+        str,
+        Form(description="Optional API key for details image analysis."),
+    ] = "",
+    details_vlm_timeout: Annotated[
+        int,
+        Form(description="Per-image timeout in seconds for details image analysis."),
+    ] = 120,
+    details_vlm_max_concurrency: Annotated[
+        int,
+        Form(description="Maximum parallel external VLM calls for details image analysis."),
+    ] = 1,
+    details_vlm_language: Annotated[
+        str,
+        Form(description="Output language for enriched details."),
+    ] = "auto",
     server_url: Annotated[
         Optional[str],
         Form(
@@ -184,7 +219,18 @@ async def parse_request_form(
         ),
         backend=backend,
         server_url=server_url,
+        details_vlm_url=details_vlm_url,
     )
+    if details_image_analysis and not details_vlm_url:
+        raise HTTPException(
+            status_code=400,
+            detail="details_vlm_url is required when details_image_analysis is enabled",
+        )
+    if details_image_analysis and not details_vlm_model:
+        raise HTTPException(
+            status_code=400,
+            detail="details_vlm_model is required when details_image_analysis is enabled",
+        )
     if client_side_output_generation:
         return_md = False
         return_middle_json = True
@@ -201,6 +247,13 @@ async def parse_request_form(
         formula_enable=formula_enable,
         table_enable=table_enable,
         image_analysis=image_analysis,
+        details_image_analysis=details_image_analysis,
+        details_vlm_url=details_vlm_url,
+        details_vlm_model=details_vlm_model,
+        details_vlm_api_key=details_vlm_api_key,
+        details_vlm_timeout=details_vlm_timeout,
+        details_vlm_max_concurrency=details_vlm_max_concurrency,
+        details_vlm_language=details_vlm_language,
         server_url=server_url,
         return_md=return_md,
         return_middle_json=return_middle_json,

--- a/mineru/cli/client.py
+++ b/mineru/cli/client.py
@@ -624,6 +624,13 @@ def build_request_form_data(
     start_page_id: int,
     end_page_id: Optional[int],
     image_analysis: bool = True,
+    details_image_analysis: bool = False,
+    details_vlm_url: Optional[str] = None,
+    details_vlm_model: Optional[str] = None,
+    details_vlm_api_key: str = "",
+    details_vlm_timeout: int = 120,
+    details_vlm_max_concurrency: int = 1,
+    details_vlm_language: str = "auto",
     client_side_output_generation: bool = False,
 ) -> dict[str, str | list[str]]:
     # 开启客户端输出生成时，服务端只负责返回 middle json、图片和原文件。
@@ -637,6 +644,13 @@ def build_request_form_data(
         formula_enable=formula_enable,
         table_enable=table_enable,
         image_analysis=image_analysis,
+        details_image_analysis=details_image_analysis,
+        details_vlm_url=details_vlm_url,
+        details_vlm_model=details_vlm_model,
+        details_vlm_api_key=details_vlm_api_key,
+        details_vlm_timeout=details_vlm_timeout,
+        details_vlm_max_concurrency=details_vlm_max_concurrency,
+        details_vlm_language=details_vlm_language,
         server_url=server_url,
         start_page_id=start_page_id,
         end_page_id=end_page_id,
@@ -869,6 +883,13 @@ async def run_orchestrated_cli(
     formula_enable: bool,
     table_enable: bool,
     image_analysis: bool = True,
+    details_image_analysis: bool = False,
+    details_vlm_url: Optional[str] = None,
+    details_vlm_model: Optional[str] = None,
+    details_vlm_api_key: str = "",
+    details_vlm_timeout: int = 120,
+    details_vlm_max_concurrency: int = 1,
+    details_vlm_language: str = "auto",
     client_side_output_generation: bool = False,
     extra_cli_args: tuple[str, ...] = (),
 ) -> None:
@@ -876,6 +897,10 @@ async def run_orchestrated_cli(
         raise click.ClickException("--start must be greater than or equal to 0")
     if end_page_id is not None and end_page_id < 0:
         raise click.ClickException("--end must be greater than or equal to 0")
+    if details_image_analysis and not details_vlm_url:
+        raise click.ClickException("--details-vlm-url is required when --details-image-analysis is enabled")
+    if details_image_analysis and not details_vlm_model:
+        raise click.ClickException("--details-vlm-model is required when --details-image-analysis is enabled")
     if api_url is None:
         try:
             ensure_backend_dependencies(backend)
@@ -937,6 +962,13 @@ async def run_orchestrated_cli(
                 formula_enable=formula_enable,
                 table_enable=table_enable,
                 image_analysis=image_analysis,
+                details_image_analysis=details_image_analysis,
+                details_vlm_url=details_vlm_url,
+                details_vlm_model=details_vlm_model,
+                details_vlm_api_key=details_vlm_api_key,
+                details_vlm_timeout=details_vlm_timeout,
+                details_vlm_max_concurrency=details_vlm_max_concurrency,
+                details_vlm_language=details_vlm_language,
                 server_url=server_url,
                 start_page_id=start_page_id,
                 end_page_id=end_page_id,
@@ -1126,6 +1158,55 @@ async def run_orchestrated_cli(
     help="Enable image/chart analysis for VLM and hybrid backends. Default is True. ",
 )
 @click.option(
+    "--details-image-analysis",
+    "details_image_analysis",
+    type=bool,
+    default=False,
+    help="Enable external VLM enrichment for referenced image/chart details. Default is False.",
+)
+@click.option(
+    "--details-vlm-url",
+    "details_vlm_url",
+    type=str,
+    default=None,
+    help="OpenAI-compatible base URL for details image analysis.",
+)
+@click.option(
+    "--details-vlm-model",
+    "details_vlm_model",
+    type=str,
+    default=None,
+    help="Model name for details image analysis.",
+)
+@click.option(
+    "--details-vlm-api-key",
+    "details_vlm_api_key",
+    type=str,
+    default="",
+    help="Optional API key for details image analysis. Default is empty.",
+)
+@click.option(
+    "--details-vlm-timeout",
+    "details_vlm_timeout",
+    type=int,
+    default=120,
+    help="Per-image timeout in seconds for details image analysis. Default is 120.",
+)
+@click.option(
+    "--details-vlm-max-concurrency",
+    "details_vlm_max_concurrency",
+    type=int,
+    default=1,
+    help="Maximum parallel external VLM calls for details image analysis. Default is 1.",
+)
+@click.option(
+    "--details-vlm-language",
+    "details_vlm_language",
+    type=str,
+    default="auto",
+    help="Output language for enriched details. Default is auto.",
+)
+@click.option(
     "--client-side-output-generation",
     "client_side_output_generation",
     is_flag=True,
@@ -1149,6 +1230,13 @@ def main(
     formula_enable: bool,
     table_enable: bool,
     image_analysis: bool,
+    details_image_analysis: bool,
+    details_vlm_url: Optional[str],
+    details_vlm_model: Optional[str],
+    details_vlm_api_key: str,
+    details_vlm_timeout: int,
+    details_vlm_max_concurrency: int,
+    details_vlm_language: str,
     client_side_output_generation: bool,
 ) -> None:
     asyncio.run(
@@ -1165,6 +1253,13 @@ def main(
             formula_enable=formula_enable,
             table_enable=table_enable,
             image_analysis=image_analysis,
+            details_image_analysis=details_image_analysis,
+            details_vlm_url=details_vlm_url,
+            details_vlm_model=details_vlm_model,
+            details_vlm_api_key=details_vlm_api_key,
+            details_vlm_timeout=details_vlm_timeout,
+            details_vlm_max_concurrency=details_vlm_max_concurrency,
+            details_vlm_language=details_vlm_language,
             client_side_output_generation=client_side_output_generation,
             extra_cli_args=tuple(ctx.args),
         )

--- a/mineru/cli/common.py
+++ b/mineru/cli/common.py
@@ -20,6 +20,11 @@ from mineru.backend.vlm.vlm_middle_json_mkcontent import union_make as vlm_union
 from mineru.backend.office.office_middle_json_mkcontent import union_make as office_union_make
 from mineru.backend.vlm.vlm_analyze import doc_analyze as vlm_doc_analyze
 from mineru.backend.vlm.vlm_analyze import aio_doc_analyze as aio_vlm_doc_analyze
+from mineru.backend.vlm.visual_details_enrichment import (
+    build_details_vlm_config,
+    enrich_visual_details,
+    validate_details_vlm_config,
+)
 from mineru.backend.office.pptx_analyze import office_pptx_analyze
 from mineru.backend.office.xlsx_analyze import office_xlsx_analyze
 from mineru.backend.office.docx_analyze import office_docx_analyze
@@ -226,6 +231,7 @@ def _process_output(
         middle_json,
         model_output=None,
         process_mode="vlm",
+        details_vlm_config=None,
 ):
     from mineru.backend.pipeline.pipeline_middle_json_mkcontent import union_make as pipeline_union_make
     if process_mode == "pipeline":
@@ -263,6 +269,14 @@ def _process_output(
 
     image_dir = str(os.path.basename(local_image_dir))
 
+    if process_mode == "vlm" and details_vlm_config is not None:
+        enrich_visual_details(
+            pdf_info,
+            local_image_dir,
+            details_vlm_config,
+            document_name=pdf_file_name,
+        )
+
     if f_dump_md:
         md_content_str = make_func(pdf_info, f_make_md_mode, image_dir)
         md_writer.write_string(
@@ -298,6 +312,10 @@ def _process_output(
         )
 
     logger.debug(f"local output dir is {local_md_dir}")
+
+
+async def _async_process_output(*args, **kwargs):
+    return await asyncio.to_thread(_process_output, *args, **kwargs)
 
 
 def _process_pipeline(
@@ -389,6 +407,7 @@ async def _async_process_vlm(
         f_dump_content_list,
         f_make_md_mode,
         server_url=None,
+        details_vlm_config=None,
         **kwargs,
 ):
     """异步处理VLM后端逻辑"""
@@ -408,11 +427,12 @@ async def _async_process_vlm(
 
         pdf_info = middle_json["pdf_info"]
 
-        _process_output(
+        await _async_process_output(
             pdf_info, pdf_bytes, pdf_file_name, local_md_dir, local_image_dir,
             md_writer, f_draw_layout_bbox, f_draw_span_bbox, f_dump_orig_pdf,
             f_dump_md, f_dump_content_list, f_dump_middle_json, f_dump_model_output,
-            f_make_md_mode, middle_json, infer_result, process_mode="vlm"
+            f_make_md_mode, middle_json, infer_result, process_mode="vlm",
+            details_vlm_config=details_vlm_config,
         )
 
 
@@ -430,6 +450,7 @@ def _process_vlm(
         f_dump_content_list,
         f_make_md_mode,
         server_url=None,
+        details_vlm_config=None,
         **kwargs,
 ):
     """同步处理VLM后端逻辑"""
@@ -453,7 +474,8 @@ def _process_vlm(
             pdf_info, pdf_bytes, pdf_file_name, local_md_dir, local_image_dir,
             md_writer, f_draw_layout_bbox, f_draw_span_bbox, f_dump_orig_pdf,
             f_dump_md, f_dump_content_list, f_dump_middle_json, f_dump_model_output,
-            f_make_md_mode, middle_json, infer_result, process_mode="vlm"
+            f_make_md_mode, middle_json, infer_result, process_mode="vlm",
+            details_vlm_config=details_vlm_config,
         )
 
 
@@ -474,6 +496,7 @@ def _process_hybrid(
         f_dump_content_list,
         f_make_md_mode,
         server_url=None,
+        details_vlm_config=None,
         **kwargs,
 ):
     hybrid_doc_analyze = _load_hybrid_analyze_entrypoint(
@@ -509,7 +532,8 @@ def _process_hybrid(
             pdf_info, pdf_bytes, pdf_file_name, local_md_dir, local_image_dir,
             md_writer, f_draw_layout_bbox, f_draw_span_bbox, f_dump_orig_pdf,
             f_dump_md, f_dump_content_list, f_dump_middle_json, f_dump_model_output,
-            f_make_md_mode, middle_json, infer_result, process_mode="vlm"
+            f_make_md_mode, middle_json, infer_result, process_mode="vlm",
+            details_vlm_config=details_vlm_config,
         )
 
 
@@ -530,6 +554,7 @@ async def _async_process_hybrid(
         f_dump_content_list,
         f_make_md_mode,
         server_url=None,
+        details_vlm_config=None,
         **kwargs,
 ):
     aio_hybrid_doc_analyze = _load_hybrid_analyze_entrypoint(
@@ -561,11 +586,12 @@ async def _async_process_hybrid(
         # f_draw_span_bbox = not _vlm_ocr_enable
         f_draw_span_bbox = False
 
-        _process_output(
+        await _async_process_output(
             pdf_info, pdf_bytes, pdf_file_name, local_md_dir, local_image_dir,
             md_writer, f_draw_layout_bbox, f_draw_span_bbox, f_dump_orig_pdf,
             f_dump_md, f_dump_content_list, f_dump_middle_json, f_dump_model_output,
-            f_make_md_mode, middle_json, infer_result, process_mode="vlm"
+            f_make_md_mode, middle_json, infer_result, process_mode="vlm",
+            details_vlm_config=details_vlm_config,
         )
 
 
@@ -640,9 +666,27 @@ def do_parse(
         start_page_id=0,
         end_page_id=None,
         image_analysis=True,
+        details_image_analysis=False,
+        details_vlm_url=None,
+        details_vlm_model=None,
+        details_vlm_api_key="",
+        details_vlm_timeout=120,
+        details_vlm_max_concurrency=1,
+        details_vlm_language="auto",
         client_side_output_generation=False,
         **kwargs,
 ):
+    details_vlm_config = build_details_vlm_config(
+        details_image_analysis=details_image_analysis,
+        details_vlm_url=details_vlm_url,
+        details_vlm_model=details_vlm_model,
+        details_vlm_api_key=details_vlm_api_key,
+        details_vlm_timeout=details_vlm_timeout,
+        details_vlm_max_concurrency=details_vlm_max_concurrency,
+        details_vlm_language=details_vlm_language,
+    )
+    validate_details_vlm_config(details_vlm_config)
+
     need_remove_index = _process_office_doc(
         output_dir,
         pdf_file_names=pdf_file_names,
@@ -690,7 +734,8 @@ def do_parse(
                 output_dir, pdf_file_names, pdf_bytes_list, backend,
                 f_draw_layout_bbox, f_draw_span_bbox, f_dump_md, f_dump_middle_json,
                 f_dump_model_output, f_dump_orig_pdf, f_dump_content_list, f_make_md_mode,
-                server_url, image_analysis=image_analysis,
+                server_url, details_vlm_config=details_vlm_config,
+                image_analysis=image_analysis,
                 client_side_output_generation=client_side_output_generation, **kwargs,
             )
         elif backend.startswith("hybrid-"):
@@ -711,7 +756,8 @@ def do_parse(
                 output_dir, pdf_file_names, pdf_bytes_list, p_lang_list, parse_method, formula_enable, backend,
                 f_draw_layout_bbox, f_draw_span_bbox, f_dump_md, f_dump_middle_json,
                 f_dump_model_output, f_dump_orig_pdf, f_dump_content_list, f_make_md_mode,
-                server_url, image_analysis=image_analysis,
+                server_url, details_vlm_config=details_vlm_config,
+                image_analysis=image_analysis,
                 client_side_output_generation=client_side_output_generation, **kwargs,
             )
 
@@ -737,9 +783,27 @@ async def aio_do_parse(
         start_page_id=0,
         end_page_id=None,
         image_analysis=True,
+        details_image_analysis=False,
+        details_vlm_url=None,
+        details_vlm_model=None,
+        details_vlm_api_key="",
+        details_vlm_timeout=120,
+        details_vlm_max_concurrency=1,
+        details_vlm_language="auto",
         client_side_output_generation=False,
         **kwargs,
 ):
+    details_vlm_config = build_details_vlm_config(
+        details_image_analysis=details_image_analysis,
+        details_vlm_url=details_vlm_url,
+        details_vlm_model=details_vlm_model,
+        details_vlm_api_key=details_vlm_api_key,
+        details_vlm_timeout=details_vlm_timeout,
+        details_vlm_max_concurrency=details_vlm_max_concurrency,
+        details_vlm_language=details_vlm_language,
+    )
+    validate_details_vlm_config(details_vlm_config)
+
     # Office 解析是同步且可能耗时的操作，异步入口需要放到线程中避免阻塞事件循环。
     need_remove_index = await asyncio.to_thread(
         _process_office_doc,
@@ -790,7 +854,8 @@ async def aio_do_parse(
                 output_dir, pdf_file_names, pdf_bytes_list, backend,
                 f_draw_layout_bbox, f_draw_span_bbox, f_dump_md, f_dump_middle_json,
                 f_dump_model_output, f_dump_orig_pdf, f_dump_content_list, f_make_md_mode,
-                server_url, image_analysis=image_analysis,
+                server_url, details_vlm_config=details_vlm_config,
+                image_analysis=image_analysis,
                 client_side_output_generation=client_side_output_generation, **kwargs,
             )
         elif backend.startswith("hybrid-"):
@@ -810,7 +875,8 @@ async def aio_do_parse(
                 output_dir, pdf_file_names, pdf_bytes_list, p_lang_list, parse_method, formula_enable, backend,
                 f_draw_layout_bbox, f_draw_span_bbox, f_dump_md, f_dump_middle_json,
                 f_dump_model_output, f_dump_orig_pdf, f_dump_content_list, f_make_md_mode,
-                server_url, image_analysis=image_analysis,
+                server_url, details_vlm_config=details_vlm_config,
+                image_analysis=image_analysis,
                 client_side_output_generation=client_side_output_generation, **kwargs,
             )
 

--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -150,6 +150,13 @@ class AsyncParseTask:
     formula_enable: bool
     table_enable: bool
     image_analysis: bool
+    details_image_analysis: bool
+    details_vlm_url: Optional[str]
+    details_vlm_model: Optional[str]
+    details_vlm_api_key: str
+    details_vlm_timeout: int
+    details_vlm_max_concurrency: int
+    details_vlm_language: str
     server_url: Optional[str]
     return_md: bool
     return_middle_json: bool
@@ -837,6 +844,13 @@ async def run_parse_job(
         formula_enable=request_options.formula_enable,
         table_enable=request_options.table_enable,
         image_analysis=request_options.image_analysis,
+        details_image_analysis=request_options.details_image_analysis,
+        details_vlm_url=request_options.details_vlm_url,
+        details_vlm_model=request_options.details_vlm_model,
+        details_vlm_api_key=request_options.details_vlm_api_key,
+        details_vlm_timeout=request_options.details_vlm_timeout,
+        details_vlm_max_concurrency=request_options.details_vlm_max_concurrency,
+        details_vlm_language=request_options.details_vlm_language,
         server_url=request_options.server_url,
         f_draw_layout_bbox=False,
         f_draw_span_bbox=False,
@@ -895,6 +909,13 @@ async def create_async_parse_task(
             formula_enable=request_options.formula_enable,
             table_enable=request_options.table_enable,
             image_analysis=request_options.image_analysis,
+            details_image_analysis=request_options.details_image_analysis,
+            details_vlm_url=request_options.details_vlm_url,
+            details_vlm_model=request_options.details_vlm_model,
+            details_vlm_api_key=request_options.details_vlm_api_key,
+            details_vlm_timeout=request_options.details_vlm_timeout,
+            details_vlm_max_concurrency=request_options.details_vlm_max_concurrency,
+            details_vlm_language=request_options.details_vlm_language,
             server_url=request_options.server_url,
             return_md=request_options.return_md,
             return_middle_json=request_options.return_middle_json,

--- a/mineru/cli/public_http_client_policy.py
+++ b/mineru/cli/public_http_client_policy.py
@@ -4,8 +4,8 @@ from loguru import logger
 
 
 PUBLIC_HTTP_CLIENT_DISABLED_DETAIL = (
-    "Publicly exposed API disables *-http-client backends and server_url by "
-    "default. Rebind to 127.0.0.1 or start with "
+    "Publicly exposed API disables *-http-client backends, server_url, and "
+    "details_vlm_url by default. Rebind to 127.0.0.1 or start with "
     "--allow-public-http-client if you understand the SSRF risk."
 )
 
@@ -30,10 +30,15 @@ def validate_public_http_client_request(
     allow_public_http_client: bool,
     backend: str,
     server_url: str | None,
+    details_vlm_url: str | None = None,
 ) -> None:
     if not public_bind_exposed or allow_public_http_client:
         return
-    if backend.endswith("-http-client") or bool(server_url and server_url.strip()):
+    if (
+        backend.endswith("-http-client")
+        or bool(server_url and server_url.strip())
+        or bool(details_vlm_url and details_vlm_url.strip())
+    ):
         raise HTTPException(status_code=400, detail=PUBLIC_HTTP_CLIENT_DISABLED_DETAIL)
 
 
@@ -56,8 +61,8 @@ def warn_if_public_http_client_policy(
         )
         return
     logger.warning(
-        "MinerU {} is listening on {}. Disabling *-http-client backends and "
-        "server_url by default because these inputs let callers choose remote HTTP "
+        "MinerU {} is listening on {}. Disabling *-http-client backends, "
+        "server_url, and details_vlm_url by default because these inputs let callers choose remote HTTP "
         "inference endpoints; when the API is publicly reachable, that creates SSRF "
         "and internal network probing risk.",
         service_name,

--- a/mineru/cli/router.py
+++ b/mineru/cli/router.py
@@ -1185,6 +1185,7 @@ async def submit_router_task(
         ),
         backend=payload.get_field_value("backend") or "",
         server_url=payload.get_field_value("server_url"),
+        details_vlm_url=payload.get_field_value("details_vlm_url"),
     )
     worker_pool: WorkerPool = request.app.state.worker_pool
     registry: RouterTaskRegistry = request.app.state.router_task_registry

--- a/tests/unittest/test_async_output_offload.py
+++ b/tests/unittest/test_async_output_offload.py
@@ -1,0 +1,144 @@
+import asyncio
+
+from mineru.cli import common
+from mineru.utils.enum_class import MakeMode
+
+
+def _output_recorder(calls):
+    def fake_process_output(*args, **kwargs):
+        calls.append(
+            {
+                "args": args,
+                "kwargs": kwargs,
+            }
+        )
+
+    return fake_process_output
+
+
+def _to_thread_recorder(calls):
+    async def fake_to_thread(func, *args, **kwargs):
+        calls.append(
+            {
+                "func": func,
+                "args": args,
+                "kwargs": kwargs,
+            }
+        )
+        await asyncio.sleep(0.01)
+        return func(*args, **kwargs)
+
+    return fake_to_thread
+
+
+def test_async_process_output_offloads_blocking_work(monkeypatch):
+    output_calls = []
+    to_thread_calls = []
+    monkeypatch.setattr(common, "_process_output", _output_recorder(output_calls))
+    monkeypatch.setattr(common.asyncio, "to_thread", _to_thread_recorder(to_thread_calls))
+
+    async def run():
+        task = asyncio.create_task(common._async_process_output("pdf-info", process_mode="vlm"))
+
+        await asyncio.sleep(0)
+
+        assert not task.done()
+        await task
+        assert to_thread_calls[0]["func"] is common._process_output
+        assert to_thread_calls[0]["args"] == ("pdf-info",)
+        assert to_thread_calls[0]["kwargs"] == {"process_mode": "vlm"}
+        assert output_calls[0]["args"] == ("pdf-info",)
+        assert output_calls[0]["kwargs"] == {"process_mode": "vlm"}
+
+    asyncio.run(run())
+
+
+def test_async_process_vlm_offloads_output(monkeypatch, tmp_path):
+    output_calls = []
+    to_thread_calls = []
+    details_vlm_config = object()
+
+    async def fake_aio_vlm_doc_analyze(*args, **kwargs):
+        return {"pdf_info": []}, {"model": "output"}
+
+    monkeypatch.setattr(common, "aio_vlm_doc_analyze", fake_aio_vlm_doc_analyze)
+    monkeypatch.setattr(common, "_process_output", _output_recorder(output_calls))
+    monkeypatch.setattr(common.asyncio, "to_thread", _to_thread_recorder(to_thread_calls))
+
+    async def run():
+        task = asyncio.create_task(
+            common._async_process_vlm(
+                tmp_path,
+                ["sample"],
+                [b"%PDF-1.7"],
+                "vllm-async-engine",
+                False,
+                False,
+                True,
+                True,
+                True,
+                True,
+                True,
+                MakeMode.MM_MD,
+                details_vlm_config=details_vlm_config,
+            )
+        )
+
+        await asyncio.sleep(0)
+
+        assert not task.done()
+        await task
+        assert to_thread_calls[0]["func"] is common._process_output
+        assert output_calls[0]["kwargs"]["process_mode"] == "vlm"
+        assert output_calls[0]["kwargs"]["details_vlm_config"] is details_vlm_config
+
+    asyncio.run(run())
+
+
+def test_async_process_hybrid_offloads_output(monkeypatch, tmp_path):
+    output_calls = []
+    to_thread_calls = []
+    details_vlm_config = object()
+
+    async def fake_aio_hybrid_doc_analyze(*args, **kwargs):
+        return {"pdf_info": []}, {"model": "output"}, False
+
+    monkeypatch.setattr(
+        common,
+        "_load_hybrid_analyze_entrypoint",
+        lambda entrypoint, backend: fake_aio_hybrid_doc_analyze,
+    )
+    monkeypatch.setattr(common, "_process_output", _output_recorder(output_calls))
+    monkeypatch.setattr(common.asyncio, "to_thread", _to_thread_recorder(to_thread_calls))
+
+    async def run():
+        task = asyncio.create_task(
+            common._async_process_hybrid(
+                tmp_path,
+                ["sample"],
+                [b"%PDF-1.7"],
+                ["en"],
+                "auto",
+                True,
+                "vllm-async-engine",
+                False,
+                False,
+                True,
+                True,
+                True,
+                True,
+                True,
+                MakeMode.MM_MD,
+                details_vlm_config=details_vlm_config,
+            )
+        )
+
+        await asyncio.sleep(0)
+
+        assert not task.done()
+        await task
+        assert to_thread_calls[0]["func"] is common._process_output
+        assert output_calls[0]["kwargs"]["process_mode"] == "vlm"
+        assert output_calls[0]["kwargs"]["details_vlm_config"] is details_vlm_config
+
+    asyncio.run(run())

--- a/tests/unittest/test_visual_details_enrichment.py
+++ b/tests/unittest/test_visual_details_enrichment.py
@@ -1,0 +1,383 @@
+import os
+
+from mineru.backend.vlm import visual_details_enrichment as enrichment
+from mineru.backend.vlm.vlm_middle_json_mkcontent import union_make
+from mineru.cli import common
+from mineru.cli.api_client import build_parse_request_form_data
+from mineru.utils.enum_class import BlockType, ContentType, MakeMode
+
+
+def _visual_para(para_type, body_type, span_type, image_path, content):
+    return {
+        "type": para_type,
+        "blocks": [
+            {
+                "type": body_type,
+                "lines": [
+                    {
+                        "spans": [
+                            {
+                                "type": span_type,
+                                "image_path": image_path,
+                                "content": content,
+                            }
+                        ]
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _text_block(block_type, text, *, index=None):
+    block = {
+        "type": block_type,
+        "lines": [{"spans": [{"type": ContentType.TEXT, "content": text}]}],
+    }
+    if index is not None:
+        block["index"] = index
+    return block
+
+
+def _visual_para_with_context(
+    para_type,
+    body_type,
+    span_type,
+    image_path,
+    content,
+    *,
+    caption_type=None,
+    caption=None,
+    footnote_type=None,
+    footnote=None,
+    index=None,
+):
+    para = _visual_para(para_type, body_type, span_type, image_path, content)
+    if index is not None:
+        para["index"] = index
+    if caption_type and caption:
+        para["blocks"].append(_text_block(caption_type, caption))
+    if footnote_type and footnote:
+        para["blocks"].append(_text_block(footnote_type, footnote))
+    return para
+
+
+def test_vlm_markdown_renders_referenced_image_details():
+    pdf_info = [
+        {
+            "page_idx": 0,
+            "page_size": [100, 100],
+            "para_blocks": [
+                _visual_para(
+                    BlockType.IMAGE,
+                    BlockType.IMAGE_BODY,
+                    ContentType.IMAGE,
+                    "image.jpg",
+                    "A sparse description.",
+                )
+            ],
+            "discarded_blocks": [],
+        }
+    ]
+
+    markdown = union_make(pdf_info, MakeMode.MM_MD, "images")
+
+    assert "![](images/image.jpg)" in markdown
+    assert "<details>" in markdown
+    assert "<summary>image content</summary>" in markdown
+    assert "A sparse description." in markdown
+
+
+def test_enrichment_selects_only_referenced_visual_details(tmp_path, monkeypatch):
+    (tmp_path / "image.jpg").write_bytes(b"image")
+    (tmp_path / "chart.jpg").write_bytes(b"chart")
+    (tmp_path / "table.jpg").write_bytes(b"table")
+    (tmp_path / "empty.jpg").write_bytes(b"empty image")
+    pdf_info = [
+        {
+            "page_idx": 0,
+            "page_size": [100, 100],
+            "para_blocks": [
+                _visual_para(BlockType.IMAGE, BlockType.IMAGE_BODY, ContentType.IMAGE, "image.jpg", "old image"),
+                _visual_para(BlockType.CHART, BlockType.CHART_BODY, ContentType.CHART, "chart.jpg", "old chart"),
+                _visual_para(BlockType.TABLE, BlockType.TABLE_BODY, ContentType.TABLE, "table.jpg", "old table"),
+                _visual_para(BlockType.IMAGE, BlockType.IMAGE_BODY, ContentType.IMAGE, "missing.jpg", "old missing"),
+                _visual_para(BlockType.IMAGE, BlockType.IMAGE_BODY, ContentType.IMAGE, "empty.jpg", ""),
+            ],
+            "discarded_blocks": [],
+        }
+    ]
+    calls = []
+
+    def fake_request(target, config):
+        calls.append((target["span_type"], target["image_path"], config.model))
+        return f"### Didactic interpretation\nenriched {target['image_path']}"
+
+    monkeypatch.setattr(enrichment, "_request_visual_description", fake_request)
+    config = enrichment.build_details_vlm_config(
+        details_image_analysis=True,
+        details_vlm_url="http://localhost:11434/v1",
+        details_vlm_model="qwen",
+    )
+
+    count = enrichment.enrich_visual_details(pdf_info, os.fspath(tmp_path), config)
+
+    assert count == 2
+    assert calls == [
+        (ContentType.IMAGE, "image.jpg", "qwen"),
+        (ContentType.CHART, "chart.jpg", "qwen"),
+    ]
+    assert pdf_info[0]["para_blocks"][0]["blocks"][0]["lines"][0]["spans"][0]["content"] == (
+        "old image\n\n### Didactic interpretation\nenriched image.jpg"
+    )
+    assert pdf_info[0]["para_blocks"][1]["blocks"][0]["lines"][0]["spans"][0]["content"] == (
+        "old chart\n\n### Didactic interpretation\nenriched chart.jpg"
+    )
+    assert pdf_info[0]["para_blocks"][2]["blocks"][0]["lines"][0]["spans"][0]["content"] == "old table"
+    assert pdf_info[0]["para_blocks"][4]["blocks"][0]["lines"][0]["spans"][0]["content"] == ""
+    assert pdf_info[0]["para_blocks"][0]["blocks"][0]["lines"][0]["spans"][0]["details_source"] == "external_vlm"
+    assert pdf_info[0]["para_blocks"][0]["blocks"][0]["lines"][0]["spans"][0]["details_model"] == "qwen"
+
+
+def test_enrichment_collects_same_visual_caption_footnote_and_nearby_context(tmp_path, monkeypatch):
+    (tmp_path / "chart.jpg").write_bytes(b"chart")
+    pdf_info = [
+        {
+            "page_idx": 0,
+            "page_size": [100, 100],
+            "para_blocks": [
+                _text_block(BlockType.TEXT, "The preceding paragraph explains drawdown risk.", index=1),
+                _text_block(BlockType.TABLE, "This table must not be used.", index=2),
+                _visual_para_with_context(
+                    BlockType.CHART,
+                    BlockType.CHART_BODY,
+                    ContentType.CHART,
+                    "chart.jpg",
+                    "old chart",
+                    caption_type=BlockType.CHART_CAPTION,
+                    caption="FIGURE 2.1 Drawdown, maximum drawdown, and duration.",
+                    footnote_type=BlockType.CHART_FOOTNOTE,
+                    footnote="Equity is measured in dollars.",
+                    index=3,
+                ),
+                _text_block(BlockType.CODE, "print('excluded')", index=4),
+                _text_block(BlockType.REF_TEXT, "The following paragraph interprets the figure.", index=5),
+            ],
+            "discarded_blocks": [],
+        },
+        {
+            "page_idx": 1,
+            "page_size": [100, 100],
+            "para_blocks": [
+                _text_block(BlockType.TEXT, "Text from another page must not be used.", index=1),
+            ],
+            "discarded_blocks": [],
+        },
+    ]
+    calls = []
+
+    def fake_request(target, config):
+        calls.append(target)
+        return "enriched chart"
+
+    monkeypatch.setattr(enrichment, "_request_visual_description", fake_request)
+    config = enrichment.build_details_vlm_config(
+        details_image_analysis=True,
+        details_vlm_url="http://localhost:11434/v1",
+        details_vlm_model="qwen",
+    )
+
+    assert enrichment.enrich_visual_details(pdf_info, os.fspath(tmp_path), config) == 1
+
+    target = calls[0]
+    assert target["caption"] == "FIGURE 2.1 Drawdown, maximum drawdown, and duration."
+    assert target["footnote"] == "Equity is measured in dollars."
+    assert target["preceding_context"] == "The preceding paragraph explains drawdown risk."
+    assert target["following_context"] == "The following paragraph interprets the figure."
+    assert "another page" not in target["preceding_context"]
+    assert "another page" not in target["following_context"]
+
+
+def test_nearby_context_uses_short_lists_and_truncates_to_limit(tmp_path):
+    (tmp_path / "image.jpg").write_bytes(b"image")
+    preceding = "prefix " + ("A" * 900)
+    following = ("B" * 900) + " suffix"
+    page = {
+        "page_idx": 0,
+        "page_size": [100, 100],
+        "para_blocks": [
+            _text_block(BlockType.LIST, "x" * 850, index=1),
+            _text_block(BlockType.LIST, "Short list context", index=2),
+            _text_block(BlockType.TEXT, preceding, index=3),
+            _visual_para_with_context(
+                BlockType.IMAGE,
+                BlockType.IMAGE_BODY,
+                ContentType.IMAGE,
+                "image.jpg",
+                "old image",
+                index=4,
+            ),
+            _text_block(BlockType.TEXT, following, index=5),
+            _text_block(BlockType.TEXT, "Later text should not be used.", index=6),
+        ],
+        "discarded_blocks": [],
+    }
+
+    target = next(enrichment._iter_referenced_visual_detail_targets([page], os.fspath(tmp_path)))
+
+    assert len(target["preceding_context"]) == enrichment.NEARBY_CONTEXT_CHAR_LIMIT
+    assert target["preceding_context"] == preceding[-enrichment.NEARBY_CONTEXT_CHAR_LIMIT:]
+    assert len(target["following_context"]) == enrichment.NEARBY_CONTEXT_CHAR_LIMIT
+    assert target["following_context"] == following[:enrichment.NEARBY_CONTEXT_CHAR_LIMIT]
+    assert "Later text" not in target["following_context"]
+
+
+def test_prompt_contains_visual_context_sections():
+    target = {
+        "span_type": ContentType.CHART,
+        "original_content": "Sparse MinerU chart text.",
+        "caption": "FIGURE 2.1 Drawdown and maximum drawdown.",
+        "footnote": "Equity values are illustrative.",
+        "preceding_context": "The text before introduces downside risk.",
+        "following_context": "The text after discusses recovery duration.",
+    }
+
+    prompt = enrichment._build_visual_details_prompt(target, "en")
+
+    assert "referenced chart" in prompt
+    assert "Sparse MinerU chart text." in prompt
+    assert "FIGURE 2.1 Drawdown and maximum drawdown." in prompt
+    assert "Equity values are illustrative." in prompt
+    assert "The text before introduces downside risk." in prompt
+    assert "The text after discusses recovery duration." in prompt
+    assert "Write the answer in this language: en." in prompt
+    assert "Do not include <details>, <summary>" in prompt
+    assert 'Start exactly with a "### Didactic interpretation" heading' in prompt
+    assert 'Do not create a "### Visual data" section' in prompt
+
+
+def test_visual_details_content_normalization_adds_didactic_section_and_strips_visual_data():
+    content = enrichment._normalize_visual_details_content(
+        "### Visual data\n- Axis: price\n\n### Interpretation\nA concise chart explanation."
+    )
+
+    assert content.startswith("### Didactic interpretation")
+    assert "### Visual data" not in content
+    assert "A concise chart explanation." in content
+
+
+def test_response_wrapper_stripping_preserves_unicode_text():
+    data = {
+        "choices": [
+            {
+                "message": {
+                    "content": "```markdown\n<details>\n<summary>line</summary>\n\nEquity ranges from 1×10⁴ to 3×10⁴ — useful for risk analysis.\n</details>\n```"
+                }
+            }
+        ]
+    }
+
+    content = enrichment._extract_chat_completion_content(data)
+
+    assert content == "Equity ranges from 1×10⁴ to 3×10⁴ — useful for risk analysis."
+    assert "⁴" in content
+    assert "<summary>" not in content
+
+
+def test_enrichment_preserves_content_on_failure(tmp_path, monkeypatch):
+    (tmp_path / "image.jpg").write_bytes(b"image")
+    pdf_info = [
+        {
+            "page_idx": 0,
+            "page_size": [100, 100],
+            "para_blocks": [
+                _visual_para(BlockType.IMAGE, BlockType.IMAGE_BODY, ContentType.IMAGE, "image.jpg", "old image")
+            ],
+            "discarded_blocks": [],
+        }
+    ]
+
+    def fake_request(target, config):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(enrichment, "_request_visual_description", fake_request)
+    config = enrichment.build_details_vlm_config(
+        details_image_analysis=True,
+        details_vlm_url="http://localhost:11434/v1",
+        details_vlm_model="qwen",
+    )
+
+    assert enrichment.enrich_visual_details(pdf_info, os.fspath(tmp_path), config) == 0
+    assert pdf_info[0]["para_blocks"][0]["blocks"][0]["lines"][0]["spans"][0]["content"] == "old image"
+
+
+def test_parse_request_form_data_includes_details_parameters():
+    data = build_parse_request_form_data(
+        lang_list=["en"],
+        backend="vlm-http-client",
+        parse_method="auto",
+        formula_enable=True,
+        table_enable=True,
+        image_analysis=True,
+        details_image_analysis=True,
+        details_vlm_url="http://localhost:11434/v1",
+        details_vlm_model="qwen",
+        details_vlm_api_key="",
+        details_vlm_timeout=180,
+        details_vlm_max_concurrency=1,
+        details_vlm_language="en",
+        server_url="http://localhost:30000",
+        start_page_id=0,
+        end_page_id=None,
+        return_md=True,
+        return_middle_json=True,
+        return_model_output=True,
+        return_content_list=True,
+        return_images=True,
+        response_format_zip=True,
+        return_original_file=True,
+    )
+
+    assert data["details_image_analysis"] == "true"
+    assert data["details_vlm_url"] == "http://localhost:11434/v1"
+    assert data["details_vlm_model"] == "qwen"
+    assert data["details_vlm_api_key"] == ""
+    assert data["details_vlm_timeout"] == "180"
+    assert data["details_vlm_max_concurrency"] == "1"
+    assert data["details_vlm_language"] == "en"
+
+
+def test_details_enrichment_preserves_mineru_image_chart_analysis(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_vlm_doc_analyze(*args, **kwargs):
+        captured.update(kwargs)
+        return {"pdf_info": []}, []
+
+    monkeypatch.setattr(common, "vlm_doc_analyze", fake_vlm_doc_analyze)
+    monkeypatch.setattr(common, "_process_output", lambda *args, **kwargs: None)
+
+    config = enrichment.build_details_vlm_config(
+        details_image_analysis=True,
+        details_vlm_url="http://localhost:11434/v1",
+        details_vlm_model="qwen",
+    )
+
+    common._process_vlm(
+        tmp_path,
+        ["doc"],
+        [b"%PDF"],
+        "vllm-engine",
+        False,
+        False,
+        True,
+        True,
+        True,
+        True,
+        True,
+        MakeMode.MM_MD,
+        details_vlm_config=config,
+        image_analysis=True,
+    )
+
+    assert captured["image_analysis"] is True


### PR DESCRIPTION
## Motivation

This PR adds an optional post-processing step for RAG-oriented workflows where `image` and `chart` blocks benefit from additional semantic explanation.

MinerU already extracts layout, crops, visual block types, tables, and base visual content. This feature keeps MinerU as the primary document parser and optionally calls an external OpenAI-compatible VLM endpoint to append a didactic interpretation to existing visual details.

The goal is to make generated Markdown/JSON more useful for retrieval-augmented generation without changing the default behavior.

## Modification

- Added optional external VLM enrichment for referenced `image` / `chart` details.
- Added CLI/API parameters:
  - `--details-image-analysis`
  - `--details-vlm-url`
  - `--details-vlm-model`
  - `--details-vlm-api-key`
  - `--details-vlm-timeout`
  - `--details-vlm-max-concurrency`
  - `--details-vlm-language`
- The external VLM is called only when:
  - the feature is explicitly enabled;
  - the block is `image` or `chart`;
  - the image file exists;
  - MinerU already generated non-empty visual `content`.
- Tables are not sent to the external VLM.
- The generated Markdown keeps MinerU's existing wrapper and summary:

  ```md
  ![](images/xxx.jpg)
  <details>
  <summary>candlestick</summary>

  <MinerU visual content>

  ### Didactic interpretation
  <external VLM enrichment>
  </details>
  ```

- Added async output offloading for async VLM/hybrid paths, so blocking output post-processing does not block the event loop.
- Added EN/ZH documentation and unit tests.

## BC-breaking (Optional)

No breaking changes.

The feature is disabled by default. Existing CLI/API behavior and output remain unchanged unless `details_image_analysis` is explicitly enabled.

## Use cases (Optional)

- RAG / knowledge-base pipelines that index MinerU Markdown.
- Technical, financial, scientific, or educational documents containing charts and figures.
- Workflows where users want to keep MinerU's structured visual extraction while appending a semantic explanation generated by a stronger external VLM.
- OpenAI-compatible endpoints, including local or remote VLM deployments. For example, users can connect to a local Ollama-compatible `/v1` endpoint or another OpenAI-compatible service running a strong VLM.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. Not applicable: this PR adds an optional feature.
- [x] The modification is covered by complete unit tests.
- [x] The documentation has been modified accordingly.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. Not expected: the feature is disabled by default.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
