### PR TITLE
chore: add dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ dependencies = [
     "fastapi",
     "python-multipart",
     "uvicorn",
+    "albumentations",
+    "hf_xet",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Hi thanks for the great library. 
## Motivation
I noticed while reinstalling mineru on windows using python 3.13, that it asks for albumentations to be installed but currently it is not in the pyproject.toml explicitly. Moreover, I added hf_xet into the pyproject.toml as well to allow for better performance

please see the screenshot below 

<img width="1090" height="468" alt="image" src="https://github.com/user-attachments/assets/84a6f1f2-95c3-4a0d-8bbc-69da43521e46" />


I have just added both these libraries as is to the pyproject.toml
