### PR TITLE
feat: add async parse pause resume support

### DIFF
--- a/docs/zh/mineru-request-level-cancel-design.md
+++ b/docs/zh/mineru-request-level-cancel-design.md
@@ -1,0 +1,365 @@
+# MinerU 请求级取消实现说明
+
+## 1. 已实现内容
+
+当前代码已经实现 MinerU 解析任务的 HTTP 取消能力：
+
+```mermaid
+flowchart LR
+  A["client / Nova"] --> B["POST /tasks/{task_id}/cancel"]
+  B --> C["AsyncTaskManager.cancel_task"]
+  C --> D["标记 task cancelled"]
+  C --> E["查 active_vllm_request_ids"]
+  E --> F["abort_requests"]
+  F --> G["返回 abort_count / aborted_vllm_request_ids"]
+```
+
+已实现接口：
+
+| 接口 | 作用 |
+| --- | --- |
+| `POST /tasks/{task_id}/cancel` | 取消整个解析任务 |
+| `POST /tasks/{task_id}/files/{file_name}/cancel` | 按文件名筛选当前 active vLLM request 后取消 |
+| `GET /tasks/{task_id}` | 返回 task 状态、取消状态、active vLLM request_id |
+
+取消响应会返回：
+
+```json
+{
+  "task_id": "xxx",
+  "status": "cancelled",
+  "message": "Task cancellation requested",
+  "abort_count": 1,
+  "aborted_vllm_request_ids": ["mineru-taskxxx-abc123"],
+  "active_vllm_request_ids": []
+}
+```
+
+状态查询会返回：
+
+```json
+{
+  "cancel_requested": true,
+  "cancel_requested_at": "2026-06-26T09:00:00+00:00",
+  "cancelled_at": "2026-06-26T09:00:01+00:00",
+  "cancel_reason": "Task cancellation requested",
+  "files": {
+    "sample": {
+      "cancel_requested": true,
+      "active_vllm_request_ids": []
+    }
+  },
+  "active_vllm_request_ids": []
+}
+```
+
+## 2. 取消执行流程
+
+```mermaid
+sequenceDiagram
+  participant API as MinerU API
+  participant Manager as AsyncTaskManager
+  participant Registry as VllmCancellationRegistry
+  participant Worker as Parse Task
+
+  API->>Manager: cancel_task(task_id, file_name?)
+  Manager->>Registry: mark_task_cancel_requested / mark_file_cancel_requested
+  Manager->>Registry: abort_requests(task_id, file_name?)
+  Registry-->>Manager: aborted_request_ids
+  Manager->>Worker: processor.cancel()
+  Manager-->>API: 202 + cancel payload
+```
+
+`AsyncTaskManager.cancel_task()` 做了这些事：
+
+1. 检查 task 是否存在。
+2. 如果传了 `file_name`，检查文件是否属于该 task。
+3. 标记 task 级或 file 级 cancel requested。
+4. 查询并取消 active vLLM request。
+5. 将 task 状态改成 `cancelled`。
+6. 取消当前 task processor。
+7. 返回 `abort_count` 和 `aborted_vllm_request_ids`。
+
+## 3. 源码改动点
+
+### 3.1 `mineru/cli/vllm_cancellation.py`
+
+新增请求级取消注册表和日志工具。
+
+主要实现：
+
+| 对象 | 作用 |
+| --- | --- |
+| `VllmCancellationRegistry` | 保存 task/file/request_id 映射，提供取消和状态查询 |
+| `vllm_request_context()` | 在解析某个 PDF 时设置当前 `task_id` 和 `file_name` |
+| `patch_vllm_async_llm_for_cancellation()` | patch 内置 `AsyncLLM.generate()`，记录 vLLM request_id |
+| `patch_http_vlm_client_for_cancellation()` | patch HTTP VLM client，注入 request_id 并记录本地请求 task |
+| `HttpVllmRequestAbortHandle` | 取消 HTTP VLM client 本地等待中的 `asyncio.Task` |
+| `print_cancel_event()` | 输出 `[MINERU_CANCEL]` 结构化日志 |
+
+核心数据结构：
+
+```python
+self._requests: dict[str, RegisteredVllmRequest]
+self._requests_by_task_file: dict[tuple[str, str], set[str]]
+self._cancelled_files: set[tuple[str, str]]
+self._cancelled_tasks: set[str]
+```
+
+核心取消方法：
+
+```python
+async def abort_requests(self, task_id: str, file_name: str | None = None) -> list[str]:
+    request_ids = self.get_active_request_ids(task_id, file_name)
+    ...
+```
+
+### 3.2 `mineru/cli/fast_api.py`
+
+给异步解析任务增加取消状态、取消接口和取消执行逻辑。
+
+主要改动：
+
+| 位置 | 改动 |
+| --- | --- |
+| `AsyncParseTask` | 新增 `cancel_requested`、`cancel_requested_at`、`cancelled_at`、`cancel_reason` |
+| `AsyncParseTask.to_status_payload()` | 状态响应返回取消字段 |
+| `AsyncTaskManager.__init__()` | 初始化 `VllmCancellationRegistry` |
+| `AsyncTaskManager.build_status_payload()` | 返回 `files[*].active_vllm_request_ids` 和 task 级 `active_vllm_request_ids` |
+| `AsyncTaskManager.cancel_task()` | 实现 task/file 取消、abort vLLM request、取消 processor |
+| `AsyncTaskManager._process_task()` | 已取消任务不再继续解析；取消后异常仍保持 `cancelled` |
+| `AsyncTaskManager._run_task()` | 给 task 注入 `mineru_cancellation_registry` |
+| `run_parse_job()` | 把 `mineru_task_id` 和 `mineru_cancellation_registry` 传入解析参数 |
+| `build_cancel_response()` | 统一构造取消响应 |
+| `cancel_async_task()` | 新增 `POST /tasks/{task_id}/cancel` |
+| `cancel_async_task_file()` | 新增 `POST /tasks/{task_id}/files/{file_name}/cancel` |
+
+取消状态写入：
+
+```python
+task.cancel_requested = True
+task.cancel_requested_at = task.cancel_requested_at or now
+task.cancel_reason = reason
+task.status = TASK_CANCELLED
+task.cancelled_at = now
+task.completed_at = now
+task.error = reason
+```
+
+### 3.3 `mineru/backend/vlm/vlm_analyze.py`
+
+给 VLM 解析路径接入 request_id 跟踪。
+
+主要改动：
+
+| 位置 | 改动 |
+| --- | --- |
+| import | 引入 `patch_http_vlm_client_for_cancellation`、`patch_vllm_async_llm_for_cancellation`、`vllm_request_context` |
+| `_get_model_async()` | 创建 `AsyncLLM` 后调用 `patch_vllm_async_llm_for_cancellation()` |
+| `_get_model_async()` | `backend == "http-client"` 时 patch HTTP VLM client |
+| `aio_doc_analyze()` | 从 `kwargs` 取 `mineru_task_id`、`mineru_file_name`、`mineru_cancellation_registry` |
+| `aio_doc_analyze()` | 每个 processing window 调模型前进入 `vllm_request_context()` |
+
+VLM window 内部的接入点：
+
+```python
+with vllm_request_context(
+    mineru_cancellation_registry,
+    mineru_task_id,
+    mineru_file_name,
+):
+    async with aio_predictor_execution_guard(predictor):
+        window_results = await predictor.aio_batch_two_step_extract(...)
+```
+
+### 3.4 `mineru/cli/common.py`
+
+把当前 PDF 文件名传给 VLM 解析函数。
+
+主要改动：
+
+| 位置 | 改动 |
+| --- | --- |
+| `_process_vlm()` | 如果存在 `mineru_task_id`，设置 `doc_kwargs["mineru_file_name"] = pdf_file_name` |
+| `_process_hybrid()` | 如果存在 `mineru_task_id`，设置 `doc_kwargs["mineru_file_name"] = pdf_file_name` |
+
+这个改动让注册表可以建立：
+
+```text
+task_id -> file_name -> vllm_request_id
+```
+
+### 3.5 `mineru/cli/router.py`
+
+给 router 层增加取消转发。
+
+主要改动：
+
+| 位置 | 改动 |
+| --- | --- |
+| `RouterTaskRecord` | 新增取消状态字段 |
+| `RouterTaskRecord.to_status_payload()` | 返回取消字段 |
+| `RouterTaskRegistry.update_from_upstream_payload()` | 从上游状态同步取消字段 |
+| `cancel_router_task()` | 转发 task/file 取消请求到上游 MinerU API |
+| `POST /tasks/{task_id}/cancel` | router task 取消入口 |
+| `POST /tasks/{task_id}/files/{file_name}/cancel` | router file 取消入口 |
+
+router 转发关系：
+
+```text
+router /tasks/{task_id}/cancel
+  -> upstream /tasks/{upstream_task_id}/cancel
+```
+
+### 3.6 `mineru/cli/api_client.py`
+
+给 client 侧增加取消调用。
+
+主要改动：
+
+| 对象 | 作用 |
+| --- | --- |
+| `CancelResponse` | 解析取消响应 |
+| `parse_cancel_response_payload()` | 从 JSON 响应中提取取消字段 |
+| `cancel_parse_task()` | async 取消接口 |
+| `cancel_parse_task_sync()` | sync 取消接口 |
+
+请求地址构造：
+
+```python
+if file_name is None:
+    cancel_url = f"{base_url}{TASKS_ENDPOINT}/{task_id}/cancel"
+else:
+    cancel_url = f"{base_url}{TASKS_ENDPOINT}/{task_id}/files/{file_name}/cancel"
+```
+
+### 3.7 `tests/unittest/test_parse_cancel.py`
+
+新增取消相关单测。
+
+覆盖内容：
+
+| 测试 | 覆盖点 |
+| --- | --- |
+| `test_cancel_pending_task_marks_cancelled_and_terminal` | pending task 取消后进入终态 |
+| `test_cancel_processing_task_aborts_active_vllm_requests` | processing task 取消 active vLLM request |
+| `test_cancelled_task_is_not_processed` | 已取消 task 不再解析 |
+| `test_worker_error_after_cancel_stays_cancelled` | 取消后 worker 报错不覆盖 `cancelled` 状态 |
+| `test_run_task_keeps_old_run_parse_job_wrapper_signature_compatible` | 兼容旧 `run_parse_job` wrapper |
+| `test_http_vlm_client_patch_injects_and_tracks_request_id` | HTTP VLM client 注入和跟踪 request_id |
+| `test_http_vlm_client_abort_cancels_local_request_task` | HTTP VLM client 取消本地请求 task |
+| `test_status_payload_includes_cancellation_and_vllm_request_ids` | 状态响应包含 active request_id |
+| `test_api_client_parses_cancel_response_payload` | client 正确解析取消响应 |
+
+## 4. 当前实现链路
+
+```mermaid
+flowchart TD
+  A["提交异步解析任务"] --> B["AsyncParseTask 保存 task_id"]
+  B --> C["run_parse_job 传入 mineru_task_id / registry"]
+  C --> D["common.py 设置 mineru_file_name"]
+  D --> E["vlm_analyze 进入 vllm_request_context"]
+  E --> F["vLLM / HTTP VLM client 注册 request_id"]
+  F --> G["GET /tasks/{task_id} 可看到 active_vllm_request_ids"]
+  G --> H["POST /tasks/{task_id}/cancel"]
+  H --> I["abort_requests"]
+  I --> J["task.status = cancelled"]
+```
+
+从 Nova App 到 MinerU 再到 vLLM 的时序：
+
+```mermaid
+sequenceDiagram
+  participant Nova as Nova App
+  participant Router as MinerU Router
+  participant API as MinerU API
+  participant Manager as AsyncTaskManager
+  participant Analyze as vlm_analyze
+  participant Registry as VllmCancellationRegistry
+  participant VLLM as vLLM
+
+  Nova->>Router: POST /tasks
+  Router->>API: POST /tasks
+  API->>Manager: create_async_parse_task()
+  Manager-->>API: task_id
+  API-->>Router: upstream_task_id
+  Router-->>Nova: task_id
+
+  Manager->>Analyze: run_parse_job(mineru_task_id, registry)
+  Analyze->>Registry: vllm_request_context(task_id, file_name)
+  Analyze->>VLLM: /v1/chat/completions(request_id)
+  Registry->>Registry: register_request(task_id, file_name, request_id)
+
+  Nova->>Router: GET /tasks/{task_id}
+  Router->>API: GET /tasks/{upstream_task_id}
+  API-->>Router: active_vllm_request_ids
+  Router-->>Nova: active_vllm_request_ids
+
+  Nova->>Router: POST /tasks/{task_id}/cancel
+  Router->>API: POST /tasks/{upstream_task_id}/cancel
+  API->>Manager: cancel_task(upstream_task_id)
+  Manager->>Registry: mark_task_cancel_requested(upstream_task_id)
+  Manager->>Registry: abort_requests(upstream_task_id)
+  Registry->>VLLM: abort tracked request
+  Registry->>Registry: unregister_request(request_id)
+  Registry-->>Manager: aborted_vllm_request_ids
+  Manager->>Manager: task.status = cancelled
+  Manager-->>API: status=cancelled, abort_count
+  API-->>Router: status=cancelled, aborted_vllm_request_ids
+  Router->>Router: update_from_upstream_payload()
+  Router-->>Nova: status=cancelled, abort_count
+
+  Nova->>Router: GET /tasks/{task_id}
+  Router->>API: GET /tasks/{upstream_task_id}
+  API-->>Router: status=cancelled, active_vllm_request_ids=[]
+  Router-->>Nova: status=cancelled, active_vllm_request_ids=[]
+```
+
+取消闭环时序：
+
+```mermaid
+sequenceDiagram
+  participant Nova as Nova App
+  participant MinerU as MinerU API
+  participant Registry as VllmCancellationRegistry
+  participant VLLM as vLLM
+
+  Nova->>MinerU: POST /tasks/{task_id}/cancel
+  MinerU->>Registry: get_active_request_ids(task_id)
+  Registry-->>MinerU: request_id
+  MinerU->>Registry: abort_requests(task_id)
+  Registry->>VLLM: abort(request_id)
+  Registry-->>MinerU: aborted_vllm_request_ids
+  MinerU->>MinerU: task.status = cancelled
+  MinerU-->>Nova: abort_count + aborted_vllm_request_ids
+  Nova->>Nova: 展示取消成功
+```
+
+## 5. 当前日志
+
+取消相关日志统一使用 `[MINERU_CANCEL]` 前缀。
+
+```text
+[MINERU_CANCEL] event=cancel_requested task_id=xxx file=*
+[MINERU_CANCEL] event=cancel_summary task_id=xxx file=* status=cancelled abort_count=1 active_after=0
+[MINERU_CANCEL] event=task_cancelled task_id=xxx status=cancelled error=Task cancellation requested
+```
+
+vLLM request 注册和取消日志：
+
+```text
+Registered VLLM request: mineru_task_id=xxx, file=sample, vllm_request_id=mineru-xxx
+Aborted VLLM request: mineru_task_id=xxx, file=sample, vllm_request_id=mineru-xxx
+Unregistered VLLM request: mineru_task_id=xxx, file=sample, vllm_request_id=mineru-xxx
+```
+
+## 6. 当前实现边界
+
+| 项 | 当前代码行为 |
+| --- | --- |
+| `vllm-engine` | patch `AsyncLLM.generate()`，通过 registry 跟踪和 abort request |
+| `http-client` | 注入 `request_id`，取消 MinerU 本地等待中的 HTTP task |
+| `/v1/chat/completions` | request body 里会带 `request_id` |
+| `/v1/responses/{id}/cancel` | 当前代码没有调用 |
+| `pipeline` backend | task 状态可被标记为 `cancelled`，但不走 vLLM request_id |
+| file 级取消 | 按 file_name 筛 active request_id，但 task 仍进入 `cancelled` 终态 |

