### PR TITLE
Fix skewed PDF text backfill

### DIFF
--- a/mineru/utils/span_pre_proc.py
+++ b/mineru/utils/span_pre_proc.py
@@ -24,6 +24,7 @@ POST_OCR_FALLBACK_CONTENT_KEY = '_post_ocr_fallback_content'
 POST_OCR_FALLBACK_SCORE_KEY = '_post_ocr_fallback_score'
 POST_OCR_REASON_KEY = '_post_ocr_reason'
 POST_OCR_REASON_PRIVATE_USE_TEXT = 'private_use_text'
+MAX_NATIVE_TEXT_SKEW_DEGREES = 30
 
 
 def __replace_ligatures(text: str):
@@ -137,7 +138,15 @@ def txt_spans_extract(pdf_page, spans, pil_img, scale, all_bboxes, all_discarded
 def _is_supported_rotation(rotation) -> bool:
     """判断 pdftext 旋转角是否属于当前可回填的四个标准方向。"""
     rotation_degrees = math.degrees(rotation)
-    return any(abs(rotation_degrees - angle) < 0.1 for angle in [0, 90, 180, 270])
+    normalized_degrees = rotation_degrees % 360
+    # ponytail: PDF italic/skewed glyphs can report a non-zero horizontal
+    # rotation; widen only the horizontal bands, keep vertical text strict.
+    return (
+        normalized_degrees <= MAX_NATIVE_TEXT_SKEW_DEGREES
+        or normalized_degrees >= 360 - MAX_NATIVE_TEXT_SKEW_DEGREES
+        or abs(normalized_degrees - 180) <= MAX_NATIVE_TEXT_SKEW_DEGREES
+        or any(abs(normalized_degrees - angle) < 0.1 for angle in [90, 270])
+    )
 
 
 def _prepare_post_ocr_spans(need_ocr_spans, spans, pil_img, scale):

--- a/tests/unittest/test_span_pre_proc.py
+++ b/tests/unittest/test_span_pre_proc.py
@@ -1,0 +1,11 @@
+import math
+
+from mineru.utils.span_pre_proc import _is_supported_rotation
+
+
+def test_pdf_italic_skew_is_supported_for_text_backfill():
+    assert _is_supported_rotation(math.radians(19.1))
+
+
+def test_diagonal_rotation_is_not_supported_for_text_backfill():
+    assert not _is_supported_rotation(math.radians(45))


### PR DESCRIPTION
## Motivation

修复 hybrid / pipeline 在 PDF 原生文本回填时，部分斜体或仿斜体文本被错误丢弃的问题。

在一些 PDF 中，视觉上只是斜体、仿斜体或带下划线的普通水平文本，`pdftext` 读取到的字符 `rotation` 可能不是 0 度，而是一个较小的水平 skew 角度，例如约 19.1 度。当前逻辑只接受接近 `0/90/180/270` 度的字符，导致这些可正常读取的原生文本字符在 bbox 回填前被过滤掉，最终 Markdown 输出缺字。

测试文件：[case.pdf](https://github.com/user-attachments/files/29493870/case.pdf)

## Modification

- 调整 `txt_spans_extract` 中字符 rotation 的过滤逻辑。
- 对水平文本允许较小的 skew 角度，避免斜体/仿斜体 PDF 字符被误判为不支持的旋转文本。
- 保持 90/270 度竖排文本的严格判断，避免误接收真正的斜向文本。
- 新增单元测试，覆盖：
  - 19.1 度 skew 字符应参与文本回填。
  - 45 度斜向字符不应参与普通文本回填。

## BC-breaking (Optional)

无。该修改不改变公开 API、输出结构或调用方式，只修复 PDF 原生文本回填阶段的字符过滤逻辑。

## Use cases (Optional)

适用于解析包含斜体、仿斜体、下划线斜体等样式文本的 PDF。修复后，这类文本在 hybrid / pipeline 的非 OCR 文本回填路径中不会因为较小 skew rotation 被错误丢弃。

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
