### PR TITLE
Fix s3a multi-bucket S3 routing

### DIFF
--- a/mineru/data/data_reader_writer/multi_bucket_s3.py
+++ b/mineru/data/data_reader_writer/multi_bucket_s3.py
@@ -3,10 +3,10 @@
 from ..utils.exceptions import InvalidConfig, InvalidParams
 from .base import DataReader, DataWriter
 from ..utils.schemas import S3Config
-from ..utils.path_utils import parse_s3_range_params, parse_s3path, remove_non_official_s3_args
+from ..utils.path_utils import is_s3_path, parse_s3_range_params, parse_s3path, remove_non_official_s3_args
 
 
-def _load_s3_io_classes():
+def _load_s3_io_classes() -> tuple[type, type]:
     """延迟加载 S3 IO 类，仅在实际读写 S3 时要求安装 boto3。"""
     try:
         from ..io.s3 import S3Reader, S3Writer
@@ -23,7 +23,8 @@ class MultiS3Mixin:
         """Initialized with multiple s3 configs.
 
         Args:
-            default_prefix (str): the default prefix of the relative path. for example, {some_bucket}/{some_prefix} or {some_bucket}
+            default_prefix (str): default relative path prefix, for example, {some_bucket}/{some_prefix}
+                or {some_bucket}.
             s3_configs (list[S3Config]): list of s3 configs, the bucket_name must be unique in the list.
 
         Raises:
@@ -49,7 +50,7 @@ class MultiS3Mixin:
                 f'default_bucket: {self.default_bucket} config must be provided in s3_configs: {s3_configs}'
             )
 
-        uniq_bucket = set([conf.bucket_name for conf in s3_configs])
+        uniq_bucket = {conf.bucket_name for conf in s3_configs}
         if len(uniq_bucket) != len(s3_configs):
             raise InvalidConfig(
                 f'the bucket_name in s3_configs: {s3_configs} must be unique'
@@ -65,8 +66,8 @@ class MultiBucketS3DataReader(DataReader, MultiS3Mixin):
         based on the bucket, also support range read.
 
         Args:
-            path (str): the s3 path of file, the path must be in the format of s3://bucket_name/path?offset,limit.
-            for example: s3://bucket_name/path?0,100.
+            path (str): the s3 path of file, the path must be in the format of s3://bucket_name/path?offset,limit
+            or s3a://bucket_name/path?offset,limit. For example: s3://bucket_name/path?0,100.
 
         Returns:
             bytes: the content of s3 file.
@@ -79,8 +80,8 @@ class MultiBucketS3DataReader(DataReader, MultiS3Mixin):
         path = remove_non_official_s3_args(path)
         return self.read_at(path, byte_start, byte_len)
 
-    def __get_s3_client(self, bucket_name: str):
-        if bucket_name not in set([conf.bucket_name for conf in self.s3_configs]):
+    def __get_s3_client(self, bucket_name: str) -> object:
+        if bucket_name not in {conf.bucket_name for conf in self.s3_configs}:
             raise InvalidParams(
                 f'bucket name: {bucket_name} not found in s3_configs: {self.s3_configs}'
             )
@@ -110,7 +111,7 @@ class MultiBucketS3DataReader(DataReader, MultiS3Mixin):
         Returns:
             bytes: the file content.
         """
-        if path.startswith('s3://'):
+        if is_s3_path(path):
             bucket_name, path = parse_s3path(path)
             s3_reader = self.__get_s3_client(bucket_name)
         else:
@@ -121,8 +122,8 @@ class MultiBucketS3DataReader(DataReader, MultiS3Mixin):
 
 
 class MultiBucketS3DataWriter(DataWriter, MultiS3Mixin):
-    def __get_s3_client(self, bucket_name: str):
-        if bucket_name not in set([conf.bucket_name for conf in self.s3_configs]):
+    def __get_s3_client(self, bucket_name: str) -> object:
+        if bucket_name not in {conf.bucket_name for conf in self.s3_configs}:
             raise InvalidParams(
                 f'bucket name: {bucket_name} not found in s3_configs: {self.s3_configs}'
             )
