### PR TITLE
修复测试/CI coverage 清理脚本中的不可达文件删除分支

### DIFF
--- a/tests/clean_coverage.py
+++ b/tests/clean_coverage.py
@@ -7,13 +7,12 @@ import shutil
 
 def delete_file(path):
     """delete file."""
-    if not os.path.exists(path):
-        if os.path.isfile(path):
-            try:
-                os.remove(path)
-                print(f"File '{path}' deleted.")
-            except TypeError as e:
-                print(f"Error deleting file '{path}': {e}")
+    if os.path.isfile(path):
+        try:
+            os.remove(path)
+            print(f"File '{path}' deleted.")
+        except TypeError as e:
+            print(f"Error deleting file '{path}': {e}")
     elif os.path.isdir(path):
         try:
             shutil.rmtree(path)


### PR DESCRIPTION
﻿## 问题描述

`tests/clean_coverage.py` 中的 `delete_file()` 用于清理 coverage 产物。

当前逻辑里，文件删除判断写在了 `if not os.path.exists(path)` 分支内部：

```python
if not os.path.exists(path):
    if os.path.isfile(path):
        os.remove(path)
```

但一个不存在的路径不可能同时是文件，所以 `os.path.isfile(path)` 永远不会为 `True`，也就是说这个文件删除分支永远不会被执行。

目录清理目前仍然可用，因为 `delete_file("htmlcov/")` 会走后面的目录分支；但脚本中已经保留的 `.coverage` 文件清理目标一旦启用，就无法正常删除文件。

目前启用的实际调用只清理 `htmlcov/` 目录；`.coverage` 的文件清理调用写在脚本里但被注释掉了。因此这个 bug 当前不会影响主程序解析功能，也不会影响线上业务路径。它影响的是这个清理 helper 的文件删除能力：如果维护者启用 `delete_file(".coverage")`，或者复用 `delete_file()` 清理其他文件，它现在删不了文件。

## 调用点

`delete_file()` 函数定义在：

`tests/clean_coverage.py` line 8

它在同一个文件的 `__main__` 里被调用：

`tests/clean_coverage.py` line 24

```python
if __name__ == "__main__":
    delete_file("htmlcov/")
    #delete_file(".coverage")
```

也就是说，直接调用点只有这个脚本自身。

这个脚本被 GitHub Actions 调用：

`.github/workflows/cli.yml` line 37

```bash
cd $GITHUB_WORKSPACE && python tests/clean_coverage.py
cd $GITHUB_WORKSPACE && coverage run
cd $GITHUB_WORKSPACE && python tests/get_coverage.py
```

所以实际链路是：

```text
GitHub Actions workflow
  -> python tests/clean_coverage.py
    -> delete_file("htmlcov/")
```

## 修复内容

将 `delete_file()` 函数的判断顺序调整为：

1. 如果路径是文件，使用 `os.remove()` 删除；
2. 如果路径是目录，使用 `shutil.rmtree()` 删除；
3. 如果路径不存在，则保持静默跳过。

这样保留了当前 `htmlcov/` 目录清理行为，同时修复了 `.coverage` 这类文件路径无法删除的问题。

## Bug 复现

`.coverage` 是 `coverage run` 会生成的真实覆盖率数据文件。可以用下面代码复现旧逻辑的问题：

```python
from pathlib import Path
import os
import shutil

def old_delete_file(path):
    if not os.path.exists(path):
        if os.path.isfile(path):
            os.remove(path)
    elif os.path.isdir(path):
        shutil.rmtree(path)

p = Path(".coverage")
p.write_text("coverage data", encoding="utf-8")

old_delete_file(str(p))

print(".coverage exists after old_delete_file:", p.exists())
p.unlink()
```

旧逻辑输出：

```text
.coverage exists after old_delete_file: True
```

修复后可以用实际函数验证：

```python
from pathlib import Path
from tests.clean_coverage import delete_file

p = Path(".coverage")
p.write_text("coverage data", encoding="utf-8")

delete_file(str(p))

print(".coverage exists after delete_file:", p.exists())
```

修复后输出：

```text
File '.coverage' deleted.
.coverage exists after delete_file: False
```
