### PR TITLE
fix: preserve DOCX heading numbering

### DIFF
--- a/mineru/backend/office/model_output_to_middle_json.py
+++ b/mineru/backend/office/model_output_to_middle_json.py
@@ -136,6 +136,16 @@ def result_to_middle_json(model_output_blocks_list, image_writer):
                 continue
             level = block.get("level", 1)
             if block.get("is_numbered_style", False):
+                # DOCX conversion can provide the exact label rendered from
+                # numbering.xml (including punctuation and numbering level).
+                # Keep the level-based counter only as a compatibility fallback.
+                explicit_section_number = block.get("section_number")
+                if (
+                    isinstance(explicit_section_number, str)
+                    and explicit_section_number.strip()
+                ):
+                    block["section_number"] = explicit_section_number.strip()
+                    continue
                 # Ensure all ancestor levels start at 1 (never 0)
                 for ancestor in range(1, level):
                     if section_counters[ancestor] == 0:

--- a/mineru/backend/office/office_magic_model.py
+++ b/mineru/backend/office/office_magic_model.py
@@ -112,6 +112,9 @@ class MagicModel:
             if block_type == BlockType.TITLE:
                 block["is_numbered_style"] = block_info.get("is_numbered_style", False)
                 block["level"] = block_info.get("level", 1)
+                section_number = block_info.get("section_number")
+                if isinstance(section_number, str) and section_number.strip():
+                    block["section_number"] = section_number.strip()
             blocks.append(block)
 
         self.image_blocks = []

--- a/mineru/model/docx/docx_converter.py
+++ b/mineru/model/docx/docx_converter.py
@@ -1514,6 +1514,10 @@ class DocxConverter:
                     "is_numbered_style": is_numbered_style,
                     "content": content_text,
                 }
+                if is_numbered_style:
+                    section_number = self._build_numbering_label(numid, ilevel)
+                    if section_number:
+                        h_block["section_number"] = section_number
                 if paragraph_anchor:
                     h_block["anchor"] = paragraph_anchor
                 self.cur_page.append(h_block)
@@ -2436,6 +2440,41 @@ class DocxConverter:
                 self.list_counters.pop(key, None)
 
         return current_number
