### PR TITLE
fix: include downloaded path in persist_downloaded_model_config warning

### DIFF
--- a/mineru/utils/models_download_utils.py
+++ b/mineru/utils/models_download_utils.py
@@ -182,7 +182,11 @@ def persist_downloaded_model_config(model_source: str, repo_mode: str, model_roo
     except Exception as exc:
         logger.warning(
             f"Failed to persist downloaded {repo_mode} model config "
-            f"to {config_file}: {exc}"
+            f"to {config_file}: {exc}. "
+            f"Models were downloaded successfully to '{model_root}' but the path will not be "
+            f"cached, so MinerU may re-download on the next run. "
+            f"To avoid this, manually add the following to {config_file}:\n"
+            f'  "models-dir": {{"{repo_mode}": "{model_root}"}}'
         )
 
 

--- a/tests/unittest/test_persist_downloaded_model_config.py
+++ b/tests/unittest/test_persist_downloaded_model_config.py
@@ -1,0 +1,87 @@
+# Copyright (c) Opendatalab. All rights reserved.
+import json
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+from mineru.utils.models_download_utils import persist_downloaded_model_config
+
+
+@pytest.fixture
+def config_path(tmp_path):
+    return str(tmp_path / "mineru.json")
+
+
+def test_persist_success_writes_models_dir(config_path):
+    """Happy path: config file is written with the correct models-dir entry."""
+    with patch("mineru.utils.models_download_utils.get_tools_config_file_path", return_value=config_path), \
+         patch("mineru.utils.models_download_utils.download_and_modify_json") as mock_dl:
+        persist_downloaded_model_config("huggingface", "pipeline", "/tmp/models")
+        mock_dl.assert_called_once()
+        _, _, modifications = mock_dl.call_args[0]
+        assert modifications["models-dir"]["pipeline"] == "/tmp/models"
+        assert modifications["model-source"] == "huggingface"
+
+
+def test_persist_failure_logs_actionable_warning(config_path, caplog):
+    """When download_and_modify_json raises, warning must include model_root path and manual fix hint."""
+    import logging
+    with patch("mineru.utils.models_download_utils.get_tools_config_file_path", return_value=config_path), \
+         patch("mineru.utils.models_download_utils.download_and_modify_json", side_effect=OSError("disk full")):
+        # loguru does not integrate with caplog by default — capture via propagation
+        import loguru
+        import sys
+        warning_messages = []
+
+        def sink(message):
+            warning_messages.append(str(message))
+
+        handler_id = loguru.logger.add(sink, level="WARNING")
+        try:
+            persist_downloaded_model_config("modelscope", "pipeline", "/tmp/models")
+        finally:
+            loguru.logger.remove(handler_id)
+
+    combined = " ".join(warning_messages)
+    # Must tell the user the downloaded path so they can fix it manually
+    assert "/tmp/models" in combined
+    # Must explain that re-download will happen
+    assert "re-download" in combined or "next run" in combined
+    # Must show the manual fix snippet
+    assert '"pipeline"' in combined
+
+
+def test_persist_failure_does_not_raise(config_path):
+    """A config-write failure must never propagate — the download already succeeded."""
+    with patch("mineru.utils.models_download_utils.get_tools_config_file_path", return_value=config_path), \
+         patch("mineru.utils.models_download_utils.download_and_modify_json", side_effect=PermissionError("no write")):
+        # Should not raise
+        persist_downloaded_model_config("huggingface", "vlm", "/tmp/vlm-models")
+
+
+def test_persist_failure_for_vlm_mode(config_path):
+    """Warning message must include the correct repo_mode (vlm) in the hint."""
+    warning_messages = []
+    import loguru
+
+    handler_id = loguru.logger.add(warning_messages.append, level="WARNING")
+    try:
+        with patch("mineru.utils.models_download_utils.get_tools_config_file_path", return_value=config_path), \
+             patch("mineru.utils.models_download_utils.download_and_modify_json", side_effect=OSError("network error")):
+            persist_downloaded_model_config("huggingface", "vlm", "/tmp/vlm-root")
+    finally:
+        loguru.logger.remove(handler_id)
+
+    combined = " ".join(str(m) for m in warning_messages)
+    assert '"vlm"' in combined
+    assert "/tmp/vlm-root" in combined
+
+
+def test_persist_success_modelscope_pipeline(config_path):
+    """modelscope + pipeline combination is correctly passed through."""
+    with patch("mineru.utils.models_download_utils.get_tools_config_file_path", return_value=config_path), \
+         patch("mineru.utils.models_download_utils.download_and_modify_json") as mock_dl:
+        persist_downloaded_model_config("modelscope", "pipeline", "/ms/models")
+        _, _, modifications = mock_dl.call_args[0]
+        assert modifications["model-source"] == "modelscope"
+        assert modifications["models-dir"]["pipeline"] == "/ms/models"


### PR DESCRIPTION
## Motivation

While reviewing recent commits, I noticed that when `persist_downloaded_model_config` fails (e.g. disk full, permission error, network issue fetching the config template), the existing warning only logs the exception message:

```
Failed to persist downloaded pipeline model config to /home/user/mineru.json: [Errno 28] No space left on device
```

The models themselves were downloaded successfully, but the path is never written to `models-dir` in the config. On the next run, `get_existing_configured_model_root` finds no config entry and falls through to `_snapshot_download_cached`, triggering a full re-download — silently, with no indication of why.

## Modification

Extended the warning message in `persist_downloaded_model_config` to include:

1. The path where models were successfully downloaded (`model_root`)
2. An explanation that MinerU will re-download on the next run without this entry
3. The exact JSON snippet the user can paste into their config file to avoid re-downloading

Example of the new warning:

```
Failed to persist downloaded pipeline model config to /home/user/mineru.json: [Errno 28] No space left on device.
Models were downloaded successfully to '/home/user/.cache/huggingface/hub/...' but the path will not be
cached, so MinerU may re-download on the next run. To avoid this, manually add the following to /home/user/mineru.json:
  "models-dir": {"pipeline": "/home/user/.cache/huggingface/hub/..."}
```

No logic changes — the exception is still caught and the download result is still returned normally.

## BC-breaking

No. This is a warning message change only. All existing behaviour is preserved.

## Checklist

**Before PR**:

- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests.
- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.