--- a/docs/zh/mineru-soft-pause-resume-checkpoint-design.md
+++ b/docs/zh/mineru-soft-pause-resume-checkpoint-design.md
@@ -1,0 +1,468 @@
+# MinerU 软暂停与继续解析检查点方案
+
+> 目标：支持用户对一个正在解析的 PDF 做「暂停」和「继续」。  
+> 当前判断：现有代码更适合先做软暂停。也就是等当前 processing window 跑完后保存检查点，然后停止提交后续页面；继续时从下一个 window 往后跑。
+
+## 1. 先把边界说清楚
+
+这次讨论的是软暂停，不是硬中断。
+
+```mermaid
+flowchart LR
+  A["用户点暂停"] --> B["当前 window 继续跑完"]
+  B --> C["写 checkpoint"]
+  C --> D["任务状态变成 paused"]
+  D --> E["不再提交后续 window"]
+  E --> F["用户点继续"]
+  F --> G["从 checkpoint 的 next_start_page 继续解析"]
+```
+
+软暂停能做到：
+
+- 不再继续解析后面的页面。
+- 不再继续提交新的 vLLM 请求。
+- Nova 可以看到任务停在第几页。
+- 后续可以从检查点继续解析。
+
+软暂停第一版不承诺：
+
+- 不会立刻打断正在跑的 vLLM request。
+- 不会立刻释放当前 request 已占用的 GPU 显存。
+- 不保证服务重启后马上能续跑，除非补齐「从磁盘 checkpoint 恢复」。
+
+如果目标是「立刻释放 GPU」，还是要走取消解析或 worker/process 级隔离。软暂停解决的是「当前小批次跑完后，别继续耗后面的 GPU/队列」。
+
+## 2. 现状：现在为什么不能直接继续
+
+当前 MinerU 的主要输出还是最终阶段落地。
+
+```mermaid
+flowchart TD
+  A["开始解析 PDF"] --> B["按 window 读取页面"]
+  B --> C["调用模型解析当前 window"]
+  C --> D["追加到内存里的 middle_json / model_output"]
+  D --> E{"还有 window 吗"}
+  E -->|"有"| B
+  E -->|"没有"| F["finalize_middle_json"]
+  F --> G["_process_output 写 md / middle.json / model.json"]
+```
+
+代码上能看到几个稳定点：
+
+| 模块 | 当前行为 | 对暂停/继续的影响 |
+| --- | --- | --- |
+| `mineru/backend/vlm/vlm_analyze.py` | `aio_doc_analyze()` 按 processing window 循环，window 完成后追加到 `middle_json` | 适合在 window 完成后写检查点 |
+| `mineru/backend/hybrid/hybrid_analyze.py` | `aio_doc_analyze()` 也是按 processing window 循环，完成后追加到 `middle_json` / `model_list` | Hybrid 也能复用同一种检查点边界 |
+| `mineru/cli/common.py` | `_process_output()` 在完整解析结束后写最终 `md` / `middle.json` / `model.json` | 不能只依赖最终输出做继续 |
+| `mineru/cli/fast_api.py` | `create_task_output_dir(task_id)` 已有任务输出目录 | 检查点可以放在这个任务目录下 |
+
+也就是说，现在真正缺的是「中间态落盘」。
+
+## 3. 检查点应该按什么粒度保存
+
+推荐第一版按 processing window 保存。
+
+```mermaid
+flowchart LR
+  W1["window 1<br/>pages 1-8"] --> C1["checkpoint<br/>completed_until_page=8"]
+  C1 --> W2["window 2<br/>pages 9-16"]
+  W2 --> C2["checkpoint<br/>completed_until_page=16"]
+  C2 --> W3["window 3<br/>pages 17-24"]
+```
+
+原因比较直接：
+
+1. 现有 VLM / Hybrid 代码已经有 window 循环。
+2. window 结束后已经拿到了本批页面的模型结果。
+3. 这时 `middle_json` 已经追加过当前页面，状态比较完整。
+4. 如果暂停，只需要在下一个 window 开始前停住。
+
+默认可以继续沿用 `MINERU_PROCESSING_WINDOW_SIZE`。如果想让暂停更灵敏，可以把 window size 调小，例如 `4 / 8 / 16` 页。粒度越小，暂停响应越快；代价是 checkpoint 写入更频繁，整体调度开销也会多一点。
+
+## 4. 检查点保存什么
+
+检查点不要只保存一个页码。后续继续解析时，需要知道任务参数、已经完成的页面、下一次从哪里开始、以及中间产物在哪里。
+
+建议结构：
+
+```json
+{
+  "version": 1,
+  "task_id": "task-xxx",
+  "file_name": "example.pdf",
+  "backend": "vlm-http-client",
+  "parse_method": "auto",
+  "status": "paused",
+  "phase": "after_window_completed",
+  "page_count": 128,
+  "window_size": 8,
+  "completed_windows": 3,
+  "completed_until_page": 24,
+  "next_start_page": 25,
+  "updated_at": "2026-06-26T10:30:00+08:00",
+  "artifacts": {
+    "middle_json_partial": "pause_resume/middle_json_partial.json",
+    "model_output_partial": "pause_resume/model_output_partial.json",
+    "latest_window": "pause_resume/windows/window-0002.json"
+  }
+}
+```
+
+页面编号建议对外用 1-based，对内可以继续用现有代码里的 0-based。checkpoint 字段里要写清楚，例如：
+
+- `completed_until_page=24` 表示前 24 页已经完成。
+- `next_start_page=25` 表示继续时从第 25 页开始。
+
+## 5. 文件放在哪里
+
+复用 FastAPI 已有的任务输出目录。
+
+```text
+{output_root}/{task_id}/
+  pause_resume/
+    checkpoint.json
+    middle_json_partial.json
+    model_output_partial.json
+    windows/
+      window-0000.json
+      window-0001.json
+      window-0002.json
+```
+
+落盘规则：
+
+1. 每个 window 完成后，先写 `windows/window-xxxx.json`。
+2. 再写 `middle_json_partial.json` 和 `model_output_partial.json`。
+3. 最后原子替换 `checkpoint.json`。
+
+`checkpoint.json` 要最后写。这样即使写文件过程中进程退出，读取方也不会拿到一个指向不存在窗口文件的新 checkpoint。
+
+## 6. API 设计
+
+建议补三个接口：
+
+```http
+POST /tasks/{task_id}/pause
+POST /tasks/{task_id}/resume
+GET  /tasks/{task_id}
+```
+
+暂停响应：
+
+```json
+{
+  "task_id": "task-xxx",
+  "status": "pause_requested",
+  "message": "pause requested, task will pause after current processing window"
+}
+```
+
+真正暂停后的任务状态：
+
+```json
+{
+  "task_id": "task-xxx",
+  "status": "paused",
+  "checkpoint": {
+    "completed_until_page": 24,
+    "next_start_page": 25,
+    "page_count": 128
+  }
+}
+```
+
+继续响应：
+
+```json
+{
+  "task_id": "task-xxx",
+  "status": "processing",
+  "resume_from_page": 25
+}
+```
+
+## 7. 状态机
+
+```mermaid
+stateDiagram-v2
+  [*] --> pending
+  pending --> processing
+  processing --> pause_requested: POST /pause
+  pause_requested --> paused: checkpoint written
+  paused --> processing: POST /resume
+  processing --> completed
+  processing --> failed
+  processing --> cancelled
+  pause_requested --> cancelled
+  paused --> cancelled
+```
+
+几个规则：
+
+- `completed / failed / cancelled` 是终态，不能继续。
+- `processing` 收到 pause 后先变成 `pause_requested`。
+- 只有 window 完成、checkpoint 写完后，才变成 `paused`。
+- `paused` 收到 resume 后继续跑后面的 window。
+
+## 8. 代码改动点
+
+第一版可以把改动控制在四类模块里。
+
+```mermaid
+flowchart TD
+  A["FastAPI task manager"] --> A1["pause_task(task_id)"]
+  A --> A2["resume_task(task_id)"]
+  A --> A3["task status 返回 checkpoint"]
+
+  B["PauseRegistry"] --> B1["request_pause(task_id)"]
+  B --> B2["is_pause_requested(task_id)"]
+  B --> B3["wait_until_resumed(task_id)"]
+
+  C["CheckpointStore"] --> C1["write_window_result()"]
+  C --> C2["write_checkpoint_atomic()"]
+  C --> C3["load_checkpoint()"]
+
+  D["VLM / Hybrid analyze"] --> D1["window 完成后写 checkpoint"]
+  D --> D2["下一个 window 前检查 pause"]
+```
+
+### 8.1 PauseRegistry
+
+职责是保存运行时暂停状态。
+
+```python
+class PauseRegistry:
+    def request_pause(self, task_id: str) -> None: ...
+    def is_pause_requested(self, task_id: str) -> bool: ...
+    async def wait_until_resumed(self, task_id: str) -> None: ...
+    def resume(self, task_id: str) -> None: ...
+```
+
+第一版可以只做内存态。服务不重启时，任务协程可以在 `paused` 状态挂起等待。
+
+### 8.2 CheckpointStore
+
+职责是把可继续解析的信息写到任务目录。
+
+```python
+class CheckpointStore:
+    def write_window_result(self, task_id: str, window_index: int, data: dict) -> str: ...
+    def write_partial_state(self, task_id: str, middle_json: dict, model_output: list) -> None: ...
+    def write_checkpoint_atomic(self, task_id: str, checkpoint: dict) -> None: ...
+    def load_checkpoint(self, task_id: str) -> dict | None: ...
+```
+
+写文件建议使用临时文件加 `os.replace()`，避免 checkpoint 写一半被读取。
+
+### 8.3 VLM / Hybrid window hook
+
+在每个 window 完成后加 hook：
+
+```mermaid
+flowchart TD
+  A["window_results / window_model_list 已返回"] --> B["append 到 middle_json"]
+  B --> C["写 window result"]
+  C --> D["写 partial middle_json / model_output"]
+  D --> E["写 checkpoint"]
+  E --> F{"pause_requested?"}
+  F -->|"是"| G["状态改 paused，等待 resume"]
+  F -->|"否"| H["继续下一个 window"]
+```
+
+这里有一个实现注意点：不要在每个 window 后都调用最终的 `finalize_middle_json()`。  
+当前 finalize 更适合作为完整解析结束后的收尾动作。检查点里保存的是「未 finalize 的 partial middle_json」和「已完成 window 的 model output」。
+
+## 9. 继续解析怎么做
+
+建议分两版。
+
+### V1：运行中暂停，运行中继续
+
+这是最小可落地版本。
+
+```mermaid
+sequenceDiagram
+  participant UI as Nova
+  participant API as MinerU API
+  participant Job as Parse coroutine
+  participant Store as CheckpointStore
+
+  UI->>API: POST /tasks/{task_id}/pause
+  API->>Job: mark pause_requested
+  Job->>Job: current window finishes
+  Job->>Store: write checkpoint
+  Job->>API: status = paused
+  UI->>API: POST /tasks/{task_id}/resume
+  API->>Job: resume event
+  Job->>Job: continue next window in memory
+```
+
+这个版本的特点：
+
+- 改动小。
+- 不需要反向重建 `middle_json`。
+- 继续解析速度快，因为内存里的 `middle_json` / `model_output` 还在。
+- checkpoint 已经落盘，但主要用于状态展示、问题排查和为 V2 铺路。
+
+限制：
+
+- MinerU 服务进程重启后，原协程没了，不能只靠 V1 继续。
+
+### V2：从磁盘 checkpoint 恢复后继续
+
+V2 才是完整的「通过检查点继续解析」。
+
+```mermaid
+flowchart TD
+  A["resume task"] --> B["load checkpoint.json"]
+  B --> C["load middle_json_partial / model_output_partial"]
+  C --> D["设置 next_start_page"]
+  D --> E["跳过已完成 window"]
+  E --> F["继续解析剩余页面"]
+  F --> G["finalize_middle_json"]
+  G --> H["_process_output 写最终产物"]
+```
+
+V2 需要补的能力更多：
+
+1. `aio_doc_analyze()` 支持传入 `resume_from_page`。
+2. `aio_doc_analyze()` 支持传入已有的 `middle_json` 和 `model_output`。
+3. window 循环从 `next_start_page - 1` 开始。
+4. 最终解析结束后，把 partial 状态 finalize 成最终输出。
+5. 如果 PDF 内容、解析参数、backend 变了，要拒绝复用旧 checkpoint。
+
+第一版如果时间紧，可以先做 V1；但文档和数据结构要按 V2 预留字段。
+
+## 10. Nova 接入方式
+
+Nova 侧需要保存 MinerU 返回的 `task_id`。
+
+```mermaid
+flowchart LR
+  A["上传 PDF"] --> B["拿到 task_id"]
+  B --> C["轮询 GET /tasks/{task_id}"]
+  C --> D{"用户操作"}
+  D -->|"暂停"| E["POST /tasks/{task_id}/pause"]
+  D -->|"继续"| F["POST /tasks/{task_id}/resume"]
+  C --> G["展示 completed_until_page / page_count"]
+```
+
+UI 文案建议按状态显示：
+
+| 状态 | 展示含义 |
+| --- | --- |
+| `processing` | 正在解析 |
+| `pause_requested` | 等当前批次完成后暂停 |
+| `paused` | 已暂停，可继续 |
+| `completed` | 解析完成 |
+| `cancelled` | 已取消 |
+| `failed` | 解析失败 |
+
+## 11. 日志建议
+
+为了方便真实环境观测，关键位置都要打印结构化日志。
+
+```text
+[MINERU_PAUSE] request_pause task_id=xxx
+[MINERU_PAUSE] checkpoint_written task_id=xxx file=example.pdf window=3 completed_until_page=24 next_start_page=25
+[MINERU_PAUSE] paused task_id=xxx file=example.pdf
+[MINERU_PAUSE] resume task_id=xxx resume_from_page=25
+[MINERU_PAUSE] completed task_id=xxx checkpoint_windows=16
+```
+
+要重点看三件事：
+
+1. 用户点暂停后，是否还有新的 window 被提交。
+2. `checkpoint.json` 里的 `next_start_page` 是否正确。
+3. 用户点继续后，是否从 `next_start_page` 往后跑，而不是从第一页重跑。
+
+## 12. 验证方案
+
+第一轮用长 PDF，把 window size 调小，例如 4 页。
+
+```mermaid
+flowchart TD
+  A["准备 50 页以上 PDF"] --> B["设置 window_size=4"]
+  B --> C["开始解析"]
+  C --> D["观察跑到第 2 或第 3 个 window"]
+  D --> E["调用 POST /pause"]
+  E --> F["等待状态变 paused"]
+  F --> G["检查 checkpoint.json"]
+  G --> H["调用 POST /resume"]
+  H --> I["最终完成"]
+  I --> J["对比未暂停解析的页数和输出"]
+```
+
+验收点：
+
+- `POST /pause` 后任务先进入 `pause_requested`。
+- 当前 window 结束后进入 `paused`。
+- `pause_resume/checkpoint.json` 存在。
+- 暂停期间不再出现后续 window 的模型请求日志。
+- `POST /resume` 后从 `next_start_page` 继续。
+- 最终产物页数和正常完整解析一致。
+
+V2 额外验收：
+
+- 暂停后重启 MinerU 服务。
+- 调用 resume 能从 checkpoint 恢复。
+- 不重复解析已经完成的页面。
+- PDF 或参数变化时拒绝恢复，并给出明确错误。
+
+## 13. 风险和取舍
+
+| 风险 | 说明 | 处理建议 |
+| --- | --- | --- |
+| 当前 window 不能立刻停 | 软暂停等 window 结束才停 | 调小 window size |
+| partial middle_json 可能比较大 | 每个 window 都写全量 partial 会增加 IO | V1 可先接受，V2 再优化为 window 增量合并 |
+| finalize 只适合最终阶段 | partial 状态不能随便 finalize | checkpoint 保存 raw partial |
+| 多文件任务状态复杂 | 一个 task 里可能有多个 PDF | 第一版先 task-level pause；后续再做 file-level pause |
+| Pipeline 路径差异 | pipeline 有自己的 streaming / batch 流程 | 第一版优先覆盖 VLM / Hybrid，再单独补 pipeline hook |
+
+## 14. 推荐落地顺序
+
+```mermaid
+flowchart TD
+  A["阶段 1：软暂停基础能力"] --> B["PauseRegistry"]
+  B --> C["POST /pause 和 /resume"]
+  C --> D["window 结束后写 checkpoint"]
+  D --> E["运行中暂停/继续"]
+
+  E --> F["阶段 2：checkpoint 恢复"]
+  F --> G["load partial middle_json / model_output"]
+  G --> H["从 next_start_page 继续"]
+  H --> I["服务重启后续跑"]
+
+  I --> J["阶段 3：体验和稳定性"]
+  J --> K["file-level pause"]
+  J --> L["checkpoint 清理策略"]
+  J --> M["Nova 进度展示"]
+```
+
+第一版最小改动建议：
+
+1. 加 `PauseRegistry`。
+2. 加 `CheckpointStore`。
+3. FastAPI 加 `/tasks/{task_id}/pause` 和 `/tasks/{task_id}/resume`。
+4. VLM / Hybrid 的 window 循环里加 checkpoint hook。
+5. `GET /tasks/{task_id}` 返回 pause 状态和 checkpoint 摘要。
+6. 日志统一打 `[MINERU_PAUSE]`。
+
+## 15. 结论
+
+软暂停可以做，比较稳的切入点是 processing window。
+
+第一版先做到：
+
+- 用户点暂停后，当前 window 跑完就停。
+- 停下时写 checkpoint。
+- 用户点继续后，从内存里的下一个 window 继续。
+- Nova 能看到停在第几页。
+
+第二版再做到：
+
+- 服务重启后读取 checkpoint。
+- 加载 partial `middle_json` / `model_output`。
+- 从 `next_start_page` 跳过已完成页面继续。
+
+这样分两步做，第一版能较快验证「暂停后不再继续耗后续 GPU/队列」，第二版再补齐「真正通过检查点跨进程继续解析」。

