### PR TITLE
修复测试/CI coverage 清理脚本中的不可达文件删除分支

### DIFF
--- a/tests/clean_coverage.py
+++ b/tests/clean_coverage.py
@@ -7,13 +7,12 @@ import shutil
 
 def delete_file(path):
     """delete file."""
-    if not os.path.exists(path):
-        if os.path.isfile(path):
-            try:
-                os.remove(path)
-                print(f"File '{path}' deleted.")
-            except TypeError as e:
-                print(f"Error deleting file '{path}': {e}")
+    if os.path.isfile(path):
+        try:
+            os.remove(path)
+            print(f"File '{path}' deleted.")
+        except TypeError as e:
+            print(f"Error deleting file '{path}': {e}")
     elif os.path.isdir(path):
         try:
             shutil.rmtree(path)


### PR DESCRIPTION
重新提交，原 PR #5165 因 fork 仓库删除被关闭。修复 clean_coverage.py 中 delete_file() 的文件删除分支永远不可达的问题。