### PR TITLE
docs(api): add response models for FastAPI OpenAPI documentation

### DIFF
--- a/mineru/cli/api_response_models.py
+++ b/mineru/cli/api_response_models.py
@@ -1,0 +1,248 @@
+# Copyright (c) Opendatalab. All rights reserved.
+"""Pydantic response models for the MinerU FastAPI service.
+
+These models are attached to the routes in :mod:`mineru.cli.fast_api` via
+FastAPI's ``response_model`` and ``responses`` parameters so that the OpenAPI
+documentation (``/openapi.json`` and ``/docs``) accurately describes the JSON
+payloads returned by each endpoint.
+
+They are intentionally documentation-oriented. The route handlers continue to
+return :class:`fastapi.responses.JSONResponse` (or
+:class:`fastapi.responses.FileResponse` for ZIP downloads) directly. When a
+handler returns a ``Response`` object, FastAPI bypasses response-model
+validation and serialization at runtime — so adding these models does not
+change runtime behavior. They only describe the documented contract for API
+consumers.
+
+Every model allows extra fields
+(``model_config = ConfigDict(extra='allow')``) so the schema stays
+forward-compatible with additive changes to the response payloads (for
+example the conditional ``queued_ahead`` key that is appended only by
+``AsyncTaskManager.build_status_payload``).
+"""
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+_SHARED_CONFIG = ConfigDict(extra='allow')
+
+
+class TaskStatusPayload(BaseModel):
+    """Shared status payload returned for parse tasks.
+
+    Emitted by ``GET /tasks/{task_id}`` and embedded in many other responses.
+    The ``queued_ahead`` key is appended by
+    ``AsyncTaskManager.build_status_payload`` and is therefore declared on the
+    derived models that include it, not on this base.
+    """
+
+    model_config = _SHARED_CONFIG
+
+    task_id: str = Field(description='unique identifier for the parse task')
+    status: str = Field(
+        description='current task lifecycle state: pending, processing, '
+        'completed, or failed'
+    )
+    backend: str = Field(
+        description='parse backend used for the task (e.g. pipeline or vlm)'
+    )
+    file_names: list[str] = Field(
+        description='normalized stems of the uploaded input files'
+    )
+    created_at: str = Field(
+        description='ISO 8601 timestamp marking when the task was created'
+    )
+    started_at: Optional[str] = Field(
+        default=None,
+        description='ISO 8601 timestamp marking when processing started; '
+        'absent until the task begins processing',
+    )
+    completed_at: Optional[str] = Field(
+        default=None,
+        description='ISO 8601 timestamp marking when processing finished; '
+        'absent until the task reaches a terminal state',
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description='error message captured when the task failed; absent '
+        'otherwise',
+    )
+    status_url: str = Field(
+        description='absolute URL to poll the task status'
+    )
+    result_url: str = Field(
+        description='absolute URL to fetch the task result'
+    )
+
+
+class TaskStatusResponse(TaskStatusPayload):
+    """Response for ``GET /tasks/{task_id}``.
+
+    Extends the base status payload with the queue position.
+    """
+
+    queued_ahead: int = Field(
+        description='number of pending tasks submitted before this one that '
+        'are still waiting to start; 0 when the task is no longer pending'
+    )
+
+
+class TaskSubmissionResponse(TaskStatusPayload):
+    """Response for ``POST /tasks`` (asynchronous submission)."""
+
+    queued_ahead: int = Field(
+        description='number of pending tasks submitted before this one that '
+        'are still waiting to start'
+    )
+    message: str = Field(
+        description='human-readable confirmation message'
+    )
+
+
+class ParseResultInner(BaseModel):
+    """Per-file parsing result returned inside the ``results`` map.
+
+    Which keys are present depends on the request's ``return_*`` flags. The
+    text/JSON values are the raw file contents (or ``null`` when the
+    corresponding result file is missing on disk). Image values are
+    ``data:`` URLs with base64-encoded payloads.
+    """
+
+    model_config = _SHARED_CONFIG
+
+    md_content: Optional[str] = Field(
+        default=None,
+        description='Markdown rendering of the parsed document',
+    )
+    middle_json: Optional[str] = Field(
+        default=None,
+        description='middle-json representation serialized as a string',
+    )
+    model_output: Optional[str] = Field(
+        default=None,
+        description='raw model output serialized as a JSON string',
+    )
+    content_list: Optional[str] = Field(
+        default=None,
+        description='content list serialized as a JSON string',
+    )
+    images: dict[str, str] = Field(
+        default_factory=dict,
+        description='map of image basename to base64 data URL for extracted '
+        'images; empty when no images were emitted',
+    )
+
+
+class FileParseResultResponse(TaskStatusPayload):
+    """JSON response for ``POST /file_parse`` on success.
+
+    Returns the task status payload together with the MinerU version and the
+    per-file parsing results. When ``response_format_zip`` is set on the
+    request, the endpoint instead returns a binary ``application/zip``
+    response (documented via the route's ``responses`` parameter).
+    """
+
+    version: str = Field(description='MinerU release version')
+    results: dict[str, ParseResultInner] = Field(
+        description='map of input file stem to its parsing result; only keys '
+        'requested via the return_* flags are populated'
+    )
+
+
+class TaskResultResponse(BaseModel):
+    """JSON response for ``GET /tasks/{task_id}/result`` on success.
+
+    Contains only the backend, MinerU version, and the per-file parsing
+    results. When ``response_format_zip`` is set on the original task, the
+    endpoint instead returns a binary ``application/zip`` response
+    (documented via the route's ``responses`` parameter).
+    """
+
+    model_config = _SHARED_CONFIG
+
+    backend: str = Field(
+        description='parse backend used for the task (e.g. pipeline or vlm)'
+    )
+    version: str = Field(description='MinerU release version')
+    results: dict[str, ParseResultInner] = Field(
+        description='map of input file stem to its parsing result; only keys '
+        'requested via the return_* flags are populated'
+    )
+
+
+class TaskMessageResponse(TaskStatusPayload):
+    """Status payload accompanying an informational or error message.
+
+    Used by endpoints that return the task status together with a short
+    human-readable ``message`` (e.g. result not ready yet, task execution
+    failed, task manager became unavailable while waiting).
+    """
+
+    message: str = Field(
+        description='human-readable status or error message'
+    )
+
+
+class HealthResponse(BaseModel):
+    """Healthy service response for ``GET /health``."""
+
+    model_config = _SHARED_CONFIG
+
+    status: str = Field(description='health indicator; "healthy" on success')
+    version: str = Field(description='MinerU release version')
+    protocol_version: int = Field(description='API protocol version')
+    queued_tasks: int = Field(
+        description='number of tasks currently in the pending state'
+    )
+    processing_tasks: int = Field(
+        description='number of tasks currently in the processing state'
+    )
+    completed_tasks: int = Field(
+        description='number of tasks in the completed state'
+    )
+    failed_tasks: int = Field(
+        description='number of tasks in the failed state'
+    )
+    max_concurrent_requests: int = Field(
+        description='maximum number of parse requests the server may process '
+        'concurrently'
+    )
+    processing_window_size: int = Field(
+        description='processing window size used by the parser'
+    )
+    task_retention_seconds: int = Field(
+        description='seconds a terminal task is retained before cleanup'
+    )
+    task_cleanup_interval_seconds: int = Field(
+        description='interval between cleanup sweeps of expired tasks'
+    )
+
+
+class UnhealthyResponse(BaseModel):
+    """Unhealthy service response for ``GET /health``."""
+
+    model_config = _SHARED_CONFIG
+
+    status: str = Field(
+        description='health indicator; "unhealthy" on failure'
+    )
+    version: str = Field(description='MinerU release version')
+    error: str = Field(
+        description='description of the underlying failure (e.g. task '
+        'manager is not initialized, dispatcher is not running)'
+    )
+
+
+class HTTPExceptionResponse(BaseModel):
+    """Response body for non-success status codes raised via HTTPException.
+
+    Matches the default FastAPI ``HTTPException`` JSON shape (``{"detail": ...}``).
+    """
+
+    model_config = _SHARED_CONFIG
+
+    detail: str = Field(
+        description='human-readable error detail'
+    )