--- a/docs/zh/mineru-soft-pause-resume-local-test.md
+++ b/docs/zh/mineru-soft-pause-resume-local-test.md
@@ -1,0 +1,308 @@
+# MinerU 软暂停/继续本地验证命令
+
+本文记录本地验证 MinerU API 软暂停、继续、取消，以及检查点文件的常用命令。测试目标是确认：
+
+- `pause` 请求后，任务会从 `processing` 进入 `pause_requested`。
+- 当前 processing window 完成后，任务进入 `paused`。
+- `pause_resume/checkpoint.json` 已写入，并能看到下一次继续解析的页码。
+- `resume` 后任务重新进入 `processing`。
+- `cancel` 后任务进入 `cancelled`，新版本会清理该任务的 `pause_resume/` 检查点目录。
+
+## 1. 准备环境
+
+在本机 MinerU 源码目录执行：
+
+```bash
+cd /Users/sunmo/Downloads/MinerU-master
+source .venv/bin/activate
+```
+
+建议先固定几个变量：
+
+```bash
+export API="http://127.0.0.1:8005"
+export OUT="/tmp/mineru-pause-local"
+export VLLM_SERVER="http://172.16.107.149:18085"
+
+# 使用页数多一点的 PDF 更容易测出暂停效果。
+export PDF="/Users/sunmo/Downloads/钢结构设计标准理解与应用-朱.pdf"
+
+rm -rf "$OUT" /tmp/mineru-api-pause.log /tmp/mineru-submit.json /tmp/mineru-status.json
+```
+
+如果短 PDF 解析太快，可能还没来得及暂停就已经完成。此时换成长 PDF，或者继续保持 `MINERU_PROCESSING_WINDOW_SIZE=1`。
+
+## 2. 启动 MinerU API
+
+在第一个终端启动 API。这个终端保持运行，不要按 `Ctrl+C`：
+
+```bash
+MINERU_LOG_LEVEL=DEBUG \
+MINERU_PROCESSING_WINDOW_SIZE=1 \
+MINERU_API_OUTPUT_ROOT=/tmp/mineru-pause-local \
+mineru-api --host 127.0.0.1 --port 8005 \
+  2>&1 | tee -a /tmp/mineru-api-pause.log
+```
+
+如果没有激活 `.venv`，也可以直接使用：
+
+```bash
+MINERU_LOG_LEVEL=DEBUG \
+MINERU_PROCESSING_WINDOW_SIZE=1 \
+MINERU_API_OUTPUT_ROOT=/tmp/mineru-pause-local \
+.venv/bin/mineru-api --host 127.0.0.1 --port 8005 \
+  2>&1 | tee -a /tmp/mineru-api-pause.log
+```
+
+这里的关键配置是：
+
+- `MINERU_PROCESSING_WINDOW_SIZE=1`：每个 window 只处理 1 页，暂停响应更容易观察。
+- `MINERU_API_OUTPUT_ROOT=/tmp/mineru-pause-local`：任务输出和检查点都写到这个目录下。
+- `/tmp/mineru-api-pause.log`：保留 API 日志，方便 grep 暂停和取消事件。
+
+## 3. 检查 API 是否启动
+
+在第二个终端执行：
+
+```bash
+curl -s "$API/health" | python3 -m json.tool
+```
+
+能返回健康状态后，再提交解析任务。
+
+## 4. 提交解析任务
+
+```bash
+curl -s -X POST "$API/tasks" \
+  -F "files=@${PDF};type=application/pdf" \
+  -F "backend=vlm-http-client" \
+  -F "server_url=${VLLM_SERVER}" \
+  -F "return_middle_json=true" \
+  -F "return_model_output=true" \
+  -F "return_md=true" \
+  -F "return_content_list=true" \
+  | tee /tmp/mineru-submit.json
+```
+
+取出任务 ID：
+
+```bash
+export TASK_ID="$(python3 - <<'PY'
+import json
+print(json.load(open('/tmp/mineru-submit.json'))['task_id'])
+PY
+)"
+
+echo "$TASK_ID"
+```
+
+## 5. 发送暂停命令
+
+```bash
+curl -s -X POST "$API/tasks/$TASK_ID/pause" | python3 -m json.tool
+```
+
+预期结果：
+
+- 如果任务还在 `processing`，接口返回 `202`，任务状态变成 `pause_requested`。
+- MinerU 不会打断当前正在跑的 window。
+- 当前 window 完成、checkpoint 写完以后，任务才会进入 `paused`。
+
+## 6. 查看任务状态
+
+单次查看：
+
+```bash
+curl -s "$API/tasks/$TASK_ID" | python3 -m json.tool
+```
+
+持续查看：
+
+```bash
+while true; do
+  date '+%H:%M:%S'
+  curl -s "$API/tasks/$TASK_ID" \
+    | python3 -m json.tool \
+    | egrep '"status"|completed_until_page|next_start_page|page_count|checkpoint'
+  sleep 1
+done
+```
+
+判断暂停成功，主要看三点：
+
+1. 状态从 `processing` 变成 `pause_requested`，再变成 `paused`。
+2. `GET /tasks/$TASK_ID` 返回里能看到 `checkpoint`。
+3. `checkpoint.status` 是 `paused`，`phase` 是 `after_window_completed`。
+
+之前本地测试看到过类似结果：
+
+```json
+{
+  "version": 1,
+  "task_id": "052af4ea-420d-4846-94c7-8c72a7bbe4e2",
+  "file_name": "钢结构设计标准理解与应用-朱",
+  "backend": "vlm-http-client",
+  "parse_method": "auto",
+  "status": "paused",
+  "phase": "after_window_completed",
+  "page_count": 492,
+  "window_size": 1,
+  "completed_windows": 9,
+  "completed_until_page": 9,
+  "next_start_page": 10,
+  "artifacts": {
+    "middle_json_partial": "pause_resume/middle_json_partial.json",
+    "model_output_partial": "pause_resume/model_output_partial.json",
+    "latest_window": "pause_resume/windows/window-0008.json"
+  }
+}
+```
+
+这个结果表示：
+
+- 任务已经暂停住了。
+- 检查点阶段是 `after_window_completed`，也就是当前 window 已完成后暂停。
+- 对外页码是 1-based，`completed_until_page=9` 表示前 9 页已经处理完。
+- `next_start_page=10` 表示继续时从第 10 页开始。
+- `latest_window=window-0008.json` 是最近一次完成的 window 结果。
+
+## 7. 查看检查点文件
+
+检查点目录由 API 启动时的 `MINERU_API_OUTPUT_ROOT` 和 `TASK_ID` 决定：
+
+```bash
+export CKPT_DIR="/tmp/mineru-pause-local/$TASK_ID/pause_resume"
+echo "$CKPT_DIR"
+```
+
+本地测试时，一个实际路径类似：
+
+```text
+/tmp/mineru-pause-local/052af4ea-420d-4846-94c7-8c72a7bbe4e2/pause_resume/checkpoint.json
+```
+
+列出检查点目录：
+
+```bash
+find "$CKPT_DIR" -maxdepth 3 -type f -print
+```
+
+格式化查看 `checkpoint.json`：
+
+```bash
+cat "$CKPT_DIR/checkpoint.json" | python3 -m json.tool
+```
+
+打开检查点所在目录：
+
+```bash
+open "$CKPT_DIR"
+```
+
+正常会看到：
+
+```text
+pause_resume/
+  checkpoint.json
+  middle_json_partial.json
+  model_output_partial.json
+  windows/
+    window-0000.json
+    window-0001.json
+    ...
+```
+
+如果没有 `checkpoint.json`，优先检查：
+
+- `TASK_ID` 是否是当前任务的 ID。
+- API 启动时是否设置了 `MINERU_API_OUTPUT_ROOT=/tmp/mineru-pause-local`。
+- 任务是否已经进入 `paused`，而不是还停在 `pause_requested`。
+- PDF 是否太短，导致任务已经 `completed`。
+
+## 8. 继续解析
+
+任务进入 `paused` 后，执行：
+
+```bash
+curl -s -X POST "$API/tasks/$TASK_ID/resume" | python3 -m json.tool
+```
+
+预期结果：
+
+- 接口返回 `202`。
+- 任务状态变回 `processing`。
+- API 日志里能看到 `MINERU_PAUSE` 的 resume 记录。
+- 解析从 checkpoint 的 `next_start_page` 继续往后跑。
+
+查看 resume 日志：
+
+```bash
+grep "MINERU_PAUSE" /tmp/mineru-api-pause.log
+```
+
+持续看日志：
+
+```bash
+tail -f /tmp/mineru-api-pause.log | grep MINERU_PAUSE
+```
+
+## 9. 取消任务
+
+取消命令：
+
+```bash
+curl -s -X POST "$API/tasks/$TASK_ID/cancel" | python3 -m json.tool
+```
+
+取消成功时，API 日志会出现类似：
+
+```text
+[MINERU_CANCEL] event=task_cancelled task_id=052af4ea-420d-4846-94c7-8c72a7bbe4e2 status=cancelled error=Task cancellation requested
+```
+
+这表示任务已经进入 `cancelled`。当前实现里，取消会清理该任务的 `pause_resume/` 检查点目录，避免同一个输出目录里的旧检查点影响后续排查。
+
+如果是旧版本已经取消过的任务，或者想手动清掉检查点，可以执行：
+
+```bash
+rm -rf "/tmp/mineru-pause-local/$TASK_ID/pause_resume"
+```
+
+查看取消日志：
+
+```bash
+grep "MINERU_CANCEL" /tmp/mineru-api-pause.log
+```
+
+## 10. 观察暂停是否释放内存
+
+软暂停只保证当前 window 完成后不再提交后续 window，不承诺立刻释放当前进程已经占用的内存或显存。可以用下面命令观察 MinerU API 进程内存：
+
+```bash
+export PID="$(pgrep -f 'mineru-api.*8005' | head -1)"
+echo "$PID"
+```
+
+持续打印 RSS：
+
+```bash
+while true; do
+  ts="$(date '+%H:%M:%S')"
+  ps -o pid=,rss=,%mem=,command= -p "$PID" \
+    | awk -v ts="$ts" '{printf "%s pid=%s rss=%.1fMB mem=%s%% cmd=%s\n", ts, $1, $2/1024, $3, $4}'
+  sleep 1
+done
+```
+
+如果要观察系统整体内存：
+
+```bash
+vm_stat 1
+```
+
+判断口径：
+
+- 暂停成功的主要证据是任务状态和 checkpoint，不是内存下降。
+- 软暂停一般不会明显释放进程内存。
+- 如果目标是尽快释放资源，应该使用 `cancel`，或者在 Nova 侧使用独立 worker/process 隔离。
+

--- a/maintain.md
+++ b/maintain.md
@@ -1,0 +1,2 @@
+# 查看mineru api日志
+tail -f /tmp/mineru_api_18086.log

--- a/mineru/backend/hybrid/hybrid_analyze.py
+++ b/mineru/backend/hybrid/hybrid_analyze.py
@@ -107,6 +107,53 @@ MEDIUM_EFFORT_LAYOUT_LABEL_TO_VLM_TYPE = {
 }
 
 
+async def _checkpoint_window_and_maybe_pause(
+    *,
+    checkpoint_store,
+    pause_registry,
+    task_output_dir,
+    task_id,
+    file_name,
+    backend,
+    parse_method,
+    page_count,
+    window_size,
+    window_index,
+    window_start,
+    window_end,
+    middle_json,
+    model_output,
+    window_result,
+):
+    if task_id is None:
+        return
+    checkpoint = None
+    pause_requested = (
+        pause_registry is not None and pause_registry.is_pause_requested(task_id)
+    )
+    if checkpoint_store is not None and task_output_dir is not None and file_name is not None:
+        checkpoint = await asyncio.to_thread(
+            checkpoint_store.write_processing_checkpoint,
+            task_output_dir=task_output_dir,
+            task_id=task_id,
+            file_name=file_name,
+            backend=f"hybrid-{backend}",
+            parse_method=parse_method,
+            status="paused" if pause_requested else "processing",
+            page_count=page_count,
+            window_size=window_size,
+            window_index=window_index,
+            window_start=window_start,
+            window_end=window_end,
+            middle_json=middle_json,
+            model_output=model_output,
+            window_result=window_result,
+        )
+    if pause_requested:
+        pause_registry.mark_paused(task_id, checkpoint)
+        await pause_registry.wait_until_resumed(task_id)
+
+
 def _validate_parse_effort(effort: str = "medium") -> str:
     """校验 Hybrid effort，避免静默走错解析强度分支。"""
     if effort not in HYBRID_ANALYZE_EFFORTS:
@@ -901,6 +948,13 @@ def doc_analyze(
 ):
     effort = _validate_parse_effort(effort)
     effective_image_analysis = _resolve_effective_image_analysis(effort, image_analysis)
+    kwargs.pop("mineru_task_id", None)
+    kwargs.pop("mineru_file_name", None)
+    kwargs.pop("mineru_cancellation_registry", None)
+    kwargs.pop("mineru_pause_registry", None)
+    kwargs.pop("mineru_checkpoint_store", None)
+    kwargs.pop("mineru_task_output_dir", None)
+    kwargs.pop("mineru_parse_method", None)
     client_side_output_generation = bool(
         kwargs.pop("client_side_output_generation", False)
     )
@@ -1109,6 +1163,13 @@ async def aio_doc_analyze(
 ):
     effort = _validate_parse_effort(effort)
     effective_image_analysis = _resolve_effective_image_analysis(effort, image_analysis)
+    mineru_task_id = kwargs.pop("mineru_task_id", None)
+    mineru_file_name = kwargs.pop("mineru_file_name", None)
+    kwargs.pop("mineru_cancellation_registry", None)
+    mineru_pause_registry = kwargs.pop("mineru_pause_registry", None)
+    mineru_checkpoint_store = kwargs.pop("mineru_checkpoint_store", None)
+    mineru_task_output_dir = kwargs.pop("mineru_task_output_dir", None)
+    mineru_parse_method = kwargs.pop("mineru_parse_method", parse_method)
     client_side_output_generation = bool(
         kwargs.pop("client_side_output_generation", False)
     )
@@ -1273,6 +1334,23 @@ async def aio_doc_analyze(
                         progress_bar=progress_bar,
                     )
                     last_append_end_time = time.time()
