### PR TITLE
feat: add CPU-only Docker deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ MinerU provides a convenient Docker deployment method, which helps quickly set u
 > - Docker deployment is only supported on Linux and Windows environments with WSL2 support;
 > - macOS users should refer to the two installation methods above for installation instead of using Docker deployment.
 
-You can get the [Docker Deployment Instructions](https://opendatalab.github.io/MinerU/quick_start/docker_deployment/) in the documentation.
+You can get the [Docker Deployment Instructions](https://opendatalab.github.io/MinerU/quick_start/docker_deployment/) in the documentation, including a [CPU-only deployment](https://opendatalab.github.io/MinerU/quick_start/docker_deployment/#cpu-only-deployment-no-gpu-required) option for environments without GPU.
 
 ---
 

--- a/docker/cpu-compose.yaml
+++ b/docker/cpu-compose.yaml
@@ -1,0 +1,30 @@
+services:
+  mineru-api:
+    build:
+      context: .
+      dockerfile: cpu/Dockerfile
+    image: mineru:cpu
+    container_name: mineru-api-cpu
+    ports:
+      - "8888:8888"
+    environment:
+      - MINERU_MODEL_SOURCE=local
+    volumes:
+      - mineru-models:/root/.cache
+      - mineru-output:/output
+      - ./mineru.json:/root/mineru.json:ro
+    command: mineru-api --host 0.0.0.0 --port 8888
+    deploy:
+      resources:
+        limits:
+          memory: 12G
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8888/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  mineru-models:
+  mineru-output:

--- a/docker/cpu/Dockerfile
+++ b/docker/cpu/Dockerfile
@@ -1,0 +1,14 @@
+# MinerU API Server - CPU-only deployment
+# For environments without GPU (cloud VMs, ARM servers, etc.)
+# Uses the pipeline backend instead of vllm-engine
+#
+# Build:   docker compose -f cpu-compose.yaml build
+# Run:     docker compose -f cpu-compose.yaml up -d
+
+FROM python:3.12-slim
+
+RUN pip install --no-cache-dir uv && \
+    uv pip install --system -U "mineru[all]"
+
+EXPOSE 8888
+CMD ["mineru-api", "--host", "0.0.0.0", "--port", "8888"]

--- a/docs/en/quick_start/docker_deployment.md
+++ b/docs/en/quick_start/docker_deployment.md
@@ -95,3 +95,47 @@ connect to `openai-server` via `vlm-http-client` backend
   >[!TIP]
   >
   >- Access `http://<server_ip>:7860` in your browser to use the Gradio WebUI.
+
+---
+
+## CPU-Only Deployment (No GPU Required)
+
+For environments without GPU (cloud VMs, ARM servers, etc.), use the lightweight `docker/cpu/` deployment with the `pipeline` backend.
+
+### Build and Start
+
+```bash
+cd docker/
+docker compose -f cpu-compose.yaml build
+docker compose -f cpu-compose.yaml run --rm mineru-api mineru-models-download -s huggingface -m pipeline
+docker compose -f cpu-compose.yaml up -d
+curl http://localhost:8888/health
+```
+
+### Submit Documents
+
+```bash
+# Submit task
+TASK_ID=$(curl -s -X POST http://localhost:8888/tasks \
+  -F "files=@document.pdf" \
+  -F "backend=pipeline" | python3 -c "import sys,json; print(json.load(sys.stdin)['task_id'])")
+
+# Poll status
+while true; do
+  STATUS=$(curl -s http://localhost:8888/tasks/$TASK_ID | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])")
+  [[ "$STATUS" == "completed" || "$STATUS" == "failed" ]] && break
+  sleep 10
+done
+
+# Get result
+python3 -c "
+import urllib.request, json
+data = json.loads(urllib.request.urlopen('http://localhost:8888/tasks/$TASK_ID/result', timeout=120).read())
+for fname, content in data['results'].items():
+    print(content['md_content'])
+"
+```
+
+> [!NOTE]
+> - Always pass `backend=pipeline` in POST requests. The default backend requires GPU.
+> - Pipeline models (~2.4GB) are downloaded to the `mineru-models` Docker volume.

--- a/docs/zh/quick_start/docker_deployment.md
+++ b/docs/zh/quick_start/docker_deployment.md
@@ -92,5 +92,49 @@ wget https://gcore.jsdelivr.net/gh/opendatalab/MinerU@master/docker/compose.yaml
   docker compose -f compose.yaml --profile gradio up -d
   ```
   >[!TIP]
-  > 
+  >
   >- 在浏览器中访问 `http://<server_ip>:7860` 使用 Gradio WebUI。
+
+---
+
+## 纯 CPU 部署（无需 GPU）
+
+适用于没有 GPU 的环境（云服务器、ARM 服务器等），使用 `pipeline` 后端的轻量级 `docker/cpu/` 部署方案。
+
+### 构建并启动
+
+```bash
+cd docker/
+docker compose -f cpu-compose.yaml build
+docker compose -f cpu-compose.yaml run --rm mineru-api mineru-models-download -s modelscope -m pipeline
+docker compose -f cpu-compose.yaml up -d
+curl http://localhost:8888/health
+```
+
+### 提交文档解析
+
+```bash
+# 提交任务
+TASK_ID=$(curl -s -X POST http://localhost:8888/tasks \
+  -F "files=@document.pdf" \
+  -F "backend=pipeline" | python3 -c "import sys,json; print(json.load(sys.stdin)['task_id'])")
+
+# 轮询状态
+while true; do
+  STATUS=$(curl -s http://localhost:8888/tasks/$TASK_ID | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])")
+  [[ "$STATUS" == "completed" || "$STATUS" == "failed" ]] && break
+  sleep 10
+done
+
+# 获取结果
+python3 -c "
+import urllib.request, json
+data = json.loads(urllib.request.urlopen('http://localhost:8888/tasks/$TASK_ID/result', timeout=120).read())
+for fname, content in data['results'].items():
+    print(content['md_content'])
+"
+```
+
+> [!NOTE]
+> - POST 请求中必须传 `backend=pipeline`，默认后端需要 GPU。
+> - Pipeline 模型（约 2.4GB）下载到 `mineru-models` Docker 卷中。


### PR DESCRIPTION
## What

Add CPU-only Docker deployment option for environments without GPU.

## Why

MinerU's official Docker deployment (`docker/global/`, `docker/china/`) is based on `vllm/vllm-openai`, which requires GPU. This PR provides a lightweight CPU-only alternative using the
`pipeline` backend.

## Changes

- `docker/cpu/Dockerfile` — Lightweight `python:3.12-slim` image, no GPU required
- `docker/cpu-compose.yaml` — Docker Compose config for CPU-only deployment
- `docs/en/quick_start/docker_deployment.md` — Add CPU deployment section
- `docs/zh/quick_start/docker_deployment.md` — 添加纯 CPU 部署章节
- `README.md` — Reference CPU deployment docs

## Usage

```bash
cd docker/
docker compose -f cpu-compose.yaml build
docker compose -f cpu-compose.yaml run --rm mineru-api mineru-models-download -s huggingface -m pipeline
docker compose -f cpu-compose.yaml up -d
curl http://localhost:8888/health

## Tested

- Verified on 16-core CPU VM (Ubuntu 22.04)
- 22-page PDF parsed in ~30 seconds
- Health check returns {"status":"healthy","version":"3.2.3"}
