### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ uv pip install -U "mineru[all]"
 ```bash
 git clone https://github.com/opendatalab/MinerU.git
 cd MinerU
-uv pip install -e .[all]
+uv pip install -e '.[all]'
 ```
 
 > [!TIP]

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -304,7 +304,7 @@ uv pip install -U "mineru[all]" -i https://mirrors.aliyun.com/pypi/simple
 ```bash
 git clone https://github.com/opendatalab/MinerU.git
 cd MinerU
-uv pip install -e .[all] -i https://mirrors.aliyun.com/pypi/simple
+uv pip install -e '.[all]' -i https://mirrors.aliyun.com/pypi/simple
 ```
 
 > [!TIP]

--- a/docs/en/quick_start/index.md
+++ b/docs/en/quick_start/index.md
@@ -116,7 +116,7 @@ uv pip install -U "mineru[all]"
 ```bash
 git clone https://github.com/opendatalab/MinerU.git
 cd MinerU
-uv pip install -e .[all]
+uv pip install -e '.[all]'
 ```
 
 > [!TIP]

--- a/docs/zh/quick_start/index.md
+++ b/docs/zh/quick_start/index.md
@@ -121,7 +121,7 @@ uv pip install -U "mineru[all]" -i https://mirrors.aliyun.com/pypi/simple
 ```bash
 git clone https://github.com/opendatalab/MinerU.git
 cd MinerU
-uv pip install -e .[all] -i https://mirrors.aliyun.com/pypi/simple
+uv pip install -e '.[all]' -i https://mirrors.aliyun.com/pypi/simple
 ```
 
 > [!TIP]

--- a/docs/zh/usage/acceleration_cards/VastAI.md
+++ b/docs/zh/usage/acceleration_cards/VastAI.md
@@ -57,7 +57,7 @@
         # 通过源码安装MinerU
         git clone https://github.com/opendatalab/MinerU.git
         git checkout 8c4b3ef3a20b11ddac9903f25124d24ea82639b5
-        pip install -e .[core] -i https://mirrors.aliyun.com/pypi/simple
+        pip install -e '.[core]' -i https://mirrors.aliyun.com/pypi/simple
 
         # 或使用pip安装MinerU
         pip install -U "mineru[core]==2.7.0" -i https://mirrors.aliyun.com/pypi/simple


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `README.md`
- `README_zh-CN.md`
- `docs/en/quick_start/index.md`
- `docs/zh/quick_start/index.md`
- `docs/zh/usage/acceleration_cards/VastAI.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`