+
+    def _build_numbering_label(self, numId: int, ilvl: int) -> Optional[str]:
+        """推进十进制 Word 编号计数器，并按当前层级的 lvlText 模板生成编号。"""
+        # 先推进当前编号层级；即使后续无法读取模板，也能返回当前数字作为降级结果。
+        current_number = self._advance_list_counter(numId, ilvl)
+        # numId 定位编号实例，ilvl 定位该实例引用的具体编号层级。
+        lvl_element = self._get_numbering_level_definition(numId, ilvl)
+        if lvl_element is None:
+            return str(current_number)
+
+        # 从当前层级读取 Word 用于展示编号的模板，例如“%1.”。
+        namespaces = {
+            "w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+        }
+        lvl_text_element = lvl_element.find("w:lvlText", namespaces=namespaces)
+        if lvl_text_element is None:
+            return str(current_number)
+
+        template = lvl_text_element.get(self.XML_KEY)
+        if not template:
+            return None
+
+        def replace_counter(match: re.Match) -> str:
+            # Word 占位符从 %1 开始，内部 ilvl 则从 0 开始，因此需要减 1。
+            referenced_level = int(match.group(1)) - 1
+            counter_key = (numId, referenced_level)
+            # 模板可能引用尚未出现的父级，缺失时按该层级的起始值初始化。
+            if counter_key not in self.list_counters:
+                self.list_counters[counter_key] = self._get_numbering_level_start(
+                    numId, referenced_level
+                )
+            return str(self.list_counters[counter_key])
+
+        # 用各层级的当前计数替换 %1 至 %9，并保留模板自带的标点。
+        return re.sub(r"%([1-9])", replace_counter, template).strip()
 
     def _is_numbered_list(self, numId: int, ilvl: int) -> bool:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ zip-safe = false
 addopts = "-s --cov=mineru --cov-report html"
 
 [tool.coverage.run]
-command_line = "-m pytest tests/unittest/test_e2e.py"
+command_line = "-m pytest tests/unittest/test_e2e.py tests/unittest/test_docx_heading_numbering.py"
 source = ["mineru/"]
 omit = [
     "*/gradio_app.py",

--- a/tests/unittest/test_docx_heading_numbering.py
+++ b/tests/unittest/test_docx_heading_numbering.py
@@ -1,0 +1,154 @@
+# Copyright (c) Opendatalab. All rights reserved.
+from io import BytesIO
+
+from docx import Document
+from docx.document import Document as DocxDocument
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
+from docx.oxml.xmlchemy import BaseOxmlElement
+
+from mineru.backend.office.docx_analyze import office_docx_analyze
+from mineru.backend.office.model_output_to_middle_json import result_to_middle_json
+from mineru.backend.office.office_middle_json_mkcontent import union_make
+from mineru.utils.enum_class import BlockType, MakeMode
+
+
+def _append_value(
+    parent: BaseOxmlElement, tag: str, value: object
+) -> BaseOxmlElement:
+    element = OxmlElement(tag)
+    element.set(qn("w:val"), str(value))
+    parent.append(element)
+    return element
+
+
+def _add_numbering_definition(
+    document: DocxDocument,
+    *,
+    num_id: int,
+    abstract_num_id: int,
+) -> None:
+    # 在内存文档中创建一套独立的十进制编号规则，不依赖任何外部 DOCX 文件。
+    numbering = document.part.numbering_part.element
+
+    # 抽象编号定义：第 0 层从 1 开始，显示模板为“%1.”。
+    abstract_num = OxmlElement("w:abstractNum")
+    abstract_num.set(qn("w:abstractNumId"), str(abstract_num_id))
+    _append_value(abstract_num, "w:multiLevelType", "multilevel")
+    level = OxmlElement("w:lvl")
+    level.set(qn("w:ilvl"), "0")
+    _append_value(level, "w:start", 1)
+    _append_value(level, "w:numFmt", "decimal")
+    _append_value(level, "w:lvlText", "%1.")
+    abstract_num.append(level)
+    numbering.append(abstract_num)
+
+    # 创建编号实例，并将其关联到上面的抽象编号定义。
+    num = OxmlElement("w:num")
+    num.set(qn("w:numId"), str(num_id))
+    _append_value(num, "w:abstractNumId", abstract_num_id)
+    numbering.append(num)
+
+
+def _add_numbered_heading(
+    document: DocxDocument,
+    text: str,
+    *,
+    num_id: int,
+) -> None:
+    paragraph = document.add_paragraph(text)
+    properties = paragraph._p.get_or_add_pPr()
+
+    # 编号层级设为 0，表示使用“%1.”这一第一级编号规则。
+    num_properties = OxmlElement("w:numPr")
+    _append_value(num_properties, "w:ilvl", 0)
+    _append_value(num_properties, "w:numId", num_id)
+    properties.append(num_properties)
+    # 大纲层级设为 1，对应内部二级标题，刻意与编号层级构造不同的维度。
+    _append_value(properties, "w:outlineLvl", 1)
+
+
+def _analyze_document(document: DocxDocument) -> tuple[dict, list]:
+    # 文档只在内存中保存和解析，测试过程不读取磁盘上的 Word 文件。
+    stream = BytesIO()
+    document.save(stream)
+    return office_docx_analyze(stream.getvalue())
+
+
+def _model_titles(model_output: list[list[dict]]) -> list[dict]:
+    return [
+        block
+        for page in model_output
+        for block in page
+        if block.get("type") == BlockType.TITLE
+    ]
+
+
+def _middle_titles(middle_json: dict) -> list[dict]:
+    return [
+        block
+        for page in middle_json["pdf_info"]
+        for block in page["para_blocks"]
+        if block.get("type") == BlockType.TITLE
+    ]
+
+
+def test_heading_number_uses_word_numbering_level_instead_of_outline_level() -> None:
+    # 使用无业务含义的虚拟标题构造最小可复现文档。
+    document = Document()
+    num_id = 42
+    abstract_num_id = 7
+    virtual_titles = ["虚拟标题甲", "虚拟标题乙"]
+    # 使用不同的实例 ID 和抽象定义 ID，验证完整的编号定义映射链路。
+    _add_numbering_definition(
+        document,
+        num_id=num_id,
+        abstract_num_id=abstract_num_id,
+    )
+    _add_numbered_heading(
+        document,
+        virtual_titles[0],
+        num_id=num_id,
+    )
+    _add_numbered_heading(
+        document,
+        virtual_titles[1],
+        num_id=num_id,
+    )
+
+    middle_json, model_output = _analyze_document(document)
+
+    # 大纲层级仍应解析为二级标题，不能为了修正编号而改成一级标题。
+    model_titles = _model_titles(model_output)
+    assert [block["level"] for block in model_titles] == [2, 2]
+    # 编号应来自 Word 的第 0 层编号模板，而不是根据二级标题层级重新推算。
+    assert [block["section_number"] for block in model_titles] == ["1.", "2."]
+    assert [block["section_number"] for block in _middle_titles(middle_json)] == [
+        "1.",
+        "2.",
+    ]
+
+    # 验证真实输出链路保留“二级标题 + 第一级编号”的组合。
+    markdown = union_make(middle_json["pdf_info"], MakeMode.MM_MD, "")
+    assert f"## 1. {virtual_titles[0]}" in markdown
+    assert f"## 2. {virtual_titles[1]}" in markdown
+    assert f"1.1 {virtual_titles[0]}" not in markdown
+
+
+def test_legacy_office_title_without_explicit_number_keeps_fallback() -> None:
+    # 构造没有显式 section_number 的旧格式输入，确认原有回退逻辑仍然可用。
+    middle_json = result_to_middle_json(
+        [[
+            {
+                "type": BlockType.TITLE,
+                "level": 2,
+                "is_numbered_style": True,
+                "content": "虚拟兼容标题",
+            }
+        ]],
+        None,
+    )
+
+    titles = _middle_titles(middle_json)
+    assert len(titles) == 1
+    assert titles[0]["section_number"] == "1.1"


### PR DESCRIPTION
## Motivation

DOCX heading outline levels and Word numbering levels represent different concepts.

For example, a paragraph can have:

  - `outlineLvl=1`, meaning it is a semantic level-2 heading and should render as `##`.
  - `numId=3`, `ilvl=0`, and `lvlText=%1.`, meaning it uses the first numbering level and should display `1.`, `2.`, etc.

Previously, the DOCX converter only preserved the semantic heading level. The middle-JSON conversion then reconstructed the section number from `level=2`, incorrectly producing `1.1`, `1.2`, etc.
<img width="1152" height="396" alt="image" src="https://github.com/user-attachments/assets/af7e22d1-bf66-4edf-bb02-472b0e49b943" />


This PR preserves the heading level while deriving the displayed section number from the actual Word numbering definition.

  ## Modification

  - Generate an explicit `section_number` for numbered DOCX `Heading` blocks.
  - Resolve numbering rules using `numId` and `ilvl` from `word/numbering.xml`.
  - Reuse the existing Word list counters and configured start values.
  - Render `%1` to `%9` placeholders from `lvlText` while preserving punctuation.
  - Propagate `section_number` through the Office `MagicModel`.
  - Prefer an explicit DOCX `section_number` during middle-JSON conversion.
  - Keep the existing level-based section counter as a compatibility fallback when no explicit number is provided.
  - Add an in-memory synthetic DOCX regression test without relying on external documents or business-specific content.
  - Add a compatibility test for legacy Office title blocks without an explicit `section_number`.
  - Include the new regression test in the configured coverage command.
  - Add comments and a method docstring describing the numbering resolution process.

  ## BC-breaking (Optional)

No backward-incompatible changes are introduced.

`section_number` was already used by the Office middle-JSON and Markdown rendering code. This PR only provides the existing field earlier in the DOCX conversion pipeline and preserves it through `MagicModel`.

Inputs without an explicit `section_number` continue to use the existing level-based numbering fallback. The additional field in DOCX model output is additive and does not change the existing public API.

  ## Use cases (Optional)

This fixes automatically numbered DOCX headings whose semantic outline level differs from their numbering level.

Example:

  - Semantic heading level: `outlineLvl=1` → Markdown `##`
  - Word numbering level: `ilvl=0`, `lvlText=%1.` → `1.`, `2.`

Before:

  `## 1.1 Virtual heading A`
  `## 1.2 Virtual heading B`

After:

  `## 1. Virtual heading A`
  `## 2. Virtual heading B`

  ## Checklist

  **Before PR**:

  - [x] Pre-commit or other linting tools are used to fix the potential lint issues.
  - [x] Bug fixes are fully covered by unit tests, and a synthetic case reproducing the issue has been added.
  - [x] The modification is covered by focused unit tests, including legacy fallback behavior.
  - [x] The relevant method docstring and inline comments have been updated. No public documentation change is required.

  **After PR**:

  - [x] No downstream validation is required because this change is additive and preserves the existing fallback behavior.
  - [x] CLA has been signed and all committers have signed the CLA in this PR.