### PR TITLE
build: enable hf-xet for model downloads

### DIFF
--- a/docs/plans/2026-07-21-hf-xet-dependency-design.md
+++ b/docs/plans/2026-07-21-hf-xet-dependency-design.md
@@ -1,0 +1,29 @@
+# Hugging Face Xet Dependency Design
+
+## Context
+
+MinerU exposes Hugging Face model downloads from the base installation. `huggingface-hub` 0.36.x intends to install `hf-xet` on
+supported 64-bit platforms, but its dependency marker omits the `AMD64` value reported by Windows. Environments constrained to the
+0.x line can therefore fall back to regular HTTP and repeatedly warn that `hf_xet` is unavailable.
+
+## Decision
+
+Enable the existing `hf_xet` extra on MinerU's base `huggingface-hub` dependency:
+
+```toml
+huggingface-hub[hf_xet]>=0.32.4
+```
+
+This keeps model download behavior available from the base installation and delegates the compatible `hf-xet` version to
+`huggingface-hub`. Document `HF_HUB_DISABLE_XET=1` as the explicit fallback for networks that cannot reach Xet CAS.
+
+## Consequences
+
+- Windows model downloads use Xet without a separate installation step.
+- Base installations include the `hf-xet` native wheel, including installations that only use ModelScope or remote parsing.
+- Supported mainstream 64-bit platforms have prebuilt wheels; unsupported platforms may need to build `hf-xet` or may fail to install.
+- Users behind incompatible proxies can disable Xet and retain regular HTTP downloads.
+
+## Verification
+
+Add a project metadata test that requires the `hf-xet` extra and resolve the project dependencies for Windows x86-64 before release.

--- a/docs/zh/usage/model_source.md
+++ b/docs/zh/usage/model_source.md
@@ -6,6 +6,14 @@ MinerU使用 `HuggingFace` 和 `ModelScope` 作为模型仓库，用户可以根
 - `HuggingFace` 在全球范围内提供了优异的加载速度和极高稳定性。
 - `ModelScope` 是中国大陆地区用户的最佳选择，提供了无缝兼容的SDK模块，适用于无法访问`HuggingFace`的用户。
 
+使用 `HuggingFace` 下载模型时，MinerU 默认通过 `hf_xet` 加速传输。如果当前网络或代理无法访问 Xet CAS，设置
+`HF_HUB_DISABLE_XET=1` 可回退到普通 HTTP 下载。
+
+```powershell
+$env:HF_HUB_DISABLE_XET = "1"
+mineru-kit models download --tier standard --source huggingface
+```
+
 ## 模型源的切换方法
 
 ### 通过环境变量切换

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "reportlab",
     "pdftext>=0.6.3,<0.8.0",
     "modelscope>=1.26.0",
-    "huggingface-hub>=0.32.4",
+    "huggingface-hub[hf_xet]>=0.32.4",
     "filelock>=3.0.0",
     "json-repair>=0.46.2",
     "opencv-python>=4.11.0.86",

--- a/tests/unittest/test_doclib_app_startup.py
+++ b/tests/unittest/test_doclib_app_startup.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 from loguru import logger as loguru_logger
+from packaging.requirements import Requirement
 
 from mineru.config import LogConfig, PatchedConfig, config as mineru_config
 from mineru.doclib import app as doclib_app
@@ -53,6 +54,15 @@ def test_doclib_runtime_dependencies_are_in_base_install() -> None:
     assert "aiosqlite" in dependency_names
     assert "packaging" in dependency_names
     assert "watchfiles" in dependency_names
+
+
+def test_huggingface_hub_base_dependency_enables_xet() -> None:
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    dependencies = (Requirement(raw_dependency) for raw_dependency in pyproject["project"]["dependencies"])
+    huggingface_hub = next(dependency for dependency in dependencies if dependency.name == "huggingface-hub")
+
+    assert huggingface_hub.extras == {"hf_xet"}
 
 
 def test_basic_extra_includes_preflight_runtime_dependencies() -> None:


### PR DESCRIPTION
## Summary

- request the `hf_xet` extra from the base `huggingface-hub` dependency so Windows AMD64 installations do not silently fall back to regular HTTP
- document `HF_HUB_DISABLE_XET=1` as the explicit fallback for networks that cannot reach Xet CAS
- add a project metadata regression test for the dependency extra

## Validation

- `28 passed` in `tests/unittest/test_doclib_app_startup.py`
- `101 passed` in model download and `mineru-kit` command tests
- built and checked the wheel metadata with Twine
- resolved the `basic` dependency set for Windows x86-64 / Python 3.11, selecting `huggingface-hub==0.36.2` and `hf-xet==1.5.2`
- Ruff checks passed for the changed test

Refs #5294