+                    await _checkpoint_window_and_maybe_pause(
+                        checkpoint_store=mineru_checkpoint_store,
+                        pause_registry=mineru_pause_registry,
+                        task_output_dir=mineru_task_output_dir,
+                        task_id=mineru_task_id,
+                        file_name=mineru_file_name,
+                        backend=backend,
+                        parse_method=mineru_parse_method,
+                        page_count=page_count,
+                        window_size=configured_window_size,
+                        window_index=window_index,
+                        window_start=window_start,
+                        window_end=window_end,
+                        middle_json=middle_json,
+                        model_output=model_list,
+                        window_result=window_model_list,
+                    )
                 finally:
                     _close_images(images_list)
         finally:

--- a/mineru/backend/vlm/vlm_analyze.py
+++ b/mineru/backend/vlm/vlm_analyze.py
@@ -35,6 +35,11 @@ from ...utils.pdfium_guard import (
     open_pdfium_document,
 )
 from ...utils.models_download_utils import auto_download_and_get_model_root_path
+from mineru.cli.vllm_cancellation import (
+    patch_http_vlm_client_for_cancellation,
+    patch_vllm_async_llm_for_cancellation,
+    vllm_request_context,
+)
 
 from mineru_vl_utils import MinerUClient
 from packaging import version
@@ -172,6 +177,7 @@ class ModelSingleton:
                             kwargs["logits_processors"] = [MinerULogitsProcessor]
                         # 使用kwargs为 vllm初始化参数
                         vllm_async_llm = AsyncLLM.from_engine_args(AsyncEngineArgs(**kwargs))
+                        patch_vllm_async_llm_for_cancellation(vllm_async_llm)
                     elif backend == "lmdeploy-engine":
                         try:
                             from lmdeploy import PytorchEngineConfig, TurbomindEngineConfig
@@ -245,6 +251,10 @@ class ModelSingleton:
                     "vllm_async_llm": vllm_async_llm,
                     "lmdeploy_engine": lmdeploy_engine,
                 }
+                if backend == "http-client":
+                    patch_http_vlm_client_for_cancellation(
+                        getattr(predictor, "client", None)
+                    )
                 _maybe_enable_serial_execution(predictor, backend)
                 self._models[key] = predictor
                 elapsed = round(time.time() - start_time, 2)
@@ -420,6 +430,53 @@ def _close_images(images_list):
                 pass
 
 