@@ -148,7 +149,7 @@ class MultiBucketS3DataWriter(DataWriter, MultiS3Mixin):
             path (str): the path of file, if the path is relative path, it will be joined with parent_dir.
             data (bytes): the data want to write.
         """
-        if path.startswith('s3://'):
+        if is_s3_path(path):
             bucket_name, path = parse_s3path(path)
             s3_writer = self.__get_s3_client(bucket_name)
         else:

--- a/mineru/data/utils/path_utils.py
+++ b/mineru/data/utils/path_utils.py
@@ -1,19 +1,22 @@
 # Copyright (c) Opendatalab. All rights reserved.
 
 
-def remove_non_official_s3_args(s3path):
+S3_URI_SCHEMES = ('s3://', 's3a://')
+
+
+def remove_non_official_s3_args(s3path: str) -> str:
     """
     example: s3://abc/xxxx.json?bytes=0,81350 ==> s3://abc/xxxx.json
     """
     arr = s3path.split("?")
     return arr[0]
 
-def parse_s3path(s3path: str):
+def parse_s3path(s3path: str) -> tuple[str, str]:
     # from s3pathlib import S3Path
     # p = S3Path(remove_non_official_s3_args(s3path))
     # return p.bucket, p.key
     s3path = remove_non_official_s3_args(s3path).strip()
-    if s3path.startswith(('s3://', 's3a://')):
+    if is_s3_path(s3path):
         prefix, path = s3path.split('://', 1)
         bucket_name, key = path.split('/', 1)
         return bucket_name, key
@@ -23,7 +26,11 @@ def parse_s3path(s3path: str):
         raise ValueError("Invalid S3 path format. Expected 's3://bucket-name/key' or 's3a://bucket-name/key'.")
 
 
-def parse_s3_range_params(s3path: str):
+def is_s3_path(s3path: str) -> bool:
+    return s3path.strip().startswith(S3_URI_SCHEMES)
+
+
+def parse_s3_range_params(s3path: str) -> list[str] | None:
     """
     example: s3://abc/xxxx.json?bytes=0,81350 ==> [0, 81350]
     """

--- a/tests/unittest/test_multi_bucket_s3.py
+++ b/tests/unittest/test_multi_bucket_s3.py
@@ -1,0 +1,69 @@
+import pytest
+
+from mineru.data.data_reader_writer.multi_bucket_s3 import MultiBucketS3DataReader, MultiBucketS3DataWriter
+from mineru.data.utils.exceptions import InvalidParams
+from mineru.data.utils.schemas import S3Config
+
+
+class FakeS3Client:
+    def __init__(self) -> None:
+        self.read_calls: list[tuple[str, int, int]] = []
+        self.write_calls: list[tuple[str, bytes]] = []
+
+    def read_at(self, path: str, offset: int = 0, limit: int = -1) -> bytes:
+        self.read_calls.append((path, offset, limit))
+        return b"data"
+
+    def write(self, path: str, data: bytes) -> None:
+        self.write_calls.append((path, data))
+
+
+def make_config(bucket_name: str) -> S3Config:
+    return S3Config(
+        bucket_name=bucket_name,
+        access_key="ak",
+        secret_key="sk",
+        endpoint_url="https://example.com",
+    )
+
+
+def test_reader_routes_s3a_uri_to_declared_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
+    reader = MultiBucketS3DataReader(
+        "default-bucket/default-prefix",
+        [make_config("default-bucket"), make_config("target-bucket")],
+    )
+    default_client = FakeS3Client()
+    target_client = FakeS3Client()
+    clients = {"default-bucket": default_client, "target-bucket": target_client}
+
+    def get_client(bucket_name: str) -> FakeS3Client:
+        if bucket_name not in clients:
+            raise InvalidParams(f"bucket name: {bucket_name} not found")
+        return clients[bucket_name]
+
+    monkeypatch.setattr(reader, "_MultiBucketS3DataReader__get_s3_client", get_client)
+
+    assert reader.read("s3a://target-bucket/dir/file.pdf?bytes=5,7") == b"data"
+    assert target_client.read_calls == [("dir/file.pdf", 5, 7)]
+    assert default_client.read_calls == []
+
+
+def test_writer_routes_s3a_uri_to_declared_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
+    writer = MultiBucketS3DataWriter(
+        "default-bucket/default-prefix",
+        [make_config("default-bucket"), make_config("target-bucket")],
+    )
+    default_client = FakeS3Client()
+    target_client = FakeS3Client()
+    clients = {"default-bucket": default_client, "target-bucket": target_client}
+
+    def get_client(bucket_name: str) -> FakeS3Client:
+        if bucket_name not in clients:
+            raise InvalidParams(f"bucket name: {bucket_name} not found")
+        return clients[bucket_name]
+
+    monkeypatch.setattr(writer, "_MultiBucketS3DataWriter__get_s3_client", get_client)
+
+    writer.write("s3a://target-bucket/out/file.md", b"content")
+    assert target_client.write_calls == [("out/file.md", b"content")]
+    assert default_client.write_calls == []


### PR DESCRIPTION
## Motivation

### What Problem This Solves

MinerU's S3 path handling currently has two different ideas of what counts as an absolute S3 object-store URI.

`parse_s3path()` already treats both `s3://bucket/key` and `s3a://bucket/key` as valid S3-style paths. It strips query-like range parameters, splits the URI at `://`, and returns the declared bucket and object key:

```python
if is_s3_path(s3path):
    prefix, path = s3path.split('://', 1)
    bucket_name, key = path.split('/', 1)
    return bucket_name, key
```

Before this PR, the multi-bucket reader and writer only called that parser when the input started with `s3://`:

```python
if path.startswith('s3://'):
    bucket_name, path = parse_s3path(path)
    s3_reader = self.__get_s3_client(bucket_name)
else:
    s3_reader = self.__get_s3_client(self.default_bucket)
```

That means a valid S3A path such as:

```text
s3a://target-bucket/dir/file.pdf
```

was not handled as an absolute S3 URI. It fell into the relative-path branch, selected the configured default bucket, and could send the full `s3a://target-bucket/dir/file.pdf` string, optionally prefixed by `default_prefix`, as the object key.

For a multi-bucket reader configured with:

```text
default bucket: default-bucket
default prefix: default-prefix
input path    : s3a://target-bucket/dir/file.pdf
```

The intended routing is:

```text
bucket: target-bucket
key   : dir/file.pdf
```

The previous routing could become:

```text
bucket: default-bucket
key   : default-prefix/s3a://target-bucket/dir/file.pdf
```

This is especially easy to hit when paths come from Hadoop, Spark, or data-lake workflows, where `s3a://` is a common URI scheme for S3-compatible storage.

### Changes

This PR adds a shared `is_s3_path()` helper backed by the same supported schemes used by `parse_s3path()`:

```python
S3_URI_SCHEMES = ('s3://', 's3a://')
```

`MultiBucketS3DataReader.read_at()` and `MultiBucketS3DataWriter.write()` now use that helper before dispatching to `parse_s3path()`. As a result, `s3://` and `s3a://` paths go through the same bucket/key parser, while ordinary relative paths still use the configured default bucket and optional default prefix.

The reader docstring is also updated to mention `s3a://` as a supported input form, and focused unit tests cover the reader and writer S3A routing behavior without requiring live S3 credentials.

### Evidence

The bug is visible at the dispatch boundary:

```text
parse_s3path(s3a://target-bucket/dir/file.pdf)
  -> bucket target-bucket, key dir/file.pdf

MultiBucketS3DataReader.read_at(s3a://target-bucket/dir/file.pdf) before this PR
  -> does not call parse_s3path()
  -> uses default bucket branch
```

After this change, the same `s3a://` input satisfies `is_s3_path()` and is routed through `parse_s3path()`, so the declared bucket and key are preserved.

Validation run locally on Windows with Python 3.12.13:

```powershell
uvx ruff check mineru/data/utils/path_utils.py mineru/data/data_reader_writer/multi_bucket_s3.py tests/unittest/test_multi_bucket_s3.py
# All checks passed!

.\.venv-pr-s3a\Scripts\python.exe -m pytest -q tests/unittest/test_multi_bucket_s3.py
# 2 passed

.\.venv-pr-s3a\Scripts\python.exe -m py_compile mineru/data/utils/path_utils.py mineru/data/data_reader_writer/multi_bucket_s3.py
# passed

git diff --check
# passed
```

### Possible call chain / impact

The affected multi-bucket read path is:

```text
MultiBucketS3DataReader.read(s3a://target-bucket/dir/file.pdf?bytes=5,7)
  -> parse_s3_range_params(...)
  -> remove_non_official_s3_args(...)
  -> MultiBucketS3DataReader.read_at(s3a://target-bucket/dir/file.pdf, 5, 7)
  -> dispatches by URI scheme
  -> parse_s3path(...)
  -> __get_s3_client(target-bucket)
  -> s3_reader.read_at(dir/file.pdf, 5, 7)
```

The affected write path is:

```text
MultiBucketS3DataWriter.write(s3a://target-bucket/out/file.md, data)
  -> dispatches by URI scheme
  -> parse_s3path(...)
  -> __get_s3_client(target-bucket)
  -> s3_writer.write(out/file.md, data)
```

This PR only changes S3 URI dispatch for `s3a://` paths. It does not change low-level S3 client behavior, credentials, endpoint selection, range parsing, relative-path behavior, default bucket/default prefix behavior, or existing `s3://` routing.

## Modification

- Add a shared `is_s3_path()` helper using the same supported URI schemes as `parse_s3path()`.
- Use that helper in both `MultiBucketS3DataReader.read_at()` and `MultiBucketS3DataWriter.write()` so `s3a://` paths are parsed into their declared bucket/key.
- Update the multi-bucket reader docstring to mention `s3a://` paths.
- Add focused unit tests for reader and writer `s3a://` routing.

## BC-breaking (Optional)

No backward compatibility break is expected. Existing `s3://` paths and relative paths keep the same behavior. The only behavior change is that strings beginning with `s3a://` are now treated as S3 URIs, matching the existing `parse_s3path()` contract, instead of being treated as default-bucket relative object keys.

## Use cases (Optional)

This helps users who pass S3A-style paths from Hadoop, Spark, or data lake workflows into MinerU's multi-bucket S3 reader/writer:

```text
s3a://target-bucket/documents/input.pdf
```

After this change, that path is routed to `target-bucket` with key `documents/input.pdf` instead of being interpreted under the configured default bucket.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] N/A - this narrow S3 URI routing fix does not require downstream project changes.
- [x] CLA has been signed and all committers have signed the CLA in this PR.