--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -1450,21 +1450,23 @@ async def health_check():
         )
 
     stats = task_manager.get_stats()
-    return {
-        "status": "healthy",
-        "version": __version__,
-        "protocol_version": API_PROTOCOL_VERSION,
-        "queued_tasks": stats[TASK_PENDING],
-        "processing_tasks": stats[TASK_PROCESSING],
-        "completed_tasks": stats[TASK_COMPLETED],
-        "failed_tasks": stats[TASK_FAILED],
-        "max_concurrent_requests": get_max_concurrent_requests(),
-        "processing_window_size": get_processing_window_size(
-            default=DEFAULT_PROCESSING_WINDOW_SIZE
-        ),
-        "task_retention_seconds": task_manager.task_retention_seconds,
-        "task_cleanup_interval_seconds": task_manager.task_cleanup_interval_seconds,
-    }
+    return JSONResponse(
+        content={
+            "status": "healthy",
+            "version": __version__,
+            "protocol_version": API_PROTOCOL_VERSION,
+            "queued_tasks": stats[TASK_PENDING],
+            "processing_tasks": stats[TASK_PROCESSING],
+            "completed_tasks": stats[TASK_COMPLETED],
+            "failed_tasks": stats[TASK_FAILED],
+            "max_concurrent_requests": get_max_concurrent_requests(),
+            "processing_window_size": get_processing_window_size(
+                default=DEFAULT_PROCESSING_WINDOW_SIZE
+            ),
+            "task_retention_seconds": task_manager.task_retention_seconds,
+            "task_cleanup_interval_seconds": task_manager.task_cleanup_interval_seconds,
+        }
+    )
 
 
 @click.command(

--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -54,6 +54,16 @@ from mineru.cli.api_protocol import (
     DEFAULT_MAX_CONCURRENT_REQUESTS,
     DEFAULT_PROCESSING_WINDOW_SIZE,
 )
+from mineru.cli.api_response_models import (
+    FileParseResultResponse,
+    HTTPExceptionResponse,
+    HealthResponse,
+    TaskMessageResponse,
+    TaskResultResponse,
+    TaskStatusResponse,
+    TaskSubmissionResponse,
+    UnhealthyResponse,
+)
 from mineru.cli.backend_options import DEFAULT_HYBRID_EFFORT
 from mineru.cli.vlm_preload import (
     maybe_preload_vlm_model,
@@ -1228,6 +1238,26 @@ def get_task_manager() -> AsyncTaskManager:
 @app.post(
     path="/file_parse",
     status_code=200,
+    response_model=FileParseResultResponse,
+    responses={
+        200: {
+            "content": {"application/zip": {}},
+            "description": (
+                "JSON parsing results (default), or a ZIP archive when "
+                "response_format_zip is set on the request"
+            ),
+        },
+        409: {
+            "model": TaskMessageResponse,
+            "description": "Task execution failed",
+        },
+        503: {
+            "model": TaskMessageResponse,
+            "description": (
+                "Task manager became unavailable while waiting for the result"
+            ),
+        },
+    },
     summary="Synchronously parse uploaded files",
     description=(
         "Submit a parsing task to the shared async task manager, wait for it to "
@@ -1276,6 +1306,7 @@ async def parse_pdf(
 @app.post(
     path="/tasks",
     status_code=202,
+    response_model=TaskSubmissionResponse,
     summary="Submit an asynchronous parse task",
     description=(
         "Submit files for parsing and return immediately with a task id that can be "
@@ -1293,16 +1324,51 @@ async def submit_parse_task(
     return build_task_submission_response(task, http_request, task_manager)
 
 
-@app.get(path="/tasks/{task_id}", name="get_async_task_status")
+@app.get(
+    path="/tasks/{task_id}",
+    name="get_async_task_status",
+    response_model=TaskStatusResponse,
+    responses={
+        404: {
+            "model": HTTPExceptionResponse,
+            "description": "Task not found",
+        },
+    },
+)
 async def get_async_task_status(task_id: str, request: Request):
     task_manager = get_task_manager()
     task = task_manager.get(task_id)
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found")
-    return task_manager.build_status_payload(task, request)
+    return JSONResponse(content=task_manager.build_status_payload(task, request))
 
 
-@app.get(path="/tasks/{task_id}/result", name="get_async_task_result")
+@app.get(
+    path="/tasks/{task_id}/result",
+    name="get_async_task_result",
+    response_model=TaskResultResponse,
+    responses={
+        200: {
+            "content": {"application/zip": {}},
+            "description": (
+                "JSON parsing results (default), or a ZIP archive when "
+                "response_format_zip is set on the original task"
+            ),
+        },
+        202: {
+            "model": TaskMessageResponse,
+            "description": "Task result is not ready yet",
+        },
+        404: {
+            "model": HTTPExceptionResponse,
+            "description": "Task not found",
+        },
+        409: {
+            "model": TaskMessageResponse,
+            "description": "Task execution failed",
+        },
+    },
+)
 async def get_async_task_result(
     task_id: str,
     request: Request,
@@ -1349,7 +1415,16 @@ async def get_async_task_result(
     )
 
 
-@app.get(path="/health")
+@app.get(
+    path="/health",
+    response_model=HealthResponse,
+    responses={
+        503: {
+            "model": UnhealthyResponse,
+            "description": "Service is unhealthy",
+        },
+    },
+)
 async def health_check():
     task_manager = getattr(app.state, "task_manager", None)
     if task_manager is None or not task_manager.is_healthy():


### PR DESCRIPTION
## Summary

The FastAPI service in `mineru/cli/fast_api.py` exposes five HTTP endpoints (`POST /file_parse`, `POST /tasks`, `GET /tasks/{task_id}`, `GET /tasks/{task_id}/result`, `GET /health`) whose handlers return manually-built `JSONResponse` / `FileResponse` objects. Prior to this change, none of them declared a FastAPI `response_model=` or `responses=` parameter, so the OpenAPI schema (`/openapi.json` and `/docs`) only advertised a generic `200`/`202` success body. The actual response shapes - the shared task status payload, the per-file `results` map, the per-status-code error bodies, and the ZIP-download branches - were undocumented for API consumers.

This change adds Pydantic v2 response models and wires them into the route decorators so that the generated OpenAPI schema accurately reflects every response contract the service actually returns.

## Reasoning

- ** discoverable contract.** Clients (and client generators) reading `/openapi.json` could not infer what fields a successful `/file_parse` response contains, what `GET /tasks/{id}/result` returns when the task is still running (202 vs 200), or which status codes each route can produce. The schema now matches the actual payloads.
- **No runtime impact.** The route handlers continue to return `JSONResponse` / `FileResponse` directly. FastAPI bypasses `response_model` validation at runtime when a handler returns a `Response` subclass, so this is a documentation-only change. The only handler bodies touched were two that previously returned a bare `dict` (`GET /tasks/{id}` success and `GET /health` healthy path) - these are now wrapped in `JSONResponse(content=...)` so that the docs-only contract holds uniformly (without that wrap, FastAPI would apply `response_model` validation to bare-dict returns, which would be a behavioural change rather than pure documentation).
- **Forward-compatible.** All new models use `model_config = ConfigDict(extra="allow")`, so additive future keys do not invalidate the documented schema. Nullable task payload fields (`started_at`, `completed_at`, `error`) are modelled as `Optional[str] = None`, matching what `AsyncParseTask.to_status_payload` actually emits.

## Changes

- **New file** `mineru/cli/api_response_models.py` (~200 lines): ten Pydantic v2 `BaseModel` classes covering every response shape:
  - `TaskStatusPayload` (shared base, 10 keys), extended by `TaskStatusResponse`, `TaskSubmissionResponse`, `TaskMessageResponse`, `FileParseResultResponse`
  - `ParseResultInner` (the per-file `results` value; `md_content` / `middle_json` / `model_output` / `content_list` as `Optional[str]`; `images: dict[str, str]`)
  - `TaskResultResponse` (standalone - `backend` / `version` / `results` only, for `/tasks/{id}/result` 200 JSON)
  - `HealthResponse`, `UnhealthyResponse`, `HTTPExceptionResponse`
- **Edited** `mineru/cli/fast_api.py`:
  - Imports the response models.
  - Each of the five routes now carries `response_model=` for the success JSON shape and `responses=` for additional status codes.
  - The two ZIP-capable routes (`POST /file_parse`, `GET /tasks/{id}/result`) additionally declare `application/zip` content via `responses={200: {"content": {"application/zip": {}}, ...}}` alongside the JSON schema that `response_model` provides.
  - Per-status error responses (404, 409, 503, 202-not-ready) get a Pydantic model in `responses=`.
  - `GET /tasks/{id}` 200 path and `GET /health` healthy path wrapped in `JSONResponse(content=...)` (see Reasoning).

## Verification

- `from mineru.cli.fast_api import app; app.openapi()` renders with all new schemas present and per-route response codes matching the live handler inventory:
  - `POST /file_parse` → 200, 409, 422, 503
  - `POST /tasks` → 202, 422
  - `GET /tasks/{id}` → 200, 404, 422
  - `GET /tasks/{id}/result` → 200, 202, 404, 409, 422
  - `GET /health` → 200, 503
- Dual media type on ZIP-capable routes confirmed: `200` exposes both `application/json` (from `response_model`) and `application/zip` (from `responses` override).
- ASGI smoke test via `fastapi.testclient.TestClient`: `GET /health` returns the expected 11-key JSON body; `GET /tasks/{unknown_id}` still returns FastAPI\u2019s default `{"detail": "Task not found"}` 404. Runtime behaviour preserved.

## Design notes

- `HTTPExceptionResponse` (with `detail: str`) is defined locally rather than imported because FastAPI does not ship a reusable model for the `{"detail": ...}` shape. The only error schema FastAPI auto-publishes is `HTTPValidationError` (422), defined as a hardcoded JSON-Schema dict inside `fastapi/openapi/utils.py`, not an importable `BaseModel`. Defining our own tiny error model is the idiomatic community pattern (examples: `Donkie/Spoolman` `Message`, several `ErrorResponse` models in ecosystem projects).
- Per-route `responses=` is used rather than router-level responses because this file uses `@app.get/@app.post(...)` decorators directly rather than `APIRouter`. If the file is ever migrated to `APIRouter`, the shared error models could be hoisted to a single `APIRouter(responses=common_error_responses)` declaration.

## Scope note

I would be happy to expand this beyond the current docs-only scope into a deeper refactor of the FastAPI application as a properly modelled interface - i.e. replacing the manually-built `JSONResponse(content=dict)` / `FileResponse` returns with Pydantic response objects (or plain dicts returned through a typed `response_model`) so that FastAPI enforces the contract at runtime, not just in the schema. That would catch schema drift between the handlers and the documented response models, and would let the request and response types together form a single typed API surface. I kept this PR strictly documentation-only to avoid changing runtime behaviour without discussion, but the modelled-interface refactor is a natural follow-up if it is desirable here.


## Implementation

This change was implemented with the assistance of an LLM coding agent. All generated code was read in full and reviewed for correctness by a human before being pushed.
