### PR TITLE
[Bug fix] common: fail loudly when md extraction produces empty content (no more silent 0-byte .md writes)

### DIFF
--- a/mineru/cli/common.py
+++ b/mineru/cli/common.py
@@ -313,6 +313,27 @@ def _process_output(
 
     if f_dump_md:
         md_content_str = make_func(pdf_info, f_make_md_mode, image_dir)
+        # Guard against silent data loss: if the input had pages but extraction
+        # produced no markdown (e.g. upstream model output didn't match the
+        # expected MinerU format markers), fail loudly instead of writing a
+        # 0-byte .md file that downstream consumers will mistake for success.
+        # Set MINERU_ALLOW_EMPTY_MD=true to opt out (e.g. for legitimately
+        # empty / image-only documents).
+        if (
+            pdf_info
+            and (md_content_str is None or not str(md_content_str).strip())
+            and os.getenv("MINERU_ALLOW_EMPTY_MD", "").lower() != "true"
+        ):
+            from mineru.data.utils.exceptions import EmptyData
+            msg = (
+                f"No markdown content was extracted for '{pdf_file_name}' "
+                f"(input had {len(pdf_info)} page(s), produced {process_mode} "
+                f"mode={f_make_md_mode}). The upstream model output may not "
+                f"match MinerU's expected format. Refusing to write 0-byte "
+                f".md file. Set MINERU_ALLOW_EMPTY_MD=true to override."
+            )
+            logger.error(msg)
+            raise EmptyData(msg)
         md_writer.write_string(
             f"{pdf_file_name}.md",
             md_content_str,

--- a/tests/unittest/test_empty_md_guard.py
+++ b/tests/unittest/test_empty_md_guard.py
@@ -1,0 +1,190 @@
+# Copyright (c) Opendatalab. All rights reserved.
+"""Regression tests for the silent 0-byte .md write bug.
+
+Repro for opendatalab/MinerU#5113-style failure mode: when the upstream
+model output cannot be assembled into markdown (e.g. format markers absent,
+parser bug, edge case), `_process_output` previously wrote a 0-byte .md file
+silently. /file_parse then returned HTTP 200 + md_content="" — indistinguishable
+from success. These tests pin the new "fail loudly" contract.
+"""
+import os
+import tempfile
+from unittest import mock
+
+import pytest
+
+from mineru.cli.common import _process_output
+from mineru.data.data_reader_writer import FileBasedDataWriter
+from mineru.data.utils.exceptions import EmptyData
+
+
+def _fake_pdf_info_with_pages():
+    """Minimal pdf_info shape: list of page dicts. Non-empty so the guard
+    triggers — represents a PDF that DID get pages, but extraction produced
+    nothing useful from them."""
+    return [
+        {
+            "para_blocks": [],
+            "discarded_blocks": [],
+            "page_idx": 0,
+            "page_size": [612, 792],
+        }
+    ]
+
+
+def test_process_output_raises_on_empty_md_with_pages(tmp_path):
+    """When pdf_info has pages but the extractor produced no markdown, refuse
+    to write a 0-byte .md file. Raise EmptyData instead."""
+    image_dir = tmp_path / "images"
+    md_dir = tmp_path / "md"
+    image_dir.mkdir()
+    md_dir.mkdir()
+    md_writer = FileBasedDataWriter(str(md_dir))
+
+    # Patch vlm_union_make to simulate "model output didn't match MinerU
+    # format markers" — returns empty string. This is the exact failure
+    # observed in #5113 with vlm-http-client + a non-MinerU upstream model.
+    with mock.patch(
+        "mineru.cli.common.vlm_union_make", return_value=""
+    ):
+        # Make sure the opt-out env var is NOT set
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MINERU_ALLOW_EMPTY_MD", None)
+            with pytest.raises(EmptyData) as excinfo:
+                _process_output(
+                    pdf_info=_fake_pdf_info_with_pages(),
+                    pdf_bytes=b"",
+                    pdf_file_name="dummy",
+                    local_md_dir=str(md_dir),
+                    local_image_dir=str(image_dir),
+                    md_writer=md_writer,
+                    f_draw_layout_bbox=False,
+                    f_draw_span_bbox=False,
+                    f_dump_orig_pdf=False,
+                    f_dump_md=True,
+                    f_dump_content_list=False,
+                    f_dump_middle_json=False,
+                    f_dump_model_output=False,
+                    f_make_md_mode="mm_md",
+                    middle_json={"pdf_info": _fake_pdf_info_with_pages()},
+                    model_output=None,
+                    process_mode="vlm",
+                )
+    assert "0-byte" in str(excinfo.value) or "No markdown" in str(excinfo.value)
+    # And critically: NO .md file should have been written.
+    assert not (md_dir / "dummy.md").exists(), (
+        "guard must refuse to write — caller should not see a 0-byte .md"
+    )
+
+
+def test_process_output_writes_when_md_nonempty(tmp_path):
+    """Sanity: real extraction output still writes normally."""
+    image_dir = tmp_path / "images"
+    md_dir = tmp_path / "md"
+    image_dir.mkdir()
+    md_dir.mkdir()
+    md_writer = FileBasedDataWriter(str(md_dir))
+
+    with mock.patch(
+        "mineru.cli.common.vlm_union_make",
+        return_value="# Real heading\n\nSome real content.",
+    ):
+        _process_output(
+            pdf_info=_fake_pdf_info_with_pages(),
+            pdf_bytes=b"",
+            pdf_file_name="dummy",
+            local_md_dir=str(md_dir),
+            local_image_dir=str(image_dir),
+            md_writer=md_writer,
+            f_draw_layout_bbox=False,
+            f_draw_span_bbox=False,
+            f_dump_orig_pdf=False,
+            f_dump_md=True,
+            f_dump_content_list=False,
+            f_dump_middle_json=False,
+            f_dump_model_output=False,
+            f_make_md_mode="mm_md",
+            middle_json={"pdf_info": _fake_pdf_info_with_pages()},
+            model_output=None,
+            process_mode="vlm",
+        )
+    md_path = md_dir / "dummy.md"
+    assert md_path.exists()
+    assert md_path.read_text(encoding="utf-8").strip() != ""
+
+
+def test_process_output_opt_out_via_env(tmp_path):
+    """MINERU_ALLOW_EMPTY_MD=true preserves legacy behavior for callers who
+    legitimately expect empty markdown (e.g. zero-content / image-only docs
+    in pipelines that handle this downstream)."""
+    image_dir = tmp_path / "images"
+    md_dir = tmp_path / "md"
+    image_dir.mkdir()
+    md_dir.mkdir()
+    md_writer = FileBasedDataWriter(str(md_dir))
+
+    with mock.patch(
+        "mineru.cli.common.vlm_union_make", return_value=""
+    ):
+        with mock.patch.dict(os.environ, {"MINERU_ALLOW_EMPTY_MD": "true"}):
+            # Should NOT raise — env opt-out honored.
+            _process_output(
+                pdf_info=_fake_pdf_info_with_pages(),
+                pdf_bytes=b"",
+                pdf_file_name="dummy",
+                local_md_dir=str(md_dir),
+                local_image_dir=str(image_dir),
+                md_writer=md_writer,
+                f_draw_layout_bbox=False,
+                f_draw_span_bbox=False,
+                f_dump_orig_pdf=False,
+                f_dump_md=True,
+                f_dump_content_list=False,
+                f_dump_middle_json=False,
+                f_dump_model_output=False,
+                f_make_md_mode="mm_md",
+                middle_json={"pdf_info": _fake_pdf_info_with_pages()},
+                model_output=None,
+                process_mode="vlm",
+            )
+    md_path = md_dir / "dummy.md"
+    assert md_path.exists()
+    # Legacy behavior preserved: 0-byte file IS allowed when opted in.
+    assert md_path.read_text(encoding="utf-8") == ""
+
+
+def test_process_output_allows_empty_pdf_info(tmp_path):
+    """Edge case: pdf_info itself is empty (zero pages). Guard should NOT
+    fire — there's nothing to extract from, so empty markdown is correct."""
+    image_dir = tmp_path / "images"
+    md_dir = tmp_path / "md"
+    image_dir.mkdir()
+    md_dir.mkdir()
+    md_writer = FileBasedDataWriter(str(md_dir))
+
+    with mock.patch(
+        "mineru.cli.common.vlm_union_make", return_value=""
+    ):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MINERU_ALLOW_EMPTY_MD", None)
+            # Empty pdf_info — empty md is a legitimate outcome, no raise.
+            _process_output(
+                pdf_info=[],
+                pdf_bytes=b"",
+                pdf_file_name="dummy",
+                local_md_dir=str(md_dir),
+                local_image_dir=str(image_dir),
+                md_writer=md_writer,
+                f_draw_layout_bbox=False,
+                f_draw_span_bbox=False,
+                f_dump_orig_pdf=False,
+                f_dump_md=True,
+                f_dump_content_list=False,
+                f_dump_middle_json=False,
+                f_dump_model_output=False,
+                f_make_md_mode="mm_md",
+                middle_json={"pdf_info": []},
+                model_output=None,
+                process_mode="vlm",
+            )
+    assert (md_dir / "dummy.md").exists()


### PR DESCRIPTION
## Summary

`_process_output` in `mineru/cli/common.py` currently writes whatever string `union_make()` returns to `<pdf_name>.md` — **including empty strings**. When extraction silently produces no content for any reason, the user gets:

- `/file_parse` returns HTTP 200 + `md_content: ""`
- A 0-byte `<pdf_name>.md` is written to disk
- No exception, no error field, no warning
- The raw model output IS visible in stdout, so it's clear extraction *did* happen — but downstream consumers see clean "success" with zero content

This is the worst possible failure mode: silent success-shape with empty data. Any pipeline that trusts the JSON response or the `.md` file propagates the empty content forward.

This PR makes `_process_output` **fail loudly** when extraction produces no markdown for an input that did have pages. It does NOT change behavior for legitimately empty inputs (zero pages reached the writer), and an opt-out env var preserves the old behavior for callers who deliberately want it.

## Motivation (and the wontfix this is NOT trying to reverse)

This was surfaced via #5113 — a user running `vlm-http-client` against `vllm/GLM-OCR` got 0-byte `.md` files. That issue was correctly closed: GLM-OCR is not a supported upstream model for `vlm-http-client`, and this PR does **not** ask for that to change.

**What this PR does fix is the failure-MODE, regardless of which upstream model is configured.** Even with a properly trained MinerU model, if the assembly step ever produces no content (corrupted PDF, parser edge case, downstream regression, a future backend change), users today get the same silent 0-byte file with no signal that anything went wrong. That's the defect being addressed here.

The "fail loudly" contract makes the existing failure visible to operators instead of letting it propagate as fake success.

## The change

In `_process_output`, after `make_func(pdf_info, ...)` returns the markdown string, before writing:

```python
if (
    pdf_info
    and (md_content_str is None or not str(md_content_str).strip())
    and os.getenv("MINERU_ALLOW_EMPTY_MD", "").lower() != "true"
):
    msg = (f"No markdown content was extracted for '{pdf_file_name}' "
           f"(input had {len(pdf_info)} page(s), produced {process_mode} "
           f"mode={f_make_md_mode}). ...")
    logger.error(msg)
    raise EmptyData(msg)
```

- **Reuses the existing `EmptyData` exception** in `mineru/data/utils/exceptions.py` — no new exception class.
- **Only triggers when `pdf_info` had pages** — zero-page inputs (where empty markdown is the correct result) pass through unchanged.
- **Env opt-out**: `MINERU_ALLOW_EMPTY_MD=true` preserves the legacy behavior for pipelines that legitimately expect empty markdown (e.g. image-only docs handled downstream).
- **Bubbles up cleanly**: `_process_vlm` / `_async_process_vlm` / `_process_pipeline` / `_process_hybrid` already propagate exceptions; `fast_api.py`'s existing `except Exception:` handlers turn this into a 5xx with the diagnostic message, so HTTP callers see a real error.

## Tests

Four tests in `tests/unittest/test_empty_md_guard.py`, all passing locally:

| Test | Asserts |
|---|---|
| `test_process_output_raises_on_empty_md_with_pages` | Empty markdown + non-empty pdf_info → `EmptyData` raised, **no 0-byte file written** |
| `test_process_output_writes_when_md_nonempty` | Normal content → file written as before (no regression) |
| `test_process_output_opt_out_via_env` | `MINERU_ALLOW_EMPTY_MD=true` → legacy behavior preserved |
| `test_process_output_allows_empty_pdf_info` | Zero pages → no raise (legitimate empty case) |

```
============================== 4 passed in 2.26s ===============================
```

## Test plan for reviewers

- [ ] Run `pytest tests/unittest/test_empty_md_guard.py -v` — should be 4 passed.
- [ ] Existing `test_e2e.py` is not exercised by this change (different code path; smoke-tested that imports still work).
- [ ] Hit `/file_parse` with a malformed input or an unsupported upstream → should now get a 5xx with the diagnostic message instead of `200 + md_content=""`.

## Scope

~25 LOC of production code (single guard at one writer site) + ~180 LOC of pure-unit tests. No new dependencies, no behavior change for the happy path, no new public API.

## Notes on signing / CLA

- Commit signed with my SSH key (`SHA256:FRX2BNfzwTboAecBb0tstGV/lZ/1ZlUwS2x4CBZetII`).
- Happy to sign the MinerU CLA if the bot prompts.