### PR TITLE
docs: expand S3 extension section with S3-compatible provider example

### DIFF
--- a/docs/en/quick_start/extension_modules.md
+++ b/docs/en/quick_start/extension_modules.md
@@ -17,6 +17,32 @@ If you need to read from or write to S3, install the `s3` extension module.
 uv pip install "mineru[s3]"
 ```
 
+The `s3` extension supports Amazon S3 and S3-compatible providers (MinIO, [Tigris](https://www.tigrisdata.com), Cloudflare R2, etc.) via the `endpoint_url` parameter on `S3DataReader` and `S3DataWriter`:
+
+```python
+from mineru.data.data_reader_writer import S3DataReader, S3DataWriter
+
+# Amazon S3
+reader = S3DataReader(
+    default_prefix_without_bucket="documents",
+    bucket="my-bucket",
+    ak="AKIAxxx",
+    sk="...",
+    endpoint_url="https://s3.us-east-1.amazonaws.com",
+)
+
+# Tigris (S3-compatible)
+reader = S3DataReader(
+    default_prefix_without_bucket="documents",
+    bucket="my-bucket",
+    ak="tid_...",
+    sk="tsec_...",
+    endpoint_url="https://t3.storage.dev",
+)
+```
+
+Tigris uses a single global endpoint with reads served from the nearest region and no egress fees, which can matter for re-extraction passes over the same corpus or workers spread across regions. Choose AWS S3 (Express One Zone in particular) when compute and bucket are pinned to the same AZ.
+
 ---
 
 ### Using `vllm` to Accelerate VLM Model Inference


### PR DESCRIPTION
## Motivation

The `s3` extension module supports any S3-compatible endpoint via the `endpoint_url`
parameter on `S3DataReader` / `S3DataWriter`, but `docs/en/quick_start/extension_modules.md`
only mentions AWS S3 in a single line. Users who want to use MinIO, Tigris, Cloudflare R2,
or another S3-compatible store have to read the source to figure out the constructor shape.

## Modification

In `docs/en/quick_start/extension_modules.md`, under "Using S3 Input and Output":

- Added a one-line note that the `s3` extension supports S3-compatible providers via `endpoint_url`.
- Added two code examples showing the full `S3DataReader` constructor — one for Amazon S3 and one for an S3-compatible provider (Tigris).
- Added two sentences on when each makes sense for MinerU workloads (global endpoint + no egress vs. AZ-pinned compute and bucket).

Docs only; no code changes.

## BC-breaking (Optional)

No.

## Use cases (Optional)

- A user running re-extraction passes or parameter sweeps over a fixed corpus who wants to avoid per-byte egress.
- A user with MinerU workers distributed across regions reading from a single bucket without AZ-colocating compute and storage.
- A user who just wants a copy-paste example of pointing `S3DataReader` at a non-AWS endpoint.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. _(N/A — docs only)_
- [ ] The modification is covered by complete unit tests. _(N/A — docs only)_
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. _(N/A — docs only)_
- [ ] CLA has been signed and all committers have signed the CLA in this PR.