+async def _checkpoint_window_and_maybe_pause(
+    *,
+    checkpoint_store,
+    pause_registry,
+    task_output_dir,
+    task_id,
+    file_name,
+    backend,
+    parse_method,
+    page_count,
+    window_size,
+    window_index,
+    window_start,
+    window_end,
+    middle_json,
+    model_output,
+    window_result,
+):
+    if task_id is None:
+        return
+    checkpoint = None
+    pause_requested = (
+        pause_registry is not None and pause_registry.is_pause_requested(task_id)
+    )
+    if checkpoint_store is not None and task_output_dir is not None and file_name is not None:
+        checkpoint = await asyncio.to_thread(
+            checkpoint_store.write_processing_checkpoint,
+            task_output_dir=task_output_dir,
+            task_id=task_id,
+            file_name=file_name,
+            backend=f"vlm-{backend}",
+            parse_method=parse_method,
+            status="paused" if pause_requested else "processing",
+            page_count=page_count,
+            window_size=window_size,
+            window_index=window_index,
+            window_start=window_start,
+            window_end=window_end,
+            middle_json=middle_json,
+            model_output=model_output,
+            window_result=window_result,
+        )
+    if pause_requested:
+        pause_registry.mark_paused(task_id, checkpoint)
+        await pause_registry.wait_until_resumed(task_id)
+
+
 def doc_analyze(
     pdf_bytes,
     image_writer: DataWriter | None,
@@ -430,6 +487,13 @@ def doc_analyze(
     image_analysis: bool = True,
     **kwargs,
 ):
+    kwargs.pop("mineru_task_id", None)
+    kwargs.pop("mineru_file_name", None)
+    kwargs.pop("mineru_cancellation_registry", None)
+    kwargs.pop("mineru_pause_registry", None)
+    kwargs.pop("mineru_checkpoint_store", None)
+    kwargs.pop("mineru_task_output_dir", None)
+    kwargs.pop("mineru_parse_method", None)
     client_side_output_generation = bool(
         kwargs.pop("client_side_output_generation", False)
     )
@@ -530,6 +594,13 @@ async def aio_doc_analyze(
     image_analysis: bool = True,
     **kwargs,
 ):
+    mineru_task_id = kwargs.pop("mineru_task_id", None)
+    mineru_file_name = kwargs.pop("mineru_file_name", None)
+    mineru_cancellation_registry = kwargs.pop("mineru_cancellation_registry", None)
+    mineru_pause_registry = kwargs.pop("mineru_pause_registry", None)
+    mineru_checkpoint_store = kwargs.pop("mineru_checkpoint_store", None)
+    mineru_task_output_dir = kwargs.pop("mineru_task_output_dir", None)
+    mineru_parse_method = kwargs.pop("mineru_parse_method", "vlm")
     client_side_output_generation = bool(
         kwargs.pop("client_side_output_generation", False)
     )
@@ -574,11 +645,16 @@ async def aio_doc_analyze(
                         f'pages {window_start + 1}-{window_end + 1}/{page_count} '
                         f'({len(images_pil_list)} pages)'
                     )
-                    async with aio_predictor_execution_guard(predictor):
-                        window_results = await predictor.aio_batch_two_step_extract(
-                            images=images_pil_list,
-                            image_analysis=image_analysis,
-                        )
+                    with vllm_request_context(
+                        mineru_cancellation_registry,
+                        mineru_task_id,
+                        mineru_file_name,
+                    ):
+                        async with aio_predictor_execution_guard(predictor):
+                            window_results = await predictor.aio_batch_two_step_extract(
+                                images=images_pil_list,
+                                image_analysis=image_analysis,
+                            )
                     results.extend(window_results)
                     if progress_bar is None:
                         progress_bar = tqdm(total=page_count, desc="Processing pages")
@@ -598,6 +674,23 @@ async def aio_doc_analyze(
                         progress_bar=progress_bar,
                     )
                     last_append_end_time = time.time()
+                    await _checkpoint_window_and_maybe_pause(
+                        checkpoint_store=mineru_checkpoint_store,
+                        pause_registry=mineru_pause_registry,
+                        task_output_dir=mineru_task_output_dir,
+                        task_id=mineru_task_id,
+                        file_name=mineru_file_name,
+                        backend=backend,
+                        parse_method=mineru_parse_method,
+                        page_count=page_count,
+                        window_size=configured_window_size,
+                        window_index=window_index,
+                        window_start=window_start,
+                        window_end=window_end,
+                        middle_json=middle_json,
+                        model_output=results,
+                        window_result=window_results,
+                    )
                 finally:
                     _close_images(images_list)
         finally:

--- a/mineru/cli/api_client.py
+++ b/mineru/cli/api_client.py
@@ -456,6 +456,16 @@ class SubmitResponse:
     result_url: str
     file_names: tuple[str, ...] = ()
     queued_ahead: int | None = None
+    upstream_task_id: str | None = None
+
+
+@dataclass(frozen=True)
+class CancelResponse:
+    task_id: str
+    status: str
+    abort_count: int
+    aborted_vllm_request_ids: tuple[str, ...]
+    payload: dict[str, object]
 
 
 @dataclass(frozen=True)
@@ -907,12 +917,14 @@ def submit_parse_task_sync(
 
     payload = response.json()
     task_id = payload.get("task_id")
+    upstream_task_id = payload.get("upstream_task_id")
     status_url = payload.get("status_url")
     result_url = payload.get("result_url")
     file_names = payload.get("file_names")
     queued_ahead = payload.get("queued_ahead")
     if (
         not isinstance(task_id, str)
+        or (upstream_task_id is not None and not isinstance(upstream_task_id, str))
         or not isinstance(status_url, str)
         or not isinstance(result_url, str)
     ):
@@ -930,7 +942,82 @@ def submit_parse_task_sync(
         result_url=result_url,
         file_names=normalized_file_names,
         queued_ahead=queued_ahead,
+        upstream_task_id=upstream_task_id,
     )
+
+
+def format_submit_mapping_message(submit_response: SubmitResponse) -> str:
+    parts = [f"mineru_task_id={submit_response.task_id}"]
+    if submit_response.upstream_task_id is not None:
+        parts.append(f"upstream_task_id={submit_response.upstream_task_id}")
+    return "Task submitted: " + ", ".join(parts)
+
+
+def parse_cancel_response_payload(payload: object) -> CancelResponse:
+    if not isinstance(payload, dict):
+        raise click.ClickException("MinerU API returned an invalid cancel payload")
+    task_id = payload.get("task_id")
+    status = payload.get("status")
+    abort_count = payload.get("abort_count", 0)
+    aborted_request_ids = payload.get("aborted_vllm_request_ids", [])
+    if not isinstance(task_id, str) or not isinstance(status, str):
+        raise click.ClickException("MinerU API returned an invalid cancel payload")
+    if not isinstance(abort_count, int):
+        abort_count = 0
+    if not (
+        isinstance(aborted_request_ids, list)
+        and all(isinstance(item, str) for item in aborted_request_ids)
+    ):
+        aborted_request_ids = []
+    return CancelResponse(
+        task_id=task_id,
+        status=status,
+        abort_count=abort_count,
+        aborted_vllm_request_ids=tuple(aborted_request_ids),
+        payload=dict(payload),
+    )
+
+
+async def cancel_parse_task(
+    base_url: str,
+    task_id: str,
+    file_name: str | None = None,
+) -> CancelResponse:
+    return await asyncio.to_thread(
+        cancel_parse_task_sync,
+        base_url,
+        task_id,
+        file_name,
+    )
+
+
+def cancel_parse_task_sync(
+    base_url: str,
+    task_id: str,
+    file_name: str | None = None,
+) -> CancelResponse:
+    if file_name is None:
+        cancel_url = f"{base_url}{TASKS_ENDPOINT}/{task_id}/cancel"
+    else:
+        cancel_url = f"{base_url}{TASKS_ENDPOINT}/{task_id}/files/{file_name}/cancel"
+    try:
+        with httpx.Client(timeout=build_http_timeout(), follow_redirects=True) as sync_client:
+            response = sync_client.post(cancel_url)
+    except httpx.TimeoutException as exc:
+        raise click.ClickException(
+            f"Timed out cancelling parsing task at {cancel_url}."
+        ) from exc
+    except httpx.RequestError as exc:
+        raise click.ClickException(
+            f"Failed to cancel parsing task at {cancel_url}: {exc}"
+        ) from exc
+
+    if response.status_code not in {200, 202}:
+        raise click.ClickException(
+            f"Failed to cancel parsing task: "
+            f"{response.status_code} {response_detail(response)}"
+        )
+    return parse_cancel_response_payload(response.json())
 
 
 async def wait_for_task_result(

--- a/mineru/cli/api_client.py
+++ b/mineru/cli/api_client.py
@@ -36,6 +36,7 @@ from mineru.utils.check_sys_env import is_linux_environment
 HEALTH_ENDPOINT = "/health"
 TASKS_ENDPOINT = "/tasks"
 TASK_STATUS_POLL_INTERVAL_SECONDS = 1.0
+TASK_NOT_READY_STATUSES = {"pending", "processing", "pause_requested", "paused"}
 LOCAL_API_SHUTDOWN_TIMEOUT_SECONDS = 10
 LOCAL_API_CLEANUP_RETRIES = 8
 LOCAL_API_CLEANUP_RETRY_INTERVAL_SECONDS = 0.25
@@ -465,6 +466,13 @@ class CancelResponse:
     status: str
     abort_count: int
     aborted_vllm_request_ids: tuple[str, ...]
+    payload: dict[str, object]
+
+
+@dataclass(frozen=True)
+class TaskActionResponse:
+    task_id: str
+    status: str
     payload: dict[str, object]
 
 
@@ -978,6 +986,20 @@ def parse_cancel_response_payload(payload: object) -> CancelResponse:
     )
 
 
+def parse_task_action_response_payload(payload: object) -> TaskActionResponse:
+    if not isinstance(payload, dict):
+        raise click.ClickException("MinerU API returned an invalid task action payload")
+    task_id = payload.get("task_id")
+    status = payload.get("status")
+    if not isinstance(task_id, str) or not isinstance(status, str):
+        raise click.ClickException("MinerU API returned an invalid task action payload")
+    return TaskActionResponse(
+        task_id=task_id,
+        status=status,
+        payload=dict(payload),
+    )
+
+
 async def cancel_parse_task(
     base_url: str,
     task_id: str,
@@ -1020,6 +1042,56 @@ def cancel_parse_task_sync(
     return parse_cancel_response_payload(response.json())
 
 
+async def pause_parse_task(base_url: str, task_id: str) -> TaskActionResponse:
+    return await asyncio.to_thread(
+        pause_parse_task_sync,
+        base_url,
+        task_id,
+    )
+
+
+def pause_parse_task_sync(base_url: str, task_id: str) -> TaskActionResponse:
+    return _post_task_action_sync(base_url, task_id, "pause")
+
+
+async def resume_parse_task(base_url: str, task_id: str) -> TaskActionResponse:
+    return await asyncio.to_thread(
+        resume_parse_task_sync,
+        base_url,
+        task_id,
+    )
+
+
+def resume_parse_task_sync(base_url: str, task_id: str) -> TaskActionResponse:
+    return _post_task_action_sync(base_url, task_id, "resume")
+
+
+def _post_task_action_sync(
+    base_url: str,
+    task_id: str,
+    action: str,
+) -> TaskActionResponse:
+    action_url = f"{base_url}{TASKS_ENDPOINT}/{task_id}/{action}"
+    try:
+        with httpx.Client(timeout=build_http_timeout(), follow_redirects=True) as sync_client:
+            response = sync_client.post(action_url)
+    except httpx.TimeoutException as exc:
+        raise click.ClickException(
+            f"Timed out sending {action} request for parsing task at {action_url}."
+        ) from exc
+    except httpx.RequestError as exc:
+        raise click.ClickException(
+            f"Failed to send {action} request for parsing task at {action_url}: {exc}"
+        ) from exc
+
+    if response.status_code not in {200, 202}:
+        raise click.ClickException(
+            f"Failed to {action} parsing task: "
+            f"{response.status_code} {response_detail(response)}"
+        )
+    return parse_task_action_response_payload(response.json())
+
+
 async def wait_for_task_result(
     client: httpx.AsyncClient,
     submit_response: SubmitResponse,
@@ -1050,7 +1122,7 @@ async def wait_for_task_result(
 
         payload = response.json()
         status = payload.get("status")
-        if status in {"pending", "processing"}:
+        if status in TASK_NOT_READY_STATUSES:
             queued_ahead = payload.get("queued_ahead")
             if not isinstance(queued_ahead, int):
                 queued_ahead = None

--- a/mineru/cli/common.py
+++ b/mineru/cli/common.py
@@ -449,9 +449,16 @@ async def _async_process_vlm(
         pdf_file_name = pdf_file_names[idx]
         local_image_dir, local_md_dir = prepare_env(output_dir, pdf_file_name, parse_method)
         image_writer, md_writer = FileBasedDataWriter(local_image_dir), FileBasedDataWriter(local_md_dir)
+        doc_kwargs = dict(kwargs)
+        if doc_kwargs.get("mineru_task_id") is not None:
+            doc_kwargs["mineru_file_name"] = pdf_file_name
 
         middle_json, infer_result = await aio_vlm_doc_analyze(
-            pdf_bytes, image_writer=image_writer, backend=backend, server_url=server_url, **kwargs,
+            pdf_bytes,
+            image_writer=image_writer,
+            backend=backend,
+            server_url=server_url,
+            **doc_kwargs,
         )
 
         pdf_info = middle_json["pdf_info"]
@@ -490,9 +497,16 @@ def _process_vlm(
         pdf_file_name = pdf_file_names[idx]
         local_image_dir, local_md_dir = prepare_env(output_dir, pdf_file_name, parse_method)
         image_writer, md_writer = FileBasedDataWriter(local_image_dir), FileBasedDataWriter(local_md_dir)
+        doc_kwargs = dict(kwargs)
+        if doc_kwargs.get("mineru_task_id") is not None:
+            doc_kwargs["mineru_file_name"] = pdf_file_name
 
         middle_json, infer_result = vlm_doc_analyze(
-            pdf_bytes, image_writer=image_writer, backend=backend, server_url=server_url, **kwargs,
+            pdf_bytes,
+            image_writer=image_writer,
+            backend=backend,
+            server_url=server_url,
+            **doc_kwargs,
         )
 
         pdf_info = middle_json["pdf_info"]
@@ -591,6 +605,9 @@ async def _async_process_hybrid(
         pdf_file_name = pdf_file_names[idx]
         local_image_dir, local_md_dir = prepare_env(output_dir, pdf_file_name, f"hybrid_{parse_method}")
         image_writer, md_writer = FileBasedDataWriter(local_image_dir), FileBasedDataWriter(local_md_dir)
+        doc_kwargs = dict(kwargs)
+        if doc_kwargs.get("mineru_task_id") is not None:
+            doc_kwargs["mineru_file_name"] = pdf_file_name
 
         middle_json, infer_result = await aio_hybrid_doc_analyze(
             pdf_bytes,
@@ -600,7 +617,7 @@ async def _async_process_hybrid(
             inline_formula_enable=inline_formula_enable,
             server_url=server_url,
             effort=validate_effort(effort),
-            **kwargs,
+            **doc_kwargs,
         )
 
         pdf_info = middle_json["pdf_info"]

--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -1,5 +1,6 @@
 # Copyright (c) Opendatalab. All rights reserved.
 import asyncio
+import json
 import mimetypes
 import multiprocessing
 import os
@@ -59,6 +60,7 @@ from mineru.cli.vlm_preload import (
     maybe_preload_vlm_model,
     split_service_and_model_config,
 )
+from mineru.cli.vllm_cancellation import VllmCancellationRegistry, print_cancel_event
 from mineru.backend.vlm.vlm_analyze import shutdown_cached_models
 from mineru.utils.cli_parser import arg_parse
 from mineru.utils.check_sys_env import is_mac_environment
@@ -79,7 +81,16 @@ TASK_PENDING = "pending"
 TASK_PROCESSING = "processing"
 TASK_COMPLETED = "completed"
 TASK_FAILED = "failed"
-TASK_TERMINAL_STATES = {TASK_COMPLETED, TASK_FAILED}
+TASK_CANCELLED = "cancelled"
+TASK_PAUSE_REQUESTED = "pause_requested"
+TASK_PAUSED = "paused"
+TASK_TERMINAL_STATES = {TASK_COMPLETED, TASK_FAILED, TASK_CANCELLED}
+TASK_NOT_READY_STATES = {
+    TASK_PENDING,
+    TASK_PROCESSING,
+    TASK_PAUSE_REQUESTED,
+    TASK_PAUSED,
+}
 SUPPORTED_UPLOAD_SUFFIXES = pdf_suffixes + image_suffixes + office_suffixes
 RESULT_IMAGE_SUFFIXES = set(image_suffixes) | {"svg"}
 DEFAULT_TASK_RETENTION_SECONDS = 24 * 60 * 60
@@ -169,6 +180,14 @@ class AsyncParseTask:
     started_at: Optional[str] = None
     completed_at: Optional[str] = None
     error: Optional[str] = None
+    cancel_requested: bool = False
+    cancel_requested_at: Optional[str] = None
+    cancelled_at: Optional[str] = None
+    cancel_reason: Optional[str] = None
+    pause_requested_at: Optional[str] = None
+    paused_at: Optional[str] = None
+    resumed_at: Optional[str] = None
+    checkpoint: Optional[dict[str, Any]] = None
 
     def to_status_payload(
         self,
@@ -184,6 +203,14 @@ class AsyncParseTask:
             "started_at": self.started_at,
             "completed_at": self.completed_at,
             "error": self.error,
+            "cancel_requested": self.cancel_requested,
+            "cancel_requested_at": self.cancel_requested_at,
+            "cancelled_at": self.cancelled_at,
+            "cancel_reason": self.cancel_reason,
+            "pause_requested_at": self.pause_requested_at,
+            "paused_at": self.paused_at,
+            "resumed_at": self.resumed_at,
+            "checkpoint": self.checkpoint,
             "status_url": str(
                 request.url_for("get_async_task_status", task_id=self.task_id)
             ),
@@ -198,6 +225,193 @@ class AsyncParseTask:
 
 class TaskWaitAbortedError(RuntimeError):
     """Raised when a synchronous file_parse request cannot keep waiting safely."""
+
+
+class PauseRegistry:
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._pause_requested: set[str] = set()
+        self._resume_events: dict[str, asyncio.Event] = {}
+        self._tasks: dict[str, AsyncParseTask] = {}
+        self._signal_callbacks: dict[str, Any] = {}
+
+    def track_task(self, task: AsyncParseTask, signal_callback: Any | None = None) -> None:
+        with self._lock:
+            self._tasks[task.task_id] = task
+            if signal_callback is not None:
+                self._signal_callbacks[task.task_id] = signal_callback
+            self._resume_events.setdefault(task.task_id, asyncio.Event()).set()
+
+    def request_pause(self, task_id: str) -> None:
+        with self._lock:
+            self._pause_requested.add(task_id)
+            self._resume_events.setdefault(task_id, asyncio.Event()).clear()
+        logger.info(f"[MINERU_PAUSE] request_pause task_id={task_id}")
+
+    def is_pause_requested(self, task_id: str) -> bool:
+        with self._lock:
+            return task_id in self._pause_requested
+
+    def mark_paused(
+        self,
+        task_id: str,
+        checkpoint: dict[str, Any] | None = None,
+    ) -> None:
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if task is not None and not is_task_terminal(task.status):
+                now = utc_now_iso()
+                task.status = TASK_PAUSED
+                task.paused_at = task.paused_at or now
+                task.checkpoint = checkpoint
+            callback = self._signal_callbacks.get(task_id)
+        if callback is not None:
+            callback(task_id)
+        logger.info(f"[MINERU_PAUSE] paused task_id={task_id}")
+
+    async def wait_until_resumed(self, task_id: str) -> None:
+        with self._lock:
+            event = self._resume_events.setdefault(task_id, asyncio.Event())
+        await event.wait()
+
+    def resume(self, task_id: str) -> None:
+        with self._lock:
+            self._pause_requested.discard(task_id)
+            event = self._resume_events.setdefault(task_id, asyncio.Event())
+            event.set()
+            task = self._tasks.get(task_id)
+            if task is not None and task.status == TASK_PAUSED:
+                task.status = TASK_PROCESSING
+                task.resumed_at = utc_now_iso()
+            callback = self._signal_callbacks.get(task_id)
+        if callback is not None:
+            callback(task_id)
+        logger.info(f"[MINERU_PAUSE] resume task_id={task_id}")
+
+    def cleanup_task(self, task_id: str) -> None:
+        with self._lock:
+            self._pause_requested.discard(task_id)
+            self._resume_events.pop(task_id, None)
+            self._tasks.pop(task_id, None)
+            self._signal_callbacks.pop(task_id, None)
+
+
+class CheckpointStore:
+    checkpoint_dir_name = "pause_resume"
+    checkpoint_file_name = "checkpoint.json"
+
+    def write_window_result(
+        self,
+        task_output_dir: str,
+        window_index: int,
+        data: Any,
+    ) -> str:
+        relative_path = f"{self.checkpoint_dir_name}/windows/window-{window_index:04d}.json"
+        self._write_json_atomic(Path(task_output_dir) / relative_path, data)
+        return relative_path
+
+    def write_partial_state(
+        self,
+        task_output_dir: str,
+        middle_json: dict[str, Any],
+        model_output: Any,
+    ) -> dict[str, str]:
+        middle_path = f"{self.checkpoint_dir_name}/middle_json_partial.json"
+        model_path = f"{self.checkpoint_dir_name}/model_output_partial.json"
+        self._write_json_atomic(Path(task_output_dir) / middle_path, middle_json)
+        self._write_json_atomic(Path(task_output_dir) / model_path, model_output)
+        return {
+            "middle_json_partial": middle_path,
+            "model_output_partial": model_path,
+        }
+
+    def write_checkpoint_atomic(
+        self,
+        task_output_dir: str,
+        checkpoint: dict[str, Any],
+    ) -> dict[str, Any]:
+        path = Path(task_output_dir) / self.checkpoint_dir_name / self.checkpoint_file_name
+        self._write_json_atomic(path, checkpoint)
+        return checkpoint
+
+    def load_checkpoint(self, task_output_dir: str) -> dict[str, Any] | None:
+        path = Path(task_output_dir) / self.checkpoint_dir_name / self.checkpoint_file_name
+        if not path.exists():
+            return None
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    def clear_checkpoint(self, task_output_dir: str) -> None:
+        path = Path(task_output_dir) / self.checkpoint_dir_name
+        if path.exists():
+            shutil.rmtree(path)
+
+    def write_processing_checkpoint(
+        self,
+        task_output_dir: str,
+        task_id: str,
+        file_name: str,
+        backend: str,
+        parse_method: str,
+        status: str,
+        page_count: int,
+        window_size: int,
+        window_index: int,
+        window_start: int,
+        window_end: int,
+        middle_json: dict[str, Any],
+        model_output: Any,
+        window_result: Any,
+    ) -> dict[str, Any]:
+        latest_window_path = self.write_window_result(
+            task_output_dir,
+            window_index,
+            window_result,
+        )
+        artifacts = self.write_partial_state(task_output_dir, middle_json, model_output)
+        artifacts["latest_window"] = latest_window_path
+        checkpoint = {
+            "version": 1,
+            "task_id": task_id,
+            "file_name": file_name,
+            "backend": backend,
+            "parse_method": parse_method,
+            "status": status,
+            "phase": "after_window_completed",
+            "page_count": page_count,
+            "window_size": window_size,
+            "completed_windows": window_index + 1,
+            "completed_until_page": window_end + 1,
+            "next_start_page": min(window_end + 2, page_count + 1),
+            "updated_at": utc_now_iso(),
+            "artifacts": artifacts,
+        }
+        logger.info(
+            "[MINERU_PAUSE] checkpoint_written "
+            f"task_id={task_id} file={file_name} window={window_index} "
+            f"completed_until_page={checkpoint['completed_until_page']} "
+            f"next_start_page={checkpoint['next_start_page']}"
+        )
+        return self.write_checkpoint_atomic(task_output_dir, checkpoint)
+
+    def _write_json_atomic(self, path: Path, data: Any) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
+        try:
+            with temp_path.open("w", encoding="utf-8") as handle:
+                json.dump(data, handle, ensure_ascii=False, indent=2, default=str)
+            os.replace(temp_path, path)
+        finally:
+            if temp_path.exists():
+                temp_path.unlink()
+
+
+@dataclass(frozen=True)
+class CancelTaskResult:
+    task: AsyncParseTask
+    abort_count: int
+    aborted_request_ids: list[str]
+    file_name: str | None = None
 
 
 @asynccontextmanager
@@ -824,6 +1038,7 @@ async def run_parse_job(
     uploads: list[StoredUpload],
     request_options: ParseRequestOptions | AsyncParseTask,
     config: dict[str, Any],
+    cancellation_registry: VllmCancellationRegistry | None = None,
 ) -> list[str]:
     pdf_file_names, pdf_bytes_list = await asyncio.to_thread(load_parse_inputs, uploads)
     actual_lang_list = normalize_lang_list(request_options.lang_list, len(pdf_file_names))
@@ -857,6 +1072,15 @@ async def run_parse_job(
             "client_side_output_generation",
             False,
         ),
+        mineru_task_id=getattr(request_options, "task_id", None),
+        mineru_cancellation_registry=(
+            cancellation_registry
+            or getattr(request_options, "mineru_cancellation_registry", None)
+        ),
+        mineru_pause_registry=getattr(request_options, "mineru_pause_registry", None),
+        mineru_checkpoint_store=getattr(request_options, "mineru_checkpoint_store", None),
+        mineru_task_output_dir=output_dir,
+        mineru_parse_method=request_options.parse_method,
         **config,
     )
 
@@ -932,6 +1156,10 @@ class AsyncTaskManager:
         self.dispatcher_task: Optional[asyncio.Task[Any]] = None
         self.cleanup_task: Optional[asyncio.Task[Any]] = None
         self.active_tasks: set[asyncio.Task[Any]] = set()
+        self.active_processors_by_task_id: dict[str, asyncio.Task[Any]] = {}
+        self.cancellation_registry = VllmCancellationRegistry()
+        self.pause_registry = PauseRegistry()
+        self.checkpoint_store = CheckpointStore()
         self.last_worker_error: Optional[str] = None
         self.is_shutting_down = False
         self.task_retention_seconds = get_task_retention_seconds()
@@ -975,12 +1203,14 @@ class AsyncTaskManager:
         if pending:
             await asyncio.gather(*pending, return_exceptions=True)
         self.active_tasks.clear()
+        self.active_processors_by_task_id.clear()
 
     async def submit(self, task: AsyncParseTask) -> None:
         task.submit_order = self._next_submit_order
         self._next_submit_order += 1
         self.tasks[task.task_id] = task
         self.task_events[task.task_id] = asyncio.Event()
+        self.pause_registry.track_task(task, self._signal_task_event)
         await self.queue.put(task.task_id)
 
     def get(self, task_id: str) -> Optional[AsyncParseTask]:
@@ -1008,9 +1238,119 @@ class AsyncTaskManager:
         task: AsyncParseTask,
         request: Request,
     ) -> dict[str, Any]:
-        return task.to_status_payload(
+        payload = task.to_status_payload(
             request,
             queued_ahead=self.get_queued_ahead(task.task_id),
+        )
+        file_status = self.cancellation_registry.build_file_status(
+            task.task_id,
+            task.file_names,
+        )
+        payload["files"] = file_status
+        payload["active_vllm_request_ids"] = sorted(
+            request_id
+            for status in file_status.values()
+            for request_id in status["active_vllm_request_ids"]
+        )
+        if task.checkpoint is None:
+            task.checkpoint = self.checkpoint_store.load_checkpoint(task.output_dir)
+            payload["checkpoint"] = task.checkpoint
+        return payload
+
+    async def pause_task(self, task_id: str) -> AsyncParseTask:
+        task = self.tasks.get(task_id)
+        if task is None:
+            raise KeyError(task_id)
+        if task.backend == "pipeline":
+            raise ValueError("Pipeline backend does not support pause/resume yet")
+        if is_task_terminal(task.status):
+            raise ValueError("Terminal task cannot be paused")
+        if task.status == TASK_PAUSED:
+            return task
+        if task.status not in (TASK_PENDING, TASK_PROCESSING, TASK_PAUSE_REQUESTED):
+            raise ValueError(f"Task cannot be paused from status: {task.status}")
+
+        now = utc_now_iso()
+        task.pause_requested_at = task.pause_requested_at or now
+        task.status = TASK_PAUSE_REQUESTED
+        self.pause_registry.track_task(task, self._signal_task_event)
+        self.pause_registry.request_pause(task_id)
+        self._signal_task_event(task_id)
+        return task
+
+    async def resume_task(self, task_id: str) -> AsyncParseTask:
+        task = self.tasks.get(task_id)
+        if task is None:
+            raise KeyError(task_id)
+        if is_task_terminal(task.status):
+            raise ValueError("Terminal task cannot be resumed")
+        if task.status != TASK_PAUSED:
+            raise ValueError(f"Task cannot be resumed from status: {task.status}")
+        self.pause_registry.track_task(task, self._signal_task_event)
+        self.pause_registry.resume(task_id)
+        self._signal_task_event(task_id)
+        return task
+
+    def _clear_task_checkpoint(self, task: AsyncParseTask) -> None:
+        task.checkpoint = None
+        self.checkpoint_store.clear_checkpoint(task.output_dir)
+
+    async def cancel_task(
+        self,
+        task_id: str,
+        file_name: str | None = None,
+        reason: str = "Task cancellation requested",
+    ) -> CancelTaskResult:
+        task = self.tasks.get(task_id)
+        if task is None:
+            raise KeyError(task_id)
+        if file_name is not None and file_name not in task.file_names:
+            raise ValueError(f"File not found in task: {file_name}")
+
+        if file_name is None:
+            self.cancellation_registry.mark_task_cancel_requested(task_id)
+        else:
+            self.cancellation_registry.mark_file_cancel_requested(task_id, file_name)
+
+        aborted_request_ids = await self.cancellation_registry.abort_requests(
+            task_id,
+            file_name,
+        )
+        abort_count = len(aborted_request_ids)
+
+        if not is_task_terminal(task.status):
+            now = utc_now_iso()
+            task.cancel_requested = True
+            task.cancel_requested_at = task.cancel_requested_at or now
+            task.cancel_reason = reason
+            task.status = TASK_CANCELLED
+            task.cancelled_at = now
+            task.completed_at = now
+            task.error = reason
+            self._clear_task_checkpoint(task)
+            processor = self.active_processors_by_task_id.get(task_id)
+            if processor is not None and not processor.done():
+                processor.cancel()
+            self._signal_task_event(task_id)
+
+        logger.info(
+            "Parse task cancellation requested: "
+            f"task_id={task_id}, file={file_name or '*'}, "
+            f"abort_count={abort_count}, vllm_request_ids={aborted_request_ids}"
+        )
+        print_cancel_event(
+            "cancel_summary",
+            task_id=task_id,
+            file=file_name or "*",
+            status=task.status,
+            abort_count=abort_count,
+            active_after=0,
+        )
+        return CancelTaskResult(
+            task=task,
+            abort_count=abort_count,
+            aborted_request_ids=aborted_request_ids,
+            file_name=file_name,
         )
 
     async def wait_for_terminal_state(self, task_id: str) -> AsyncParseTask:
@@ -1059,8 +1399,11 @@ class AsyncTaskManager:
         stats = {
             TASK_PENDING: 0,
             TASK_PROCESSING: 0,
+            TASK_PAUSE_REQUESTED: 0,
+            TASK_PAUSED: 0,
             TASK_COMPLETED: 0,
             TASK_FAILED: 0,
+            TASK_CANCELLED: 0,
         }
         for task in self.tasks.values():
             if task.status in stats:
@@ -1102,6 +1445,7 @@ class AsyncTaskManager:
                     name=f"mineru-fastapi-task-{task_id}",
                 )
                 self.active_tasks.add(processor)
+                self.active_processors_by_task_id[task_id] = processor
                 processor.add_done_callback(self._on_processor_done)
                 self.queue.task_done()
         except asyncio.CancelledError:
@@ -1126,6 +1470,9 @@ class AsyncTaskManager:
 
     def _on_processor_done(self, processor: asyncio.Task[Any]) -> None:
         self.active_tasks.discard(processor)
+        for task_id, active_processor in list(self.active_processors_by_task_id.items()):
+            if active_processor is processor:
+                self.active_processors_by_task_id.pop(task_id, None)
         if processor.cancelled():
             return
         exception = processor.exception()
@@ -1137,6 +1484,13 @@ class AsyncTaskManager:
         task = self.tasks.get(task_id)
         if task is None:
             return
+        if task.cancel_requested or task.status == TASK_CANCELLED:
+            task.status = TASK_CANCELLED
+            now = utc_now_iso()
+            task.cancelled_at = task.cancelled_at or now
+            task.completed_at = task.completed_at or now
+            self._signal_task_event(task_id)
+            return
 
         try:
             if _request_semaphore is not None:
@@ -1145,8 +1499,38 @@ class AsyncTaskManager:
             else:
                 await self._run_task(task)
         except asyncio.CancelledError:
+            if task.cancel_requested or task.status == TASK_CANCELLED:
+                now = utc_now_iso()
+                task.status = TASK_CANCELLED
+                task.cancelled_at = task.cancelled_at or now
+                task.completed_at = task.completed_at or now
+                task.error = task.cancel_reason or "Task cancellation requested"
+                self._signal_task_event(task_id)
+                logger.info(f"Async task cancelled: {task_id}")
+                print_cancel_event(
+                    "task_cancelled",
+                    task_id=task_id,
+                    status=task.status,
+                    error=task.error,
+                )
+                return
             raise
         except Exception as exc:
+            if task.cancel_requested or task.status == TASK_CANCELLED:
+                now = utc_now_iso()
+                task.status = TASK_CANCELLED
+                task.cancelled_at = task.cancelled_at or now
+                task.completed_at = task.completed_at or now
+                task.error = task.cancel_reason or "Task cancellation requested"
+                self._signal_task_event(task_id)
+                logger.info(f"Async task cancelled after worker error: {task_id}")
+                print_cancel_event(
+                    "task_cancelled_after_worker_error",
+                    task_id=task_id,
+                    status=task.status,
+                    error=task.error,
+                )
+                return
             task.status = TASK_FAILED
             task.error = str(exc)
             task.completed_at = utc_now_iso()
@@ -1154,8 +1538,14 @@ class AsyncTaskManager:
             logger.exception(f"Async task failed: {task_id}")
 
     async def _run_task(self, task: AsyncParseTask) -> None:
-        task.status = TASK_PROCESSING
-        task.started_at = utc_now_iso()
+        if task.cancel_requested or task.status == TASK_CANCELLED:
+            task.status = TASK_CANCELLED
+            task.completed_at = task.completed_at or utc_now_iso()
+            self._signal_task_event(task.task_id)
+            return
+        if task.status != TASK_PAUSE_REQUESTED:
+            task.status = TASK_PROCESSING
+        task.started_at = task.started_at or utc_now_iso()
         task.error = None
 
         uploads = [
@@ -1171,12 +1561,24 @@ class AsyncTaskManager:
             )
         ]
         config = getattr(self.app.state, "config", {})
+        task.mineru_cancellation_registry = self.cancellation_registry
+        task.mineru_pause_registry = self.pause_registry
+        task.mineru_checkpoint_store = self.checkpoint_store
+        self.pause_registry.track_task(task, self._signal_task_event)
         await run_parse_job(
             output_dir=task.output_dir,
             uploads=uploads,
             request_options=task,
             config=config,
         )
+        if task.cancel_requested or task.status == TASK_CANCELLED:
+            now = utc_now_iso()
+            task.status = TASK_CANCELLED
+            task.cancelled_at = task.cancelled_at or now
+            task.completed_at = task.completed_at or now
+            task.error = task.cancel_reason or "Task cancellation requested"
+            self._signal_task_event(task.task_id)
+            return
         task.status = TASK_COMPLETED
         task.completed_at = utc_now_iso()
         self._signal_task_event(task.task_id)
@@ -1200,11 +1602,13 @@ class AsyncTaskManager:
             if task_event is not None:
                 task_event.set()
             cleanup_file(task.output_dir)
+            self.pause_registry.cleanup_task(task_id)
+            self.cancellation_registry.cleanup_task(task_id)
             logger.info(f"Cleaned expired async task: {task_id}")
         return len(expired_task_ids)
 
     def _is_task_expired(self, task: AsyncParseTask, now: datetime) -> bool:
-        if task.status not in (TASK_COMPLETED, TASK_FAILED):
+        if task.status not in TASK_TERMINAL_STATES:
             return False
         if not task.completed_at:
             return False
@@ -1261,8 +1665,16 @@ async def parse_pdf(
         return JSONResponse(
             status_code=409,
             content={
-                **task.to_status_payload(http_request),
+                **task_manager.build_status_payload(task, http_request),
                 "message": "Task execution failed",
+            },
+        )
+    if task.status == TASK_CANCELLED:
+        return JSONResponse(
+            status_code=409,
+            content={
+                **task_manager.build_status_payload(task, http_request),
+                "message": "Task execution cancelled",
             },
         )
 
@@ -1302,6 +1714,77 @@ async def get_async_task_status(task_id: str, request: Request):
     return task_manager.build_status_payload(task, request)
 
 
+def build_cancel_response(
+    cancel_result: CancelTaskResult,
+    request: Request,
+    task_manager: AsyncTaskManager,
+) -> JSONResponse:
+    payload = task_manager.build_status_payload(cancel_result.task, request)
+    payload.update(
+        {
+            "message": "Task cancellation requested",
+            "abort_count": cancel_result.abort_count,
+            "aborted_vllm_request_ids": cancel_result.aborted_request_ids,
+        }
+    )
+    if cancel_result.file_name is not None:
+        payload["cancelled_file_name"] = cancel_result.file_name
+    return JSONResponse(status_code=202, content=payload)
+
+
+@app.post(path="/tasks/{task_id}/cancel", name="cancel_async_task")
+async def cancel_async_task(task_id: str, request: Request):
+    task_manager = get_task_manager()
+    try:
+        cancel_result = await task_manager.cancel_task(task_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return build_cancel_response(cancel_result, request, task_manager)
+
+
+@app.post(path="/tasks/{task_id}/pause", name="pause_async_task")
+async def pause_async_task(task_id: str, request: Request):
+    task_manager = get_task_manager()
+    try:
+        task = await task_manager.pause_task(task_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Task not found")
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    payload = task_manager.build_status_payload(task, request)
+    payload["message"] = "Pause requested, task will pause after current processing window"
+    return JSONResponse(status_code=202, content=payload)
+
+
+@app.post(path="/tasks/{task_id}/resume", name="resume_async_task")
+async def resume_async_task(task_id: str, request: Request):
+    task_manager = get_task_manager()
+    try:
+        task = await task_manager.resume_task(task_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Task not found")
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    payload = task_manager.build_status_payload(task, request)
+    checkpoint = payload.get("checkpoint") or {}
+    payload["message"] = "Task resumed"
+    if "next_start_page" in checkpoint:
+        payload["resume_from_page"] = checkpoint["next_start_page"]
+    return JSONResponse(status_code=202, content=payload)
+
+
+@app.post(path="/tasks/{task_id}/files/{file_name}/cancel", name="cancel_async_task_file")
+async def cancel_async_task_file(task_id: str, file_name: str, request: Request):
+    task_manager = get_task_manager()
+    try:
+        cancel_result = await task_manager.cancel_task(task_id, file_name=file_name)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Task not found")
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return build_cancel_response(cancel_result, request, task_manager)
+
+
 @app.get(path="/tasks/{task_id}/result", name="get_async_task_result")
 async def get_async_task_result(
     task_id: str,
@@ -1313,11 +1796,11 @@ async def get_async_task_result(
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found")
 
-    if task.status in (TASK_PENDING, TASK_PROCESSING):
+    if task.status in TASK_NOT_READY_STATES:
         return JSONResponse(
             status_code=202,
             content={
-                **task.to_status_payload(request),
+                **task_manager.build_status_payload(task, request),
                 "message": "Task result is not ready yet",
             },
         )
@@ -1326,8 +1809,16 @@ async def get_async_task_result(
         return JSONResponse(
             status_code=409,
             content={
-                **task.to_status_payload(request),
+                **task_manager.build_status_payload(task, request),
                 "message": "Task execution failed",
+            },
+        )
+    if task.status == TASK_CANCELLED:
+        return JSONResponse(
+            status_code=409,
+            content={
+                **task_manager.build_status_payload(task, request),
+                "message": "Task execution cancelled",
             },
         )
 

--- a/mineru/cli/vllm_cancellation.py
+++ b/mineru/cli/vllm_cancellation.py
@@ -1,0 +1,316 @@
+# Copyright (c) Opendatalab. All rights reserved.
+import asyncio
+import inspect
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from threading import RLock
+from typing import Any, Iterator
+
+from loguru import logger
+
+
+def print_cancel_event(event: str, **fields: Any) -> None:
+    field_text = " ".join(
+        f"{key}={value}" for key, value in fields.items() if value is not None
+    )
+    message = f"[MINERU_CANCEL] event={event}"
+    if field_text:
+        message = f"{message} {field_text}"
+    print(message, flush=True)
+
+
+class VllmRequestCancelled(asyncio.CancelledError):
+    pass
+
+
+@dataclass(frozen=True)
+class VllmRequestContext:
+    registry: "VllmCancellationRegistry"
+    task_id: str
+    file_name: str
+
+
+_current_context: ContextVar[VllmRequestContext | None] = ContextVar(
+    "mineru_vllm_request_context",
+    default=None,
+)
+_current_http_request_id: ContextVar[str | None] = ContextVar(
+    "mineru_http_vllm_request_id",
+    default=None,
+)
+
+
+@contextmanager
+def vllm_request_context(
+    registry: "VllmCancellationRegistry | None",
+    task_id: str | None,
+    file_name: str | None,
+) -> Iterator[None]:
+    if registry is None or task_id is None or file_name is None:
+        yield
+        return
+    token = _current_context.set(
+        VllmRequestContext(
+            registry=registry,
+            task_id=task_id,
+            file_name=file_name,
+        )
+    )
+    try:
+        yield
+    finally:
+        _current_context.reset(token)
+
+
+@dataclass
+class RegisteredVllmRequest:
+    task_id: str
+    file_name: str
+    request_id: str
+    abort_handle: Any
+
+
+class VllmCancellationRegistry:
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._requests: dict[str, RegisteredVllmRequest] = {}
+        self._requests_by_task_file: dict[tuple[str, str], set[str]] = {}
+        self._cancelled_files: set[tuple[str, str]] = set()
+        self._cancelled_tasks: set[str] = set()
+
+    def mark_task_cancel_requested(self, task_id: str) -> None:
+        with self._lock:
+            self._cancelled_tasks.add(task_id)
+        logger.info(f"Cancel requested for mineru_task_id={task_id}")
+        print_cancel_event("cancel_requested", task_id=task_id, file="*")
+
+    def mark_file_cancel_requested(self, task_id: str, file_name: str) -> None:
+        with self._lock:
+            self._cancelled_files.add((task_id, file_name))
+        logger.info(f"Cancel requested for mineru_task_id={task_id}, file={file_name}")
+        print_cancel_event("cancel_requested", task_id=task_id, file=file_name)
+
+    def is_task_cancel_requested(self, task_id: str) -> bool:
+        with self._lock:
+            return task_id in self._cancelled_tasks
+
+    def is_file_cancel_requested(self, task_id: str, file_name: str) -> bool:
+        with self._lock:
+            return task_id in self._cancelled_tasks or (task_id, file_name) in self._cancelled_files
+
+    def register_request(
+        self,
+        task_id: str,
+        file_name: str,
+        request_id: str,
+        abort_handle: Any,
+    ) -> None:
+        with self._lock:
+            if task_id in self._cancelled_tasks or (task_id, file_name) in self._cancelled_files:
+                raise VllmRequestCancelled(
+                    f"VLLM request blocked because file was cancelled: task_id={task_id}, file={file_name}"
+                )
+            self._requests[request_id] = RegisteredVllmRequest(
+                task_id=task_id,
+                file_name=file_name,
+                request_id=request_id,
+                abort_handle=abort_handle,
+            )
+            self._requests_by_task_file.setdefault((task_id, file_name), set()).add(request_id)
+        logger.info(
+            "Registered VLLM request: "
+            f"mineru_task_id={task_id}, file={file_name}, vllm_request_id={request_id}"
+        )
+
+    def unregister_request(self, request_id: str) -> None:
+        with self._lock:
+            record = self._requests.pop(request_id, None)
+            if record is None:
+                return
+            request_ids = self._requests_by_task_file.get((record.task_id, record.file_name))
+            if request_ids is not None:
+                request_ids.discard(request_id)
+                if not request_ids:
+                    self._requests_by_task_file.pop((record.task_id, record.file_name), None)
+        logger.info(
+            "Unregistered VLLM request: "
+            f"mineru_task_id={record.task_id}, file={record.file_name}, vllm_request_id={request_id}"
+        )
+
+    def get_active_request_ids(self, task_id: str, file_name: str | None = None) -> list[str]:
+        with self._lock:
+            if file_name is not None:
+                return sorted(self._requests_by_task_file.get((task_id, file_name), set()))
+            return sorted(
+                request_id
+                for request_id, record in self._requests.items()
+                if record.task_id == task_id
+            )
+
+    async def abort_requests(self, task_id: str, file_name: str | None = None) -> list[str]:
+        request_ids = self.get_active_request_ids(task_id, file_name)
+        aborted: list[str] = []
+        for request_id in request_ids:
+            with self._lock:
+                record = self._requests.get(request_id)
+            if record is None:
+                continue
+            abort = getattr(record.abort_handle, "abort", None)
+            if not callable(abort):
+                logger.warning(
+                    "Cannot abort VLLM request because abort() is unavailable: "
+                    f"mineru_task_id={record.task_id}, file={record.file_name}, "
+                    f"vllm_request_id={request_id}"
+                )
+                continue
+            result = abort(request_id)
+            if inspect.isawaitable(result):
+                await result
+            aborted.append(request_id)
+            self.unregister_request(request_id)
+            logger.info(
+                "Aborted VLLM request: "
+                f"mineru_task_id={record.task_id}, file={record.file_name}, "
+                f"vllm_request_id={request_id}"
+            )
+        return aborted
+
+    def build_file_status(self, task_id: str, file_names: list[str]) -> dict[str, dict[str, Any]]:
+        with self._lock:
+            return {
+                file_name: {
+                    "cancel_requested": task_id in self._cancelled_tasks
+                    or (task_id, file_name) in self._cancelled_files,
+                    "active_vllm_request_ids": sorted(
+                        self._requests_by_task_file.get((task_id, file_name), set())
+                    ),
+                }
+                for file_name in file_names
+            }
+
+    def cleanup_task(self, task_id: str) -> None:
+        with self._lock:
+            for request_id, record in list(self._requests.items()):
+                if record.task_id == task_id:
+                    self._requests.pop(request_id, None)
+                    self._requests_by_task_file.get((record.task_id, record.file_name), set()).discard(request_id)
+            for key, request_ids in list(self._requests_by_task_file.items()):
+                if key[0] == task_id or not request_ids:
+                    self._requests_by_task_file.pop(key, None)
+            self._cancelled_tasks.discard(task_id)
+            for key in list(self._cancelled_files):
+                if key[0] == task_id:
+                    self._cancelled_files.discard(key)
+
+
+def patch_vllm_async_llm_for_cancellation(vllm_async_llm: Any) -> None:
+    if vllm_async_llm is None or getattr(vllm_async_llm, "_mineru_cancel_patch", False):
+        return
+
+    original_generate = vllm_async_llm.generate
+
+    def generate_with_tracking(*args: Any, **kwargs: Any):
+        request_id = kwargs.get("request_id")
+        context = _current_context.get()
+        if context is None or not isinstance(request_id, str):
+            return original_generate(*args, **kwargs)
+
+        context.registry.register_request(
+            task_id=context.task_id,
+            file_name=context.file_name,
+            request_id=request_id,
+            abort_handle=vllm_async_llm,
+        )
+
+        async def tracked_iterator():
+            try:
+                async for output in original_generate(*args, **kwargs):
+                    yield output
+            finally:
+                context.registry.unregister_request(request_id)
+
+        return tracked_iterator()
+
+    vllm_async_llm.generate = generate_with_tracking
+    vllm_async_llm._mineru_cancel_patch = True
+    logger.info("Enabled VLLM request cancellation tracking on AsyncLLM")
+
+
+class HttpVllmRequestAbortHandle:
+    def __init__(self, client: Any) -> None:
+        self._client = client
+        self._lock = RLock()
+        self._tasks: dict[str, asyncio.Task[Any]] = {}
+
+    def register_task(self, request_id: str, task: asyncio.Task[Any] | None) -> None:
+        if task is None:
+            return
+        with self._lock:
+            self._tasks[request_id] = task
+
+    def unregister_task(self, request_id: str) -> None:
+        with self._lock:
+            self._tasks.pop(request_id, None)
+
+    async def abort(self, request_id: str) -> None:
+        with self._lock:
+            task = self._tasks.get(request_id)
+        if task is not None and not task.done():
+            task.cancel()
+            logger.info(f"Cancelled local HTTP VLLM request task: vllm_request_id={request_id}")
+        logger.info(
+            "Skipped VLLM HTTP server-side cancel because /v1/chat/completions "
+            f"request_id is not a /v1/responses response_id: vllm_request_id={request_id}"
+        )
+
+
+def patch_http_vlm_client_for_cancellation(vlm_client: Any) -> None:
+    if vlm_client is None or getattr(vlm_client, "_mineru_cancel_patch", False):
+        return
+    if not all(hasattr(vlm_client, attr) for attr in ("aio_predict", "build_request_body")):
+        return
+    if not hasattr(vlm_client, "chat_url"):
+        return
+
+    original_aio_predict = vlm_client.aio_predict
+    original_build_request_body = vlm_client.build_request_body
+    abort_handle = HttpVllmRequestAbortHandle(vlm_client)
+
+    def build_request_body_with_request_id(*args: Any, **kwargs: Any):
+        request_body = original_build_request_body(*args, **kwargs)
+        request_id = _current_http_request_id.get()
+        if request_id:
+            request_body["request_id"] = request_id
+        return request_body
+
+    async def aio_predict_with_tracking(*args: Any, **kwargs: Any):
+        context = _current_context.get()
+        if context is None:
+            return await original_aio_predict(*args, **kwargs)
+
+        short_task_id = "".join(
+            char for char in context.task_id if char.isascii() and char.isalnum()
+        )[:12] or "task"
+        request_id = f"mineru-{short_task_id}-{uuid.uuid4().hex[:12]}"
+        current_task = asyncio.current_task()
+        abort_handle.register_task(request_id, current_task)
+        context.registry.register_request(
+            task_id=context.task_id,
+            file_name=context.file_name,
+            request_id=request_id,
+            abort_handle=abort_handle,
+        )
+        token = _current_http_request_id.set(request_id)
+        try:
+            return await original_aio_predict(*args, **kwargs)
+        finally:
+            _current_http_request_id.reset(token)
+            abort_handle.unregister_task(request_id)
+            context.registry.unregister_request(request_id)
+
+    vlm_client.build_request_body = build_request_body_with_request_id
+    vlm_client.aio_predict = aio_predict_with_tracking
+    vlm_client._mineru_cancel_patch = True
+    logger.info("Enabled VLLM request cancellation tracking on HTTP VLM client")

--- a/tests/unittest/test_parse_cancel.py
+++ b/tests/unittest/test_parse_cancel.py
@@ -280,6 +280,98 @@ class ParseCancelPayloadTests(unittest.TestCase):
         self.assertEqual(response.abort_count, 2)
         self.assertEqual(response.aborted_vllm_request_ids, ("req-1", "req-2"))
 
+    def test_api_client_parses_task_action_response_payload(self):
+        response = api_client.parse_task_action_response_payload(
+            {
+                "task_id": "task-1",
+                "status": "paused",
+                "checkpoint": {"next_start_page": 10},
+            }
+        )
+
+        self.assertEqual(response.task_id, "task-1")
+        self.assertEqual(response.status, "paused")
+        self.assertEqual(response.payload["checkpoint"], {"next_start_page": 10})
+
+    def test_api_client_posts_pause_and_resume_task_actions(self):
+        calls: list[str] = []
+
+        class RecordingClient:
+            def __init__(self, **_kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return None
+
+            def post(self, url):
+                calls.append(url)
+                return api_client.httpx.Response(
+                    202,
+                    json={"task_id": "task-1", "status": "processing"},
+                    request=api_client.httpx.Request("POST", url),
+                )
+
+        original_client = api_client.httpx.Client
+        api_client.httpx.Client = RecordingClient
+        try:
+            pause = api_client.pause_parse_task_sync("http://mineru.local", "task-1")
+            resume = api_client.resume_parse_task_sync("http://mineru.local", "task-1")
+        finally:
+            api_client.httpx.Client = original_client
+
+        self.assertEqual(
+            calls,
+            [
+                "http://mineru.local/tasks/task-1/pause",
+                "http://mineru.local/tasks/task-1/resume",
+            ],
+        )
+        self.assertEqual(pause.task_id, "task-1")
+        self.assertEqual(resume.task_id, "task-1")
+
+
+class ParseTaskActionClientTests(unittest.IsolatedAsyncioTestCase):
+    async def test_wait_for_task_result_treats_pause_states_as_not_ready(self):
+        statuses = ["pause_requested", "paused", "processing", "completed"]
+
+        class PollingClient:
+            async def get(self, url):
+                status = statuses.pop(0)
+                return api_client.httpx.Response(
+                    200,
+                    json={"status": status},
+                    request=api_client.httpx.Request("GET", url),
+                )
+
+        seen_statuses: list[str] = []
+        snapshots: list[api_client.TaskStatusSnapshot] = []
+        original_interval = api_client.TASK_STATUS_POLL_INTERVAL_SECONDS
+        api_client.TASK_STATUS_POLL_INTERVAL_SECONDS = 0
+        try:
+            await api_client.wait_for_task_result(
+                PollingClient(),
+                api_client.SubmitResponse(
+                    task_id="task-1",
+                    status_url="http://mineru.local/tasks/task-1",
+                    result_url="http://mineru.local/tasks/task-1/result",
+                ),
+                "sample",
+                status_callback=seen_statuses.append,
+                status_snapshot_callback=snapshots.append,
+                timeout_seconds=5,
+            )
+        finally:
+            api_client.TASK_STATUS_POLL_INTERVAL_SECONDS = original_interval
+
+        self.assertEqual(seen_statuses, ["pause_requested", "paused", "processing"])
+        self.assertEqual(
+            [snapshot.status for snapshot in snapshots],
+            ["pause_requested", "paused", "processing"],
+        )
+
 
 class ParsePauseRegistryTests(unittest.IsolatedAsyncioTestCase):
     async def test_pause_registry_blocks_until_resume_and_cleans_up(self):

--- a/tests/unittest/test_parse_cancel.py
+++ b/tests/unittest/test_parse_cancel.py
@@ -1,0 +1,544 @@
+import asyncio
+import json
+import os
+import tempfile
+import unittest
+
+from fastapi import BackgroundTasks
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from mineru.cli import api_client, fast_api
+from mineru.backend.hybrid import hybrid_analyze
+from mineru.backend.vlm import vlm_analyze
+from mineru.cli.vllm_cancellation import (
+    VllmCancellationRegistry,
+    patch_http_vlm_client_for_cancellation,
+    vllm_request_context,
+)
+
+
+class FakeRequest:
+    def url_for(self, name, **path_params):
+        task_id = path_params["task_id"]
+        if name.endswith("status"):
+            return f"http://testserver/tasks/{task_id}"
+        if name.endswith("result"):
+            return f"http://testserver/tasks/{task_id}/result"
+        raise AssertionError(f"unexpected route name: {name}")
+
+
+class AbortHandle:
+    def __init__(self):
+        self.aborted: list[str] = []
+
+    async def abort(self, request_id: str):
+        self.aborted.append(request_id)
+
+
+def make_task(task_id="task-1", status=None, backend="vlm-vllm-engine"):
+    return fast_api.AsyncParseTask(
+        task_id=task_id,
+        status=status or fast_api.TASK_PENDING,
+        backend=backend,
+        file_names=["sample"],
+        created_at="2026-06-25T00:00:00+00:00",
+        output_dir="/tmp/mineru-test-output",
+        effort="medium",
+        parse_method="auto",
+        lang_list=["ch"],
+        formula_enable=True,
+        table_enable=True,
+        image_analysis=True,
+        server_url=None,
+        return_md=True,
+        return_middle_json=True,
+        return_model_output=True,
+        return_content_list=True,
+        return_images=True,
+        response_format_zip=False,
+        return_original_file=False,
+        client_side_output_generation=False,
+        start_page_id=0,
+        end_page_id=99999,
+        upload_names=["sample.pdf"],
+        uploads=["/tmp/sample.pdf"],
+    )
+
+
+class ParseCancelTests(unittest.IsolatedAsyncioTestCase):
+    async def test_cancel_pending_task_marks_cancelled_and_terminal(self):
+        manager = fast_api.AsyncTaskManager(FastAPI())
+        task = make_task()
+        manager.tasks[task.task_id] = task
+        manager.task_events[task.task_id] = asyncio.Event()
+
+        result = await manager.cancel_task(task.task_id)
+
+        self.assertEqual(result.task.status, fast_api.TASK_CANCELLED)
+        self.assertIsNotNone(result.task.completed_at)
+        self.assertEqual(result.abort_count, 0)
+        self.assertTrue(fast_api.is_task_terminal(result.task.status))
+        self.assertTrue(manager.task_events[task.task_id].is_set())
+
+    async def test_cancel_processing_task_aborts_active_vllm_requests(self):
+        manager = fast_api.AsyncTaskManager(FastAPI())
+        task = make_task(status=fast_api.TASK_PROCESSING)
+        manager.tasks[task.task_id] = task
+        manager.task_events[task.task_id] = asyncio.Event()
+        abort_handle = AbortHandle()
+        manager.cancellation_registry.register_request(
+            task_id=task.task_id,
+            file_name="sample",
+            request_id="vllm-req-1",
+            abort_handle=abort_handle,
+        )
+
+        result = await manager.cancel_task(task.task_id)
+
+        self.assertEqual(result.task.status, fast_api.TASK_CANCELLED)
+        self.assertEqual(result.abort_count, 1)
+        self.assertEqual(result.aborted_request_ids, ["vllm-req-1"])
+        self.assertEqual(abort_handle.aborted, ["vllm-req-1"])
+
+    async def test_cancelled_task_is_not_processed(self):
+        manager = fast_api.AsyncTaskManager(FastAPI())
+        task = make_task(status=fast_api.TASK_CANCELLED)
+        task.cancel_requested = True
+        manager.tasks[task.task_id] = task
+        manager.task_events[task.task_id] = asyncio.Event()
+
+        original_run_parse_job = fast_api.run_parse_job
+
+        async def fail_if_called(**kwargs):
+            raise AssertionError("cancelled task should not be parsed")
+
+        fast_api.run_parse_job = fail_if_called
+        try:
+            await manager._process_task(task.task_id)
+        finally:
+            fast_api.run_parse_job = original_run_parse_job
+
+        self.assertEqual(task.status, fast_api.TASK_CANCELLED)
+        self.assertTrue(manager.task_events[task.task_id].is_set())
+
+    async def test_worker_error_after_cancel_stays_cancelled(self):
+        manager = fast_api.AsyncTaskManager(FastAPI())
+        task = make_task(status=fast_api.TASK_PROCESSING)
+        manager.tasks[task.task_id] = task
+        manager.task_events[task.task_id] = asyncio.Event()
+
+        async def fail_after_cancel(task):
+            task.cancel_requested = True
+            task.cancel_reason = "Task cancellation requested"
+            raise RuntimeError("vllm returned 500")
+
+        manager._run_task = fail_after_cancel
+
+        await manager._process_task(task.task_id)
+
+        self.assertEqual(task.status, fast_api.TASK_CANCELLED)
+        self.assertEqual(task.error, "Task cancellation requested")
+        self.assertTrue(manager.task_events[task.task_id].is_set())
+
+    async def test_run_task_keeps_old_run_parse_job_wrapper_signature_compatible(self):
+        manager = fast_api.AsyncTaskManager(FastAPI())
+        task = make_task(status=fast_api.TASK_PENDING)
+        manager.tasks[task.task_id] = task
+        manager.task_events[task.task_id] = asyncio.Event()
+        calls = []
+        original_run_parse_job = fast_api.run_parse_job
+
+        async def old_signature_wrapper(output_dir, uploads, request_options, config):
+            calls.append((output_dir, uploads, request_options, config))
+            self.assertIs(
+                request_options.mineru_cancellation_registry,
+                manager.cancellation_registry,
+            )
+            return ["sample"]
+
+        fast_api.run_parse_job = old_signature_wrapper
+        try:
+            await manager._run_task(task)
+        finally:
+            fast_api.run_parse_job = original_run_parse_job
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(task.status, fast_api.TASK_COMPLETED)
+
+    async def test_http_vlm_client_patch_injects_and_tracks_request_id(self):
+        class FakeHttpClient:
+            chat_url = "http://vllm.test/v1/chat/completions"
+            server_url = ""
+            server_headers = None
+
+            def __init__(self):
+                self.started = asyncio.Event()
+                self.finish = asyncio.Event()
+                self.last_request_body = None
+
+            def build_request_body(self, *args, **kwargs):
+                return {"model": "mineru-test", "messages": []}
+
+            async def aio_predict(self, *args, **kwargs):
+                self.last_request_body = self.build_request_body()
+                self.started.set()
+                await self.finish.wait()
+                return "ok"
+
+        client = FakeHttpClient()
+        registry = VllmCancellationRegistry()
+        patch_http_vlm_client_for_cancellation(client)
+
+        async def run_predict():
+            with vllm_request_context(registry, "task-1", "sample"):
+                return await client.aio_predict()
+
+        task = asyncio.create_task(run_predict())
+        await client.started.wait()
+
+        request_ids = registry.get_active_request_ids("task-1", "sample")
+        self.assertEqual(len(request_ids), 1)
+        self.assertEqual(client.last_request_body["request_id"], request_ids[0])
+        self.assertRegex(request_ids[0], r"^mineru-task1-[0-9a-f]{12}$")
+
+        client.finish.set()
+        self.assertEqual(await task, "ok")
+        self.assertEqual(registry.get_active_request_ids("task-1", "sample"), [])
+
+    async def test_http_vlm_client_abort_cancels_local_request_task(self):
+        class FakeHttpClient:
+            chat_url = "http://vllm.test/v1/chat/completions"
+            server_url = ""
+            server_headers = None
+
+            def __init__(self):
+                self.started = asyncio.Event()
+                self.finish = asyncio.Event()
+
+            def build_request_body(self, *args, **kwargs):
+                return {"model": "mineru-test", "messages": []}
+
+            async def aio_predict(self, *args, **kwargs):
+                self.build_request_body()
+                self.started.set()
+                await self.finish.wait()
+                return "ok"
+
+        client = FakeHttpClient()
+        registry = VllmCancellationRegistry()
+        patch_http_vlm_client_for_cancellation(client)
+
+        async def run_predict():
+            with vllm_request_context(registry, "task-1", "sample"):
+                return await client.aio_predict()
+
+        task = asyncio.create_task(run_predict())
+        await client.started.wait()
+        request_ids = registry.get_active_request_ids("task-1", "sample")
+
+        aborted_request_ids = await registry.abort_requests("task-1", "sample")
+
+        self.assertEqual(aborted_request_ids, request_ids)
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+
+
+class ParseCancelPayloadTests(unittest.TestCase):
+    def test_status_payload_includes_cancellation_and_vllm_request_ids(self):
+        manager = fast_api.AsyncTaskManager(FastAPI())
+        task = make_task(status=fast_api.TASK_PROCESSING)
+        manager.tasks[task.task_id] = task
+        manager.task_events[task.task_id] = asyncio.Event()
+        manager.cancellation_registry.register_request(
+            task_id=task.task_id,
+            file_name="sample",
+            request_id="vllm-req-1",
+            abort_handle=AbortHandle(),
+        )
+
+        payload = manager.build_status_payload(task, FakeRequest())
+
+        self.assertFalse(payload["cancel_requested"])
+        self.assertEqual(
+            payload["files"]["sample"]["active_vllm_request_ids"],
+            ["vllm-req-1"],
+        )
+
+    def test_api_client_parses_cancel_response_payload(self):
+        response = api_client.parse_cancel_response_payload(
+            {
+                "task_id": "task-1",
+                "status": "cancelled",
+                "abort_count": 2,
+                "aborted_vllm_request_ids": ["req-1", "req-2"],
+            }
+        )
+
+        self.assertEqual(response.task_id, "task-1")
+        self.assertEqual(response.status, "cancelled")
+        self.assertEqual(response.abort_count, 2)
+        self.assertEqual(response.aborted_vllm_request_ids, ("req-1", "req-2"))
+
+
+class ParsePauseRegistryTests(unittest.IsolatedAsyncioTestCase):
+    async def test_pause_registry_blocks_until_resume_and_cleans_up(self):
+        registry = fast_api.PauseRegistry()
+        task = make_task(status=fast_api.TASK_PROCESSING)
+        signalled = asyncio.Event()
+        registry.track_task(task, lambda task_id: signalled.set())
+
+        registry.request_pause(task.task_id)
+        self.assertTrue(registry.is_pause_requested(task.task_id))
+
+        checkpoint = {"completed_until_page": 4, "next_start_page": 5}
+        registry.mark_paused(task.task_id, checkpoint)
+        self.assertEqual(task.status, fast_api.TASK_PAUSED)
+        self.assertEqual(task.checkpoint, checkpoint)
+        self.assertTrue(signalled.is_set())
+
+        waiter = asyncio.create_task(registry.wait_until_resumed(task.task_id))
+        await asyncio.sleep(0)
+        self.assertFalse(waiter.done())
+
+        registry.resume(task.task_id)
+        await asyncio.wait_for(waiter, timeout=1)
+        self.assertFalse(registry.is_pause_requested(task.task_id))
+        self.assertEqual(task.status, fast_api.TASK_PROCESSING)
+        self.assertIsNotNone(task.resumed_at)
+
+        registry.cleanup_task(task.task_id)
+        self.assertFalse(registry.is_pause_requested(task.task_id))
+
+
+class ParseCheckpointStoreTests(unittest.TestCase):
+    def test_checkpoint_store_writes_window_partials_and_checkpoint(self):
+        with tempfile.TemporaryDirectory() as output_dir:
+            store = fast_api.CheckpointStore()
+
+            checkpoint = store.write_processing_checkpoint(
+                task_output_dir=output_dir,
+                task_id="task-1",
+                file_name="sample",
+                backend="vlm-http-client",
+                parse_method="auto",
+                status=fast_api.TASK_PAUSED,
+                page_count=10,
+                window_size=4,
+                window_index=1,
+                window_start=4,
+                window_end=7,
+                middle_json={"pdf_info": [{"page_idx": 0}]},
+                model_output=[{"page": 5}],
+                window_result=[{"page": 5}],
+            )
+
+            self.assertEqual(checkpoint["completed_until_page"], 8)
+            self.assertEqual(checkpoint["next_start_page"], 9)
+            self.assertEqual(checkpoint["artifacts"]["latest_window"], "pause_resume/windows/window-0001.json")
+
+            loaded = store.load_checkpoint(output_dir)
+            self.assertEqual(loaded["task_id"], "task-1")
+            self.assertEqual(loaded["status"], fast_api.TASK_PAUSED)
+
+            with open(f"{output_dir}/pause_resume/middle_json_partial.json", encoding="utf-8") as handle:
+                self.assertEqual(json.load(handle), {"pdf_info": [{"page_idx": 0}]})
+            with open(f"{output_dir}/pause_resume/model_output_partial.json", encoding="utf-8") as handle:
+                self.assertEqual(json.load(handle), [{"page": 5}])
+
+    def test_checkpoint_store_clears_pause_resume_artifacts(self):
+        with tempfile.TemporaryDirectory() as output_dir:
+            store = fast_api.CheckpointStore()
+            store.write_processing_checkpoint(
+                task_output_dir=output_dir,
+                task_id="task-1",
+                file_name="sample",
+                backend="vlm-http-client",
+                parse_method="auto",
+                status=fast_api.TASK_PAUSED,
+                page_count=10,
+                window_size=4,
+                window_index=1,
+                window_start=4,
+                window_end=7,
+                middle_json={"pdf_info": [{"page_idx": 0}]},
+                model_output=[{"page": 5}],
+                window_result=[{"page": 5}],
+            )
+
+            store.clear_checkpoint(output_dir)
+
+            self.assertFalse(os.path.exists(f"{output_dir}/pause_resume"))
+
+
+class ParsePauseManagerTests(unittest.IsolatedAsyncioTestCase):
+    async def test_pause_processing_task_marks_pause_requested(self):
+        manager = fast_api.AsyncTaskManager(FastAPI())
+        task = make_task(status=fast_api.TASK_PROCESSING)
+        manager.tasks[task.task_id] = task
+        manager.task_events[task.task_id] = asyncio.Event()
+        manager.pause_registry.track_task(task, manager._signal_task_event)
+
+        result = await manager.pause_task(task.task_id)
+
+        self.assertIs(result, task)
+        self.assertEqual(task.status, fast_api.TASK_PAUSE_REQUESTED)
+        self.assertIsNotNone(task.pause_requested_at)
+        self.assertTrue(manager.pause_registry.is_pause_requested(task.task_id))
+        self.assertTrue(manager.task_events[task.task_id].is_set())
+
+    async def test_resume_paused_task_marks_processing(self):
+        manager = fast_api.AsyncTaskManager(FastAPI())
+        task = make_task(status=fast_api.TASK_PAUSED)
+        task.checkpoint = {"next_start_page": 5}
+        manager.tasks[task.task_id] = task
+        manager.task_events[task.task_id] = asyncio.Event()
+        manager.pause_registry.track_task(task, manager._signal_task_event)
+        manager.pause_registry.request_pause(task.task_id)
+        manager.pause_registry.mark_paused(task.task_id, task.checkpoint)
+
+        result = await manager.resume_task(task.task_id)
+
+        self.assertIs(result, task)
+        self.assertEqual(task.status, fast_api.TASK_PROCESSING)
+        self.assertIsNotNone(task.resumed_at)
+        self.assertFalse(manager.pause_registry.is_pause_requested(task.task_id))
+
+    async def test_pause_terminal_task_is_rejected(self):
+        manager = fast_api.AsyncTaskManager(FastAPI())
+        task = make_task(status=fast_api.TASK_COMPLETED)
+        manager.tasks[task.task_id] = task
+
+        with self.assertRaises(ValueError):
+            await manager.pause_task(task.task_id)
+
+    async def test_cancel_paused_task_clears_checkpoint_artifacts(self):
+        with tempfile.TemporaryDirectory() as output_dir:
+            manager = fast_api.AsyncTaskManager(FastAPI())
+            task = make_task(status=fast_api.TASK_PAUSED)
+            task.output_dir = output_dir
+            task.checkpoint = {"next_start_page": 10}
+            manager.tasks[task.task_id] = task
+            manager.task_events[task.task_id] = asyncio.Event()
+            manager.pause_registry.track_task(task, manager._signal_task_event)
+            manager.checkpoint_store.write_processing_checkpoint(
+                task_output_dir=output_dir,
+                task_id=task.task_id,
+                file_name="sample",
+                backend="vlm-http-client",
+                parse_method="auto",
+                status=fast_api.TASK_PAUSED,
+                page_count=10,
+                window_size=1,
+                window_index=8,
+                window_start=8,
+                window_end=8,
+                middle_json={"pdf_info": [{"page_idx": 8}]},
+                model_output=[{"page": 9}],
+                window_result=[{"page": 9}],
+            )
+
+            result = await manager.cancel_task(task.task_id)
+
+            self.assertEqual(result.task.status, fast_api.TASK_CANCELLED)
+            self.assertIsNone(result.task.checkpoint)
+            self.assertFalse(os.path.exists(f"{output_dir}/pause_resume"))
+
+    async def test_result_endpoint_returns_accepted_for_paused_task(self):
+        manager = fast_api.AsyncTaskManager(FastAPI())
+        task = make_task(status=fast_api.TASK_PAUSED)
+        manager.tasks[task.task_id] = task
+        original_task_manager = getattr(fast_api.app.state, "task_manager", None)
+        fast_api.app.state.task_manager = manager
+        try:
+            response = await fast_api.get_async_task_result(
+                task.task_id,
+                FakeRequest(),
+                BackgroundTasks(),
+            )
+        finally:
+            if original_task_manager is None:
+                delattr(fast_api.app.state, "task_manager")
+            else:
+                fast_api.app.state.task_manager = original_task_manager
+
+        self.assertIsInstance(response, JSONResponse)
+        self.assertEqual(response.status_code, 202)
+
+
+class ParsePauseAnalyzeHookTests(unittest.IsolatedAsyncioTestCase):
+    async def test_vlm_window_hook_writes_checkpoint_and_waits_for_resume(self):
+        with tempfile.TemporaryDirectory() as output_dir:
+            registry = fast_api.PauseRegistry()
+            task = make_task(status=fast_api.TASK_PAUSE_REQUESTED)
+            registry.track_task(task)
+            registry.request_pause(task.task_id)
+
+            hook_task = asyncio.create_task(
+                vlm_analyze._checkpoint_window_and_maybe_pause(
+                    checkpoint_store=fast_api.CheckpointStore(),
+                    pause_registry=registry,
+                    task_output_dir=output_dir,
+                    task_id=task.task_id,
+                    file_name="sample",
+                    backend="http-client",
+                    parse_method="vlm",
+                    page_count=6,
+                    window_size=2,
+                    window_index=0,
+                    window_start=0,
+                    window_end=1,
+                    middle_json={"pdf_info": [{"page_idx": 0}]},
+                    model_output=[{"page": 1}],
+                    window_result=[{"page": 1}],
+                )
+            )
+            await asyncio.sleep(0.05)
+
+            self.assertFalse(hook_task.done())
+            self.assertEqual(task.status, fast_api.TASK_PAUSED)
+            self.assertEqual(task.checkpoint["completed_until_page"], 2)
+
+            registry.resume(task.task_id)
+            await asyncio.wait_for(hook_task, timeout=1)
+            self.assertEqual(task.status, fast_api.TASK_PROCESSING)
+
+    async def test_hybrid_window_hook_writes_checkpoint_and_waits_for_resume(self):
+        with tempfile.TemporaryDirectory() as output_dir:
+            registry = fast_api.PauseRegistry()
+            task = make_task(status=fast_api.TASK_PAUSE_REQUESTED, backend="hybrid-vllm-engine")
+            registry.track_task(task)
+            registry.request_pause(task.task_id)
+
+            hook_task = asyncio.create_task(
+                hybrid_analyze._checkpoint_window_and_maybe_pause(
+                    checkpoint_store=fast_api.CheckpointStore(),
+                    pause_registry=registry,
+                    task_output_dir=output_dir,
+                    task_id=task.task_id,
+                    file_name="sample",
+                    backend="vllm-engine",
+                    parse_method="auto",
+                    page_count=6,
+                    window_size=2,
+                    window_index=0,
+                    window_start=0,
+                    window_end=1,
+                    middle_json={"pdf_info": [{"page_idx": 0}]},
+                    model_output=[{"page": 1}],
+                    window_result=[{"page": 1}],
+                )
+            )
+            await asyncio.sleep(0.05)
+
+            self.assertFalse(hook_task.done())
+            self.assertEqual(task.status, fast_api.TASK_PAUSED)
+            self.assertEqual(task.checkpoint["next_start_page"], 3)
+
+            registry.resume(task.task_id)
+            await asyncio.wait_for(hook_task, timeout=1)
+            self.assertEqual(task.status, fast_api.TASK_PROCESSING)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Async parsing tasks can run for a long time, especially with VLM and hybrid backends. This PR adds task-level soft pause/resume checkpointing and cancellation-aware status handling so operators can pause work at processing-window boundaries, resume later, and keep cancellation state observable from both the server API and the client API.

## Modification

- Add pause/resume task states, checkpoint persistence, and API status payload fields for async parse tasks.
- Add VLLM request cancellation tracking for local async engines and HTTP VLM clients.
- Thread task/file context through VLM and hybrid parse paths so checkpoints and cancellation events stay tied to the correct task.
- Add API client helpers for parse-task actions:
  - cancel: `cancel_parse_task` / `cancel_parse_task_sync`
  - pause: `pause_parse_task` / `pause_parse_task_sync`
  - resume: `resume_parse_task` / `resume_parse_task_sync`
- Add task-action response parsing via `TaskActionResponse` and `parse_task_action_response_payload`.
- Treat `pause_requested` and `paused` as non-terminal wait states in client-side result polling.
- Add unit coverage and Chinese design/local verification runbooks.

## BC-breaking (Optional)

No intentional breaking API changes. Existing completed/failed task flows are preserved; new task states, optional status fields, and client helpers are added for pause/cancel/resume workflows.

## Use cases (Optional)

- Pause a long async parse task after the current processing window completes, inspect the checkpoint, and resume it later.
- Cancel a running parse task while preserving cancelled status even if worker cleanup reports an error.
- Abort tracked VLLM requests associated with a cancelled MinerU task.
- Use the Python client API to cancel, pause, or resume parse tasks from downstream integrations without hand-rolling HTTP requests.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.

## Test Plan

- `/Users/sunmo/Downloads/MinerU-master/.venv/bin/python -m unittest tests.unittest.test_parse_cancel` from the GitHub master-based PR branch: 22 tests passed.
