### PR TITLE
feat(api): expose async task page progress

### DIFF
--- a/mineru/backend/hybrid/hybrid_analyze.py
+++ b/mineru/backend/hybrid/hybrid_analyze.py
@@ -886,6 +886,15 @@ def _close_images(images_list):
                 pass
 
 
+def _emit_progress(progress_callback, **payload):
+    if progress_callback is None:
+        return
+    try:
+        progress_callback(**payload)
+    except Exception:
+        logger.exception("Progress callback failed")
+
+
 def doc_analyze(
         pdf_bytes,
         image_writer: DataWriter | None,
@@ -901,6 +910,7 @@ def doc_analyze(
 ):
     effort = _validate_parse_effort(effort)
     effective_image_analysis = _resolve_effective_image_analysis(effort, image_analysis)
+    progress_callback = kwargs.pop("progress_callback", None)
     client_side_output_generation = bool(
         kwargs.pop("client_side_output_generation", False)
     )
@@ -932,6 +942,14 @@ def doc_analyze(
             f'Hybrid processing-window run. page_count={page_count}, '
             f'window_size={configured_window_size}, total_windows={total_windows}'
         )
+        _emit_progress(
+            progress_callback,
+            page_total=page_count,
+            page_current=0,
+            window_index=0,
+            window_total=total_windows,
+            text=f"0/{page_count} pages",
+        )
 
         batch_ratio = get_batch_ratio(device) if not _ocr_enable else 1
 
@@ -955,6 +973,16 @@ def doc_analyze(
                         f'Hybrid processing window {window_index + 1}/{total_windows}: '
                         f'pages {window_start + 1}-{window_end + 1}/{page_count} '
                         f'({len(images_pil_list)} pages)'
+                    )
+                    _emit_progress(
+                        progress_callback,
+                        page_total=page_count,
+                        page_current=window_start,
+                        window_index=window_index + 1,
+                        window_total=total_windows,
+                        window_start=window_start + 1,
+                        window_end=window_end + 1,
+                        text=f"pages {window_start + 1}-{window_end + 1}/{page_count}",
                     )
                     images_layout_res, hybrid_pipeline_model = _predict_layout_for_window(
                         images_pil_list,
@@ -1058,6 +1086,16 @@ def doc_analyze(
                         _ocr_enable=_ocr_enable,
                         progress_bar=progress_bar,
                     )
+                    _emit_progress(
+                        progress_callback,
+                        page_total=page_count,
+                        page_current=window_end + 1,
+                        window_index=window_index + 1,
+                        window_total=total_windows,
+                        window_start=window_start + 1,
+                        window_end=window_end + 1,
+                        text=f"pages {window_start + 1}-{window_end + 1}/{page_count}",
+                    )
                     last_append_end_time = time.time()
                 finally:
                     _close_images(images_list)
@@ -1109,6 +1147,7 @@ async def aio_doc_analyze(
 ):
     effort = _validate_parse_effort(effort)
     effective_image_analysis = _resolve_effective_image_analysis(effort, image_analysis)
+    progress_callback = kwargs.pop("progress_callback", None)
     client_side_output_generation = bool(
         kwargs.pop("client_side_output_generation", False)
     )
@@ -1140,6 +1179,14 @@ async def aio_doc_analyze(
             f'Hybrid processing-window run. page_count={page_count}, '
             f'window_size={configured_window_size}, total_windows={total_windows}'
         )
+        _emit_progress(
+            progress_callback,
+            page_total=page_count,
+            page_current=0,
+            window_index=0,
+            window_total=total_windows,
+            text=f"0/{page_count} pages",
+        )
 
         batch_ratio = get_batch_ratio(device) if not _ocr_enable else 1
 
@@ -1162,6 +1209,16 @@ async def aio_doc_analyze(
                         f'Hybrid processing window {window_index + 1}/{total_windows}: '
                         f'pages {window_start + 1}-{window_end + 1}/{page_count} '
                         f'({len(images_pil_list)} pages)'
+                    )
+                    _emit_progress(
+                        progress_callback,
+                        page_total=page_count,
+                        page_current=window_start,
+                        window_index=window_index + 1,
+                        window_total=total_windows,
+                        window_start=window_start + 1,
+                        window_end=window_end + 1,
+                        text=f"pages {window_start + 1}-{window_end + 1}/{page_count}",
                     )
                     images_layout_res, hybrid_pipeline_model = await asyncio.to_thread(
                         _predict_layout_for_window,
@@ -1271,6 +1328,16 @@ async def aio_doc_analyze(
                         page_start_index=window_start,
                         _ocr_enable=_ocr_enable,
                         progress_bar=progress_bar,
+                    )
+                    _emit_progress(
+                        progress_callback,
+                        page_total=page_count,
+                        page_current=window_end + 1,
+                        window_index=window_index + 1,
+                        window_total=total_windows,
+                        window_start=window_start + 1,
+                        window_end=window_end + 1,
+                        text=f"pages {window_start + 1}-{window_end + 1}/{page_count}",
                     )
                     last_append_end_time = time.time()
                 finally:

--- a/mineru/backend/pipeline/pipeline_analyze.py
+++ b/mineru/backend/pipeline/pipeline_analyze.py
@@ -30,6 +30,16 @@ from ...utils.pdfium_guard import (
 
 os.environ['PYTORCH_ENABLE_MPS_FALLBACK'] = '1'  # 让mps可以fallback
 
+
+def _emit_progress(progress_callback, **payload):
+    if progress_callback is None:
+        return
+    try:
+        progress_callback(**payload)
+    except Exception:
+        logger.exception("Progress callback failed")
+
+
 class ModelSingleton:
     _instance = None
     _models = {}
@@ -163,6 +173,7 @@ def doc_analyze_streaming(
         formula_enable=True,
         table_enable=True,
         client_side_output_generation=False,
+        progress_callback=None,
 ):
     if not (len(pdf_bytes_list) == len(image_writer_list) == len(lang_list)):
         raise ValueError("pdf_bytes_list, image_writer_list, and lang_list must have the same length")
@@ -209,6 +220,15 @@ def doc_analyze_streaming(
         logger.info(
             f'Pipeline processing-window multi-file run. doc_count={len(doc_contexts)}, '
             f'total_pages={total_pages}, window_size={window_size}, total_batches={total_batches}'
+        )
+        _emit_progress(
+            progress_callback,
+            file_index=0,
+            page_total=total_pages,
+            page_current=0,
+            window_index=0,
+            window_total=total_batches,
+            text=f"0/{total_pages} pages",
         )
 
         _emit_zero_page_contexts(
@@ -266,6 +286,15 @@ def doc_analyze_streaming(
                     f'{processed_pages + len(batch_images)}/{total_pages} pages, '
                     f'batch_pages={len(batch_images)}, doc_slices={_format_doc_slices(batch_slices)}'
                 )
+                _emit_progress(
+                    progress_callback,
+                    file_index=0,
+                    page_total=total_pages,
+                    page_current=processed_pages,
+                    window_index=batch_index,
+                    window_total=total_batches,
+                    text=f"{processed_pages}/{total_pages} pages",
+                )
 
                 try:
                     batch_results = batch_image_analyze(
@@ -311,6 +340,15 @@ def doc_analyze_streaming(
 
                 last_append_end_time = time.time()
                 processed_pages += len(batch_images)
+                _emit_progress(
+                    progress_callback,
+                    file_index=0,
+                    page_total=total_pages,
+                    page_current=processed_pages,
+                    window_index=batch_index,
+                    window_total=total_batches,
+                    text=f"{processed_pages}/{total_pages} pages",
+                )
         finally:
             if progress_bar is not None:
                 progress_bar.close()

--- a/mineru/backend/vlm/vlm_analyze.py
+++ b/mineru/backend/vlm/vlm_analyze.py
@@ -420,6 +420,15 @@ def _close_images(images_list):
                 pass
 
 
+def _emit_progress(progress_callback, **payload):
+    if progress_callback is None:
+        return
+    try:
+        progress_callback(**payload)
+    except Exception:
+        logger.exception("Progress callback failed")
+
+
 def doc_analyze(
     pdf_bytes,
     image_writer: DataWriter | None,
@@ -430,6 +439,7 @@ def doc_analyze(
     image_analysis: bool = True,
     **kwargs,
 ):
+    progress_callback = kwargs.pop("progress_callback", None)
     client_side_output_generation = bool(
         kwargs.pop("client_side_output_generation", False)
     )
@@ -454,6 +464,14 @@ def doc_analyze(
             f'VLM processing-window run. page_count={page_count}, '
             f'window_size={configured_window_size}, total_windows={total_windows}'
         )
+        _emit_progress(
+            progress_callback,
+            page_total=page_count,
+            page_current=0,
+            window_index=0,
+            window_total=total_windows,
+            text=f"0/{page_count} pages",
+        )
 
         infer_start = time.time()
         progress_bar = None
@@ -474,6 +492,16 @@ def doc_analyze(
                         f'VLM processing window {window_index + 1}/{total_windows}: '
                         f'pages {window_start + 1}-{window_end + 1}/{page_count} '
                         f'({len(images_pil_list)} pages)'
+                    )
+                    _emit_progress(
+                        progress_callback,
+                        page_total=page_count,
+                        page_current=window_start,
+                        window_index=window_index + 1,
+                        window_total=total_windows,
+                        window_start=window_start + 1,
+                        window_end=window_end + 1,
+                        text=f"pages {window_start + 1}-{window_end + 1}/{page_count}",
                     )
                     with predictor_execution_guard(predictor):
                         window_results = predictor.batch_two_step_extract(
@@ -497,6 +525,16 @@ def doc_analyze(
                         image_writer,
                         page_start_index=window_start,
                         progress_bar=progress_bar,
+                    )
+                    _emit_progress(
+                        progress_callback,
+                        page_total=page_count,
+                        page_current=window_end + 1,
+                        window_index=window_index + 1,
+                        window_total=total_windows,
+                        window_start=window_start + 1,
+                        window_end=window_end + 1,
+                        text=f"pages {window_start + 1}-{window_end + 1}/{page_count}",
                     )
                     last_append_end_time = time.time()
                 finally:
@@ -530,6 +568,7 @@ async def aio_doc_analyze(
     image_analysis: bool = True,
     **kwargs,
 ):
+    progress_callback = kwargs.pop("progress_callback", None)
     client_side_output_generation = bool(
         kwargs.pop("client_side_output_generation", False)
     )
@@ -554,6 +593,14 @@ async def aio_doc_analyze(
             f'VLM processing-window run. page_count={page_count}, '
             f'window_size={configured_window_size}, total_windows={total_windows}'
         )
+        _emit_progress(
+            progress_callback,
+            page_total=page_count,
+            page_current=0,
+            window_index=0,
+            window_total=total_windows,
+            text=f"0/{page_count} pages",
+        )
 
         infer_start = time.time()
         progress_bar = None
@@ -573,6 +620,16 @@ async def aio_doc_analyze(
                         f'VLM processing window {window_index + 1}/{total_windows}: '
                         f'pages {window_start + 1}-{window_end + 1}/{page_count} '
                         f'({len(images_pil_list)} pages)'
+                    )
+                    _emit_progress(
+                        progress_callback,
+                        page_total=page_count,
+                        page_current=window_start,
+                        window_index=window_index + 1,
+                        window_total=total_windows,
+                        window_start=window_start + 1,
+                        window_end=window_end + 1,
+                        text=f"pages {window_start + 1}-{window_end + 1}/{page_count}",
                     )
                     async with aio_predictor_execution_guard(predictor):
                         window_results = await predictor.aio_batch_two_step_extract(
@@ -596,6 +653,16 @@ async def aio_doc_analyze(
                         image_writer,
                         page_start_index=window_start,
                         progress_bar=progress_bar,
+                    )
+                    _emit_progress(
+                        progress_callback,
+                        page_total=page_count,
+                        page_current=window_end + 1,
+                        window_index=window_index + 1,
+                        window_total=total_windows,
+                        window_start=window_start + 1,
+                        window_end=window_end + 1,
+                        text=f"pages {window_start + 1}-{window_end + 1}/{page_count}",
                     )
                     last_append_end_time = time.time()
                 finally:

--- a/mineru/cli/common.py
+++ b/mineru/cli/common.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Sequence
 
+import pypdfium2 as pdfium
 from loguru import logger
 
 from mineru.cli.backend_options import (
@@ -29,7 +30,10 @@ from mineru.backend.office.pptx_analyze import office_pptx_analyze
 from mineru.backend.office.xlsx_analyze import office_xlsx_analyze
 from mineru.backend.office.docx_analyze import office_docx_analyze
 from mineru.utils.pdfium_guard import (
+    close_pdfium_document,
+    get_pdfium_document_page_count,
     get_loadable_pdfium_page_indices,
+    open_pdfium_document,
     rewrite_pdf_bytes_with_pdfium,
 )
 
@@ -84,6 +88,36 @@ def _load_hybrid_analyze_entrypoint(entrypoint_name: str, backend: str):
             build_hybrid_dependency_error_message(backend)
         ) from exc
     return getattr(hybrid_analyze, entrypoint_name)
+
+
+def _file_progress_callback(progress_callback, file_index: int):
+    if progress_callback is None:
+        return None
+
+    def _callback(**payload):
+        progress_callback(file_index=file_index, **payload)
+
+    return _callback
+
+
+def _prime_task_page_totals(pdf_bytes_list, progress_callback):
+    if progress_callback is None:
+        return
+
+    for file_index, pdf_bytes in enumerate(pdf_bytes_list):
+        pdf_doc = None
+        try:
+            pdf_doc = open_pdfium_document(pdfium.PdfDocument, pdf_bytes)
+            page_total = get_pdfium_document_page_count(pdf_doc)
+            progress_callback(
+                file_index=file_index,
+                page_total=page_total,
+                page_current=0,
+            )
+        except Exception as exc:
+            logger.warning(f"Unable to read PDF page count for progress: {exc}")
+        finally:
+            close_pdfium_document(pdf_doc)
 
 
 def utf8_byte_length(value: str) -> int:
@@ -365,6 +399,7 @@ def _process_pipeline(
         f_dump_content_list,
         f_make_md_mode,
         client_side_output_generation=False,
+        progress_callback=None,
 ):
     """处理pipeline后端逻辑"""
     from mineru.backend.pipeline.pipeline_analyze import doc_analyze_streaming as pipeline_doc_analyze_streaming
@@ -416,6 +451,7 @@ def _process_pipeline(
             formula_enable=p_formula_enable,
             table_enable=p_table_enable,
             client_side_output_generation=client_side_output_generation,
+            progress_callback=progress_callback,
         )
 
         for future in output_futures:
@@ -444,6 +480,7 @@ async def _async_process_vlm(
     f_draw_span_bbox = False
     if not backend.endswith("client"):
         server_url = None
+    progress_callback = kwargs.pop("progress_callback", None)
 
     for idx, pdf_bytes in enumerate(pdf_bytes_list):
         pdf_file_name = pdf_file_names[idx]
@@ -451,7 +488,12 @@ async def _async_process_vlm(
         image_writer, md_writer = FileBasedDataWriter(local_image_dir), FileBasedDataWriter(local_md_dir)
 
         middle_json, infer_result = await aio_vlm_doc_analyze(
-            pdf_bytes, image_writer=image_writer, backend=backend, server_url=server_url, **kwargs,
+            pdf_bytes,
+            image_writer=image_writer,
+            backend=backend,
+            server_url=server_url,
+            progress_callback=_file_progress_callback(progress_callback, idx),
+            **kwargs,
         )
 
         pdf_info = middle_json["pdf_info"]
@@ -485,6 +527,7 @@ def _process_vlm(
     f_draw_span_bbox = False
     if not backend.endswith("client"):
         server_url = None
+    progress_callback = kwargs.pop("progress_callback", None)
 
     for idx, pdf_bytes in enumerate(pdf_bytes_list):
         pdf_file_name = pdf_file_names[idx]
@@ -492,7 +535,12 @@ def _process_vlm(
         image_writer, md_writer = FileBasedDataWriter(local_image_dir), FileBasedDataWriter(local_md_dir)
 
         middle_json, infer_result = vlm_doc_analyze(
-            pdf_bytes, image_writer=image_writer, backend=backend, server_url=server_url, **kwargs,
+            pdf_bytes,
+            image_writer=image_writer,
+            backend=backend,
+            server_url=server_url,
+            progress_callback=_file_progress_callback(progress_callback, idx),
+            **kwargs,
         )
 
         pdf_info = middle_json["pdf_info"]
@@ -531,6 +579,7 @@ def _process_hybrid(
     """同步处理hybrid后端逻辑"""
     if not backend.endswith("client"):
         server_url = None
+    progress_callback = kwargs.pop("progress_callback", None)
 
     for idx, pdf_bytes in enumerate(pdf_bytes_list):
         pdf_file_name = pdf_file_names[idx]
@@ -545,6 +594,7 @@ def _process_hybrid(
             inline_formula_enable=inline_formula_enable,
             server_url=server_url,
             effort=validate_effort(effort),
+            progress_callback=_file_progress_callback(progress_callback, idx),
             **kwargs,
         )
 
@@ -586,6 +636,7 @@ async def _async_process_hybrid(
     """异步处理hybrid后端逻辑"""
     if not backend.endswith("client"):
         server_url = None
+    progress_callback = kwargs.pop("progress_callback", None)
 
     for idx, pdf_bytes in enumerate(pdf_bytes_list):
         pdf_file_name = pdf_file_names[idx]
@@ -600,6 +651,7 @@ async def _async_process_hybrid(
             inline_formula_enable=inline_formula_enable,
             server_url=server_url,
             effort=validate_effort(effort),
+            progress_callback=_file_progress_callback(progress_callback, idx),
             **kwargs,
         )
 
@@ -712,6 +764,7 @@ def do_parse(
 
     # 预处理PDF字节数据
     pdf_bytes_list = _prepare_pdf_bytes(pdf_bytes_list, start_page_id, end_page_id)
+    progress_callback = kwargs.get("progress_callback")
 
     if backend == "pipeline":
         _process_pipeline(
@@ -720,8 +773,10 @@ def do_parse(
             f_draw_layout_bbox, f_draw_span_bbox, f_dump_md, f_dump_middle_json,
             f_dump_model_output, f_dump_orig_pdf, f_dump_content_list, f_make_md_mode,
             client_side_output_generation=client_side_output_generation,
+            progress_callback=progress_callback,
         )
     else:
+        _prime_task_page_totals(pdf_bytes_list, progress_callback)
         if backend.startswith("vlm-"):
             backend = backend[4:]
 
@@ -806,6 +861,7 @@ async def aio_do_parse(
 
     # 预处理PDF字节数据
     pdf_bytes_list = _prepare_pdf_bytes(pdf_bytes_list, start_page_id, end_page_id)
+    progress_callback = kwargs.get("progress_callback")
 
     if backend == "pipeline":
         # pipeline模式暂不支持异步，使用同步处理方式
@@ -815,8 +871,10 @@ async def aio_do_parse(
             f_draw_layout_bbox, f_draw_span_bbox, f_dump_md, f_dump_middle_json,
             f_dump_model_output, f_dump_orig_pdf, f_dump_content_list, f_make_md_mode,
             client_side_output_generation=client_side_output_generation,
+            progress_callback=progress_callback,
         )
     else:
+        _prime_task_page_totals(pdf_bytes_list, progress_callback)
         if backend.startswith("vlm-"):
             backend = backend[4:]
 

--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -169,6 +169,7 @@ class AsyncParseTask:
     started_at: Optional[str] = None
     completed_at: Optional[str] = None
     error: Optional[str] = None
+    progress: Optional[dict[str, Any]] = None
 
     def to_status_payload(
         self,
@@ -184,6 +185,7 @@ class AsyncParseTask:
             "started_at": self.started_at,
             "completed_at": self.completed_at,
             "error": self.error,
+            "progress": self.progress,
             "status_url": str(
                 request.url_for("get_async_task_status", task_id=self.task_id)
             ),
@@ -198,6 +200,50 @@ class AsyncParseTask:
 
 class TaskWaitAbortedError(RuntimeError):
     """Raised when a synchronous file_parse request cannot keep waiting safely."""
+
+
+class TaskPageProgress:
+    def __init__(self, task: AsyncParseTask, file_names: list[str]):
+        self.task = task
+        file_count = len(file_names)
+        self.page_totals = [0] * file_count
+        self.page_currents = [0] * file_count
+
+    def update(
+        self,
+        *,
+        file_index: int = 0,
+        page_total: int = 0,
+        page_current: int = 0,
+        **_: Any,
+    ) -> None:
+        if not (0 <= file_index < len(self.page_totals)):
+            return
+        page_total = max(0, int(page_total or 0))
+        page_current = max(0, min(int(page_current or 0), page_total or page_current))
+        self.page_totals[file_index] = max(self.page_totals[file_index], page_total)
+        self.page_currents[file_index] = page_current
+
+        total_pages = sum(self.page_totals)
+        current_pages = sum(self.page_currents)
+        percent = int(current_pages * 100 / total_pages) if total_pages else 0
+        self.task.progress = {
+            "page_current": current_pages,
+            "page_total": total_pages,
+            "percent": max(0, min(100, percent)),
+            "text": f"{current_pages}/{total_pages} pages",
+        }
+
+    def complete(self) -> None:
+        if self.task.progress is None:
+            return
+        total_pages = self.task.progress.get("page_total", 0)
+        self.task.progress = {
+            **self.task.progress,
+            "page_current": total_pages,
+            "percent": 100,
+            "text": "completed",
+        }
 
 
 @asynccontextmanager
@@ -828,6 +874,11 @@ async def run_parse_job(
     pdf_file_names, pdf_bytes_list = await asyncio.to_thread(load_parse_inputs, uploads)
     actual_lang_list = normalize_lang_list(request_options.lang_list, len(pdf_file_names))
     response_file_names = list(pdf_file_names)
+    progress = (
+        TaskPageProgress(request_options, response_file_names)
+        if isinstance(request_options, AsyncParseTask)
+        else None
+    )
 
     parse_kwargs = dict(
         output_dir=output_dir,
@@ -857,6 +908,7 @@ async def run_parse_job(
             "client_side_output_generation",
             False,
         ),
+        progress_callback=progress.update if progress is not None else None,
         **config,
     )
 
@@ -864,6 +916,8 @@ async def run_parse_job(
         await asyncio.to_thread(do_parse, **parse_kwargs)
     else:
         await aio_do_parse(**parse_kwargs)
+    if progress is not None:
+        progress.complete()
     return response_file_names
 
 


### PR DESCRIPTION
Adds page-level progress reporting to async /tasks parsing.\n\n- Exposes progress in task status responses\n- Reports whole-task page_current/page_total/percent only\n- Supports pipeline, vlm, and hybrid backends\n- Keeps progress callback failures non-fatal\n- Preloads page totals for multi-file VLM/hybrid tasks to keep percentages stable\n\nValidation:\n- python -m py_compile mineru/cli/fast_api.py mineru/cli/common.py mineru/backend/vlm/vlm_analyze.py mineru/backend/hybrid/hybrid_analyze.py mineru/backend/pipeline/pipeline_analyze.py\n- git diff --check\n- TaskPageProgress smoke test for multi-file aggregation