### PR TITLE
fix: bind doclib discovery to endpoint instance

### DIFF
--- a/docs/next/cli/mineru-e2e-test-cases.md
+++ b/docs/next/cli/mineru-e2e-test-cases.md
@@ -407,7 +407,8 @@ mineru server status --json
 预期:
 
 - endpoint 文件存在，且 stdout 可解析为 JSON
-- endpoint JSON 至少包含 `version`、`pid`、`transports`
+- endpoint JSON 至少包含 `version=2`、`pid`、非空 `server_id`、`transports`
+- endpoint JSON 的 `server_id` 等于 status JSON 的 `server_id`
 - `transports` 非空，每个 transport 均包含 `type`
 - 默认 UDS 可用环境下，`transports` 至少包含 `{"type": "uds", "path": ...}`，且 path 位于测试 HOME
 - 如果当前环境使用 TCP transport，则对应项包含 `{"type": "tcp", "base_url": "http://127.0.0.1:<port>"}`
@@ -466,7 +467,7 @@ MAIN_MINERU_HOME="$MINERU_HOME"
 export MINERU_HOME="$HOME/mineru-e2e-test-stale-endpoint"
 mkdir -p "$MINERU_HOME"
 cat > "$MINERU_HOME/doclib.endpoint.json" <<'JSON'
-{"version":1,"pid":999999,"transports":[{"type":"tcp","base_url":"http://127.0.0.1:9"}]}
+{"version":2,"pid":999999,"server_id":"stale-server","transports":[{"type":"tcp","base_url":"http://127.0.0.1:9"}]}
 JSON
 mineru server status --json
 mineru server stop
@@ -480,6 +481,19 @@ export MINERU_HOME="$MAIN_MINERU_HOME"
 - stop exit code = 0
 - stop 输出 `Server is not running` 或等价信息
 - stop 后 stale endpoint 文件被 best-effort 清理
+
+### SERVER-016 endpoint server identity 校验
+
+前置:
+
+- 主测试 HOME 的 server 正在运行。
+- 使用独立 `MINERU_HOME`，并将主测试 HOME 的 endpoint 复制到该目录后修改 `server_id`。
+
+预期:
+
+- 默认 client 在发送业务请求前发现 `server_id` 不匹配。
+- 不向主测试 HOME 的 server 发送业务请求或 shutdown 请求。
+- 没有其他匹配 transport 时返回 `server_instance_mismatch`，或由 `server status` 表示当前 HOME 的 server 未运行。
 
 ## 4A. Telemetry 命令
 
@@ -3570,6 +3584,7 @@ mineru server start
 - SERVER-013 endpoint discovery 文件写入
 - SERVER-014 TCP-only fallback
 - SERVER-015 endpoint stale 清理
+- SERVER-016 endpoint server identity 校验
 - SERVER-012 error summary 与 recent logs
 - SERVER-010 停止 server
 

--- a/docs/next/cli/mineru-server.md
+++ b/docs/next/cli/mineru-server.md
@@ -52,6 +52,7 @@
 
 - `running`
 - `pid`
+- `server_id`
 - `uptime_seconds`
 - `mineru_home`
 - `socket_path`

--- a/docs/next/decisions/0021-doclib-local-transport-discovery.md
+++ b/docs/next/decisions/0021-doclib-local-transport-discovery.md
@@ -103,8 +103,9 @@ $MINERU_HOME/doclib.endpoint.json
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "pid": 12345,
+  "server_id": "df971716-36c7-4e4d-b585-b798331ec7f4",
   "transports": [
     {
       "type": "uds",
@@ -121,6 +122,7 @@ $MINERU_HOME/doclib.endpoint.json
 规则:
 
 - 只写入实际成功绑定的 transports。
+- `server_id` 是每次 server 启动生成的随机 UUID，并由 `/server/status` 返回。
 - TCP 使用随机端口时，`base_url` 必须写入真实端口。
 - 文件写入应使用 atomic write: 先写临时文件，再 `replace`。
 - server shutdown / stop 时 best-effort 删除该文件。
@@ -170,14 +172,19 @@ DOCLIB_UDS_BASE_URL = "http://mineru"
 3. 否则读取 `$MINERU_HOME/doclib.endpoint.json`。
 4. endpoint 中同时存在 UDS 和 TCP 时，优先尝试 UDS。
 5. UDS 不存在、不可用或连接失败时，尝试 TCP。
-6. endpoint 不存在时，可以根据当前 config 推导默认 UDS / TCP endpoint 作为 fallback。
-7. 所有候选 endpoint 都失败时，抛 `ServerNotRunningError`。
+6. endpoint 不存在、无效或不包含可用 transport 时，不根据当前 config 推导 transport。
+7. 第一次使用候选 transport 前，通过 `/server/status` 校验其 `server_id` 与 endpoint 一致。
+8. 身份不匹配时继续尝试下一个 transport；所有候选均不匹配时抛出 `server_instance_mismatch`。
+9. 没有候选 endpoint 或所有候选 endpoint 都无法连接时，抛 `ServerNotRunningError`。
+
+显式 `socket_path` 或 `base_url` 代表调用方明确选择的 server，不执行 endpoint `server_id` 校验。
 
 CLI 的 `server status`、`server stop` 和业务命令都应使用同一套 resolver，不再依赖 socket 文件是否存在判断 server 是否运行。
 
 ### Server status
 
-状态模型中的 `http` 字段改为 `tcp`，CLI human-readable 输出也显示 `TCP`。
+状态模型中的 `http` 字段改为 `tcp`，CLI human-readable 输出也显示 `TCP`。状态中的 `server_id` 标识当前
+server 进程，并用于默认 endpoint discovery 的身份校验；`pid` 和 `mineru_home` 只用于诊断。
 
 `server status --json` 应继续返回:
 

--- a/docs/next/errors.md
+++ b/docs/next/errors.md
@@ -172,6 +172,7 @@ CLI 在调用 server 前或通信层面产生本地错误。它们使用同一 `
 | `invalid_request_error` | `file_not_found` | 否 | 本地文件路径不存在 | `check_path` |
 | `invalid_request_error` | `file_permission_denied` | 否 | 本地文件无读取权限 | `fix_file_permission` |
 | `api_error` | `server_not_running` | 是 | CLI 无法连接 doclib UDS | `run_mineru_server_start` |
+| `api_error` | `server_instance_mismatch` | 是 | endpoint 指向的进程不是写入该 endpoint 的 server 实例 | `restart_server` |
 | `api_error` | `server_protocol_error` | 是 | CLI 与 server 协议不兼容或响应损坏 | `upgrade_or_restart_server` |
 
 CLI 在 TTY 中可以用表格或 rich 文本展示，但非 TTY、`--json` 或 Agent 调用场景应输出结构化错误。

--- a/docs/next/sdk/doclib-client.md
+++ b/docs/next/sdk/doclib-client.md
@@ -46,7 +46,10 @@ class DoclibClient:
 
 - 构造 client 不应启动 doclib server。
 - 默认通过 `$MINERU_HOME/doclib.endpoint.json` 发现 doclib endpoint。
+- 默认发现不从启动配置推导 UDS 或 TCP；endpoint 文件不存在或无效时，方法调用抛出 `ServerNotRunningError`。
+- 默认发现会在首次请求前校验 endpoint 与 `/server/status` 的 `server_id`；不匹配的 transport 不会承载业务请求。
 - `socket_path` 表示显式 UDS endpoint；`base_url` 只表示显式 TCP endpoint，例如 `http://127.0.0.1:15980`。
+- 显式 `socket_path` / `base_url` 代表调用方明确选择的 server，不执行 endpoint `server_id` 校验。
 - `socket_path` 和 `base_url` 不能同时传入。
 - 无法连接任何候选 endpoint 时，方法调用抛出 `ServerNotRunningError`。
 - client 当前支持 `close()`；是否增加 context manager 仍是迁移任务。

--- a/docs/plans/2026-07-21-endpoint-only-discovery-design.md
+++ b/docs/plans/2026-07-21-endpoint-only-discovery-design.md
@@ -18,12 +18,27 @@ Transports recorded in a valid endpoint file remain ordered with UDS before
 TCP. Explicit `socket_path` and `base_url` constructor arguments remain direct
 endpoint overrides and do not read the discovery file.
 
-This change does not add server home validation. That is a separate follow-up
-needed to reject stale endpoint files that resolve to a live server owned by a
-different home.
+## Server identity validation
+
+Each Doclib Server process generates a random `server_id`. Endpoint version 2
+stores that identifier alongside the PID and transports, and
+`GET /server/status` returns the same value. A default-discovery client lazily
+probes each candidate transport before its first business request and only uses
+a candidate whose reported `server_id` matches the endpoint.
+
+This binds the endpoint file selected through `MINERU_HOME` to the exact server
+process that wrote it without comparing runtime-specific path strings. A stale
+endpoint whose TCP port or UDS path has been reused is rejected with
+`server_instance_mismatch`. Version 1 endpoints and malformed version 2
+endpoints are invalid and provide no connection candidates.
+
+Explicit `socket_path` and `base_url` values represent a caller-selected server
+and bypass endpoint discovery and instance validation. PID and `mineru_home`
+remain diagnostic fields and are not identity checks.
 
 ## Verification
 
-Unit tests cover valid endpoint ordering, missing and invalid endpoint files,
-and explicit UDS/TCP overrides. Existing doclib and CLI server tests must remain
-green.
+Unit tests cover endpoint schema round trips, valid endpoint ordering, missing
+and invalid endpoint files, explicit UDS/TCP overrides, matching identities,
+mismatched identities, and fallback to another transport after an identity
+mismatch. Existing doclib and CLI server tests must remain green.

--- a/docs/plans/2026-07-21-endpoint-only-discovery-design.md
+++ b/docs/plans/2026-07-21-endpoint-only-discovery-design.md
@@ -1,0 +1,29 @@
+# Endpoint-only Doclib discovery
+
+## Context
+
+The default `DoclibClient` resolver reads the endpoint file under the current
+`MINERU_HOME`, but currently derives UDS or TCP transports from startup
+configuration when that file is missing or invalid. A derived TCP endpoint can
+connect to a server owned by another home.
+
+## Decision
+
+Default discovery treats `$MINERU_HOME/doclib.endpoint.json` as the sole source
+of runtime transports. If the file is absent, invalid, or contains no usable
+transport, the client has no connection candidates and reports that the server
+is not running when a request is made.
+
+Transports recorded in a valid endpoint file remain ordered with UDS before
+TCP. Explicit `socket_path` and `base_url` constructor arguments remain direct
+endpoint overrides and do not read the discovery file.
+
+This change does not add server home validation. That is a separate follow-up
+needed to reject stale endpoint files that resolve to a live server owned by a
+different home.
+
+## Verification
+
+Unit tests cover valid endpoint ordering, missing and invalid endpoint files,
+and explicit UDS/TCP overrides. Existing doclib and CLI server tests must remain
+green.

--- a/mineru/doclib/app.py
+++ b/mineru/doclib/app.py
@@ -8,6 +8,7 @@ import logging
 import os
 import socket
 import time
+import uuid
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 from logging.handlers import RotatingFileHandler
@@ -299,6 +300,7 @@ class AppState:
         self.background_tasks: list[asyncio.Task[Any]] = []
         self.start_time: float = 0.0
         self.pid: int = 0
+        self.server_id: str = str(uuid.uuid4())
         self.mineru_home: str = ""
         self.socket_path: str = ""
         self.data_dir: str = ""
@@ -436,7 +438,8 @@ def main() -> None:
         raise RuntimeError("At least one doclib local transport must be enabled.")
     if uds_enabled and not uds_available():
         raise RuntimeError(
-            "Unix domain socket is enabled but is not available in this Python runtime. Enable doclib.tcp or disable doclib.uds."
+            "Unix domain socket is enabled but is not available in this Python runtime. "
+            "Enable doclib.tcp or disable doclib.uds."
         )
 
     app = create_app(cfg)
@@ -479,7 +482,12 @@ def main() -> None:
     else:
         app.state.doclib_state.tcp_port = None
 
-    write_endpoint_file(endpoint_path, pid=os.getpid(), transports=transports)
+    write_endpoint_file(
+        endpoint_path,
+        pid=os.getpid(),
+        server_id=app.state.doclib_state.server_id,
+        transports=transports,
+    )
     print("MinerU server listening on " + " and ".join(_format_transport(transport) for transport in transports))
 
     loop = asyncio.new_event_loop()

--- a/mineru/doclib/client.py
+++ b/mineru/doclib/client.py
@@ -16,7 +16,6 @@ from .base import DoclibInterface
 from .endpoint import (
     DOCLIB_UDS_BASE_URL,
     EndpointTransport,
-    config_transports,
     default_endpoint_path,
     read_endpoint_file,
     uds_available,
@@ -103,13 +102,14 @@ class DoclibClient(DoclibInterface):
     ) -> None:
         if socket_path is not None and base_url is not None:
             raise ValueError("socket_path and base_url cannot both be provided.")
-        self._clients = _build_clients(
+        self._clients, self._expected_server_id = _build_clients(
             endpoint_path=endpoint_path,
             socket_path=socket_path,
             base_url=base_url,
             timeout=timeout,
         )
         self._active_client: httpx.Client | None = self._clients[0] if self._clients else None
+        self._validated_client_ids: set[int] = set()
         self._api_prefix = api_prefix.rstrip("/")
         self._default_telemetry_context = infer_default_client_context(source="sdk")
 
@@ -425,8 +425,10 @@ class DoclibClient(DoclibInterface):
         if not self._clients:
             raise ServerNotRunningError()
         clients = self._ordered_clients()
+        instance_mismatch: _ServerInstanceMismatch | None = None
         for client in clients:
             try:
+                self._validate_server_instance(client)
                 if method == "GET":
                     resp = client.get(path, params=params, headers=self._telemetry_headers())
                 elif method == "POST":
@@ -438,10 +440,37 @@ class DoclibClient(DoclibInterface):
                 else:
                     raise MineruError("internal_error", f"Unsupported client method: {method}")
             except httpx.ConnectError:
+                self._validated_client_ids.discard(id(client))
+                continue
+            except _ServerInstanceMismatch as exc:
+                instance_mismatch = exc
                 continue
             self._active_client = client
             return resp
+        if instance_mismatch is not None:
+            raise MineruError(
+                "server_instance_mismatch",
+                "The discovered endpoint belongs to a different MinerU server instance. "
+                "Restart the local MinerU server to refresh the endpoint file.",
+            )
         raise ServerNotRunningError() from None
+
+    def _validate_server_instance(self, client: httpx.Client) -> None:
+        expected_server_id = self._expected_server_id
+        client_id = id(client)
+        if expected_server_id is None or client_id in self._validated_client_ids:
+            return
+
+        resp = client.get(
+            f"{self._api_prefix}/server/status",
+            params={},
+            headers=self._telemetry_headers(),
+        )
+        data = _decode_response(resp)
+        actual_server_id = data.get("server_id")
+        if actual_server_id != expected_server_id:
+            raise _ServerInstanceMismatch()
+        self._validated_client_ids.add(client_id)
 
     def _ordered_clients(self) -> list[httpx.Client]:
         if self._active_client is None:
@@ -483,25 +512,25 @@ def _build_clients(
     socket_path: str | Path | None,
     base_url: str | None,
     timeout: int,
-) -> list[httpx.Client]:
+) -> tuple[list[httpx.Client], str | None]:
     if socket_path is not None:
         client = _client_for_transport(EndpointTransport(type="uds", path=str(socket_path)), timeout=timeout)
-        return [client] if client is not None else []
+        return ([client] if client is not None else [], None)
     if base_url is not None:
         client = _client_for_transport(EndpointTransport(type="tcp", base_url=base_url), timeout=timeout)
-        return [client] if client is not None else []
+        return ([client] if client is not None else [], None)
 
     discovery_path = str(endpoint_path) if endpoint_path is not None else default_endpoint_path()
-    transports = read_endpoint_file(discovery_path)
-    if not transports:
-        transports = config_transports()
+    endpoint = read_endpoint_file(discovery_path)
+    if endpoint is None:
+        return [], None
 
     clients: list[httpx.Client] = []
-    for transport in sorted(transports, key=lambda item: 0 if item.type == "uds" else 1):
+    for transport in sorted(endpoint.transports, key=lambda item: 0 if item.type == "uds" else 1):
         client = _client_for_transport(transport, timeout=timeout)
         if client is not None:
             clients.append(client)
-    return clients
+    return clients, endpoint.server_id
 
 
 def _client_for_transport(transport: EndpointTransport, *, timeout: int) -> httpx.Client | None:
@@ -517,6 +546,10 @@ def _client_for_transport(transport: EndpointTransport, *, timeout: int) -> http
     if not transport.base_url:
         return None
     return httpx.Client(base_url=transport.base_url, timeout=timeout, trust_env=False)
+
+
+class _ServerInstanceMismatch(Exception):
+    pass
 
 
 def _decode_response(resp: httpx.Response) -> dict[str, Any]:

--- a/mineru/doclib/endpoint.py
+++ b/mineru/doclib/endpoint.py
@@ -21,8 +21,16 @@ class EndpointTransport:
     base_url: str | None = None
 
 
+@dataclass(frozen=True)
+class EndpointInfo:
+    version: int
+    pid: int | None
+    server_id: str
+    transports: list[EndpointTransport]
+
+
 DOCLIB_UDS_BASE_URL = "http://mineru"
-ENDPOINT_VERSION = 1
+ENDPOINT_VERSION = 2
 
 
 def uds_available() -> bool:
@@ -38,12 +46,13 @@ def default_endpoint_path(cfg: Config | None = None) -> str:
     return os.path.expanduser(cfg.doclib.endpoint_path)
 
 
-def write_endpoint_file(path: str | os.PathLike[str], *, pid: int, transports: list[EndpointTransport]) -> None:
+def write_endpoint_file(path: str | os.PathLike[str], *, pid: int, server_id: str, transports: list[EndpointTransport]) -> None:
     endpoint_path = Path(path).expanduser()
     endpoint_path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "version": ENDPOINT_VERSION,
         "pid": pid,
+        "server_id": server_id,
         "transports": [_transport_to_payload(transport) for transport in transports],
     }
     tmp_path = endpoint_path.with_name(f"{endpoint_path.name}.tmp")
@@ -62,26 +71,26 @@ def remove_endpoint_file(path: str | os.PathLike[str]) -> None:
         pass
 
 
-def read_endpoint_file(path: str | os.PathLike[str]) -> list[EndpointTransport]:
+def read_endpoint_file(path: str | os.PathLike[str]) -> EndpointInfo | None:
     endpoint_path = Path(path).expanduser()
     try:
         payload = json.loads(endpoint_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return []
+        return None
+    if not isinstance(payload, dict):
+        return None
+    version = payload.get("version")
+    pid = payload.get("pid")
+    server_id = payload.get("server_id")
     transports = payload.get("transports")
-    if not isinstance(transports, list):
-        return []
-    return [_parse_transport(item) for item in transports if isinstance(item, dict)]
-
-
-def config_transports(cfg: Config | None = None) -> list[EndpointTransport]:
-    cfg = config if cfg is None else cfg
-    transports: list[EndpointTransport] = []
-    if cfg.doclib.resolved_uds_enabled and uds_available():
-        transports.append(EndpointTransport(type="uds", path=os.path.expanduser(cfg.doclib.uds.path)))
-    if cfg.doclib.resolved_tcp_enabled:
-        transports.append(EndpointTransport(type="tcp", base_url=f"http://{cfg.doclib.tcp.host}:{cfg.doclib.tcp.port}"))
-    return transports
+    if version != ENDPOINT_VERSION or not isinstance(server_id, str) or not server_id or not isinstance(transports, list):
+        return None
+    return EndpointInfo(
+        version=version,
+        pid=pid if isinstance(pid, int) and not isinstance(pid, bool) and pid > 0 else None,
+        server_id=server_id,
+        transports=[_parse_transport(item) for item in transports if isinstance(item, dict)],
+    )
 
 
 def _transport_to_payload(transport: EndpointTransport) -> dict[str, str]:
@@ -104,8 +113,8 @@ def _parse_transport(item: dict[str, Any]) -> EndpointTransport:
 __all__ = [
     "DOCLIB_UDS_BASE_URL",
     "ENDPOINT_VERSION",
+    "EndpointInfo",
     "EndpointTransport",
-    "config_transports",
     "default_endpoint_path",
     "read_endpoint_file",
     "remove_endpoint_file",

--- a/mineru/doclib/server.py
+++ b/mineru/doclib/server.py
@@ -289,6 +289,7 @@ class DoclibServer(AsyncDoclibInterface):
         return ServerStatusResponse(
             running=True,
             pid=getattr(self.state, "pid", os.getpid()),
+            server_id=getattr(self.state, "server_id", ""),
             uptime_seconds=uptime,
             mineru_home=getattr(self.state, "mineru_home", ""),
             version=__version__,

--- a/mineru/doclib/types.py
+++ b/mineru/doclib/types.py
@@ -591,6 +591,7 @@ class ErrorSummary(DoclibModel):
 class ServerStatusResponse(DoclibModel):
     running: bool
     pid: int | None = None
+    server_id: str = ""
     uptime_seconds: float | None = None
     mineru_home: str = ""
     version: str = ""

--- a/mineru/errors.py
+++ b/mineru/errors.py
@@ -90,6 +90,7 @@ _ERROR_TYPE_MAP: dict[str, ErrorType] = {
     "scan_failed": "api_error",
     "service_unavailable": "api_error",
     "server_not_running": "api_error",
+    "server_instance_mismatch": "api_error",
     "server_busy": "api_error",
     "remote_timeout": "api_error",
     "remote_unreachable": "api_error",

--- a/tests/unittest/test_doclib_app_startup.py
+++ b/tests/unittest/test_doclib_app_startup.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import subprocess
 import tomllib
+import uuid
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
@@ -378,6 +379,7 @@ def test_server_status_reports_configured_socket_path(monkeypatch, tmp_path) -> 
 
     assert response.status_code == 200
     payload = response.json()
+    assert uuid.UUID(payload["server_id"])
     assert payload["mineru_home"]
     assert payload["version"] == __version__
     assert isinstance(payload["python_version"], str)

--- a/tests/unittest/test_doclib_endpoint.py
+++ b/tests/unittest/test_doclib_endpoint.py
@@ -1,27 +1,55 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
+import httpx
 import pytest
 
-from mineru.config import PatchedConfig
 from mineru.doclib import client as client_module
 from mineru.doclib.client import DoclibClient
 from mineru.doclib.endpoint import (
     DOCLIB_UDS_BASE_URL,
+    ENDPOINT_VERSION,
+    EndpointInfo,
     EndpointTransport,
-    config_transports,
     read_endpoint_file,
     write_endpoint_file,
 )
+from mineru.errors import MineruError, ServerNotRunningError
 
 
-def test_endpoint_file_round_trips_transports(tmp_path) -> None:
+def _status_payload(server_id: str) -> dict[str, object]:
+    return {
+        "running": True,
+        "server_id": server_id,
+        "socket_path": "",
+        "data_dir": "",
+        "sqlite_path": "",
+        "log_path": "",
+    }
+
+
+class _FakeClient:
+    def __init__(self, server_id: str) -> None:
+        self.server_id = server_id
+        self.paths: list[str] = []
+
+    def get(self, path: str, *, params: dict | None = None, headers: dict | None = None) -> httpx.Response:
+        self.paths.append(path)
+        return httpx.Response(200, json=_status_payload(self.server_id), request=httpx.Request("GET", path))
+
+    def close(self) -> None:
+        pass
+
+
+def test_endpoint_file_round_trips_transports(tmp_path: Path) -> None:
     endpoint = tmp_path / "doclib.endpoint.json"
 
     write_endpoint_file(
         endpoint,
         pid=123,
+        server_id="server-123",
         transports=[
             EndpointTransport(type="uds", path=str(tmp_path / "doclib.sock")),
             EndpointTransport(type="tcp", base_url="http://127.0.0.1:15980"),
@@ -29,23 +57,40 @@ def test_endpoint_file_round_trips_transports(tmp_path) -> None:
     )
 
     payload = json.loads(endpoint.read_text(encoding="utf-8"))
-    assert payload["version"] == 1
+    assert payload["version"] == ENDPOINT_VERSION
     assert payload["pid"] == 123
-    assert read_endpoint_file(endpoint) == [
-        EndpointTransport(type="uds", path=str(tmp_path / "doclib.sock")),
-        EndpointTransport(type="tcp", base_url="http://127.0.0.1:15980"),
-    ]
-
-
-def test_config_transports_uses_tcp_when_uds_disabled(tmp_path) -> None:
-    cfg = PatchedConfig(
-        doclib={
-            "uds": {"enabled": False, "path": str(tmp_path / "doclib.sock")},
-            "tcp": {"enabled": True, "host": "127.0.0.1", "port": 17000},
-        }
+    assert payload["server_id"] == "server-123"
+    assert read_endpoint_file(endpoint) == EndpointInfo(
+        version=ENDPOINT_VERSION,
+        pid=123,
+        server_id="server-123",
+        transports=[
+            EndpointTransport(type="uds", path=str(tmp_path / "doclib.sock")),
+            EndpointTransport(type="tcp", base_url="http://127.0.0.1:15980"),
+        ],
     )
 
-    assert config_transports(cfg) == [EndpointTransport(type="tcp", base_url="http://127.0.0.1:17000")]
+
+def test_endpoint_pid_is_diagnostic_only(tmp_path: Path) -> None:
+    endpoint = tmp_path / "doclib.endpoint.json"
+    endpoint.write_text(
+        json.dumps(
+            {
+                "version": ENDPOINT_VERSION,
+                "pid": "not-a-pid",
+                "server_id": "server-123",
+                "transports": [{"type": "tcp", "base_url": "http://127.0.0.1:15980"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert read_endpoint_file(endpoint) == EndpointInfo(
+        version=ENDPOINT_VERSION,
+        pid=None,
+        server_id="server-123",
+        transports=[EndpointTransport(type="tcp", base_url="http://127.0.0.1:15980")],
+    )
 
 
 def test_doclib_client_rejects_explicit_uds_and_tcp() -> None:
@@ -53,11 +98,38 @@ def test_doclib_client_rejects_explicit_uds_and_tcp() -> None:
         DoclibClient(socket_path="/tmp/doclib.sock", base_url="http://127.0.0.1:15980")
 
 
-def test_doclib_client_discovers_uds_then_tcp(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+@pytest.mark.parametrize(
+    ("override", "expected_transport"),
+    [
+        ({"socket_path": "/tmp/explicit.sock"}, EndpointTransport(type="uds", path="/tmp/explicit.sock")),
+        ({"base_url": "http://127.0.0.1:17000"}, EndpointTransport(type="tcp", base_url="http://127.0.0.1:17000")),
+    ],
+)
+def test_doclib_client_explicit_transport_bypasses_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    override: dict[str, str],
+    expected_transport: EndpointTransport,
+) -> None:
+    transports: list[EndpointTransport] = []
+
+    def _record_transport(transport: EndpointTransport, *, timeout: int) -> None:
+        transports.append(transport)
+
+    monkeypatch.setattr(client_module, "read_endpoint_file", lambda path: pytest.fail(f"unexpected discovery read: {path}"))
+    monkeypatch.setattr(client_module, "_client_for_transport", _record_transport)
+
+    DoclibClient(endpoint_path=tmp_path / "missing.json", **override)
+
+    assert transports == [expected_transport]
+
+
+def test_doclib_client_discovers_uds_then_tcp(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     endpoint = tmp_path / "doclib.endpoint.json"
     write_endpoint_file(
         endpoint,
         pid=123,
+        server_id="server-123",
         transports=[
             EndpointTransport(type="tcp", base_url="http://127.0.0.1:15980"),
             EndpointTransport(type="uds", path=str(tmp_path / "doclib.sock")),
@@ -70,7 +142,7 @@ def test_doclib_client_discovers_uds_then_tcp(monkeypatch: pytest.MonkeyPatch, t
             self.uds = uds
 
     class _Client:
-        def __init__(self, *, transport=None, base_url: str, timeout: int, trust_env: bool) -> None:
+        def __init__(self, *, transport: object | None = None, base_url: str, timeout: int, trust_env: bool) -> None:
             calls.append({"transport": transport, "base_url": base_url, "timeout": timeout, "trust_env": trust_env})
 
         def close(self) -> None:
@@ -86,3 +158,102 @@ def test_doclib_client_discovers_uds_then_tcp(monkeypatch: pytest.MonkeyPatch, t
     assert calls[0]["base_url"] == DOCLIB_UDS_BASE_URL
     assert calls[0]["transport"].uds == str(tmp_path / "doclib.sock")
     assert calls[1] == {"transport": None, "base_url": "http://127.0.0.1:15980", "timeout": 5, "trust_env": False}
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        None,
+        "{}",
+        "not json",
+        json.dumps({"version": 1, "pid": 123, "transports": [{"type": "tcp", "base_url": "http://127.0.0.1:15980"}]}),
+    ],
+)
+def test_doclib_client_does_not_infer_transports_without_valid_endpoint(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, contents: str | None
+) -> None:
+    endpoint = tmp_path / "doclib.endpoint.json"
+    if contents is not None:
+        endpoint.write_text(contents, encoding="utf-8")
+    inferred_transports: list[EndpointTransport] = []
+
+    def _reject_inferred_transport(transport: EndpointTransport, *, timeout: int) -> None:
+        inferred_transports.append(transport)
+        return None
+
+    monkeypatch.setattr(client_module, "_client_for_transport", _reject_inferred_transport)
+
+    client = DoclibClient(endpoint_path=endpoint)
+
+    assert inferred_transports == []
+    with pytest.raises(ServerNotRunningError):
+        client.get_server_status()
+
+
+def test_doclib_client_lazily_validates_discovered_server_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    endpoint = tmp_path / "doclib.endpoint.json"
+    write_endpoint_file(
+        endpoint,
+        pid=123,
+        server_id="expected-server",
+        transports=[EndpointTransport(type="tcp", base_url="http://127.0.0.1:15980")],
+    )
+    fake_client = _FakeClient("expected-server")
+    monkeypatch.setattr(client_module, "_client_for_transport", lambda transport, timeout: fake_client)
+
+    client = DoclibClient(endpoint_path=endpoint)
+
+    assert fake_client.paths == []
+    status = client.get_server_status()
+    assert status.server_id == "expected-server"
+    assert fake_client.paths == ["/api/v1/server/status", "/api/v1/server/status"]
+
+
+def test_doclib_client_rejects_discovered_server_id_mismatch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    endpoint = tmp_path / "doclib.endpoint.json"
+    write_endpoint_file(
+        endpoint,
+        pid=123,
+        server_id="expected-server",
+        transports=[EndpointTransport(type="tcp", base_url="http://127.0.0.1:15980")],
+    )
+    fake_client = _FakeClient("other-server")
+    monkeypatch.setattr(client_module, "_client_for_transport", lambda transport, timeout: fake_client)
+
+    client = DoclibClient(endpoint_path=endpoint)
+
+    with pytest.raises(MineruError) as exc_info:
+        client.get_server_status()
+    assert exc_info.value.code == "server_instance_mismatch"
+    assert fake_client.paths == ["/api/v1/server/status"]
+
+
+def test_doclib_client_tries_next_transport_after_server_id_mismatch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    endpoint = tmp_path / "doclib.endpoint.json"
+    first_url = "http://127.0.0.1:15980"
+    second_url = "http://127.0.0.1:15981"
+    write_endpoint_file(
+        endpoint,
+        pid=123,
+        server_id="expected-server",
+        transports=[
+            EndpointTransport(type="tcp", base_url=first_url),
+            EndpointTransport(type="tcp", base_url=second_url),
+        ],
+    )
+    fake_clients = {
+        first_url: _FakeClient("other-server"),
+        second_url: _FakeClient("expected-server"),
+    }
+
+    def _fake_client_for_transport(transport: EndpointTransport, *, timeout: int) -> _FakeClient:
+        assert transport.base_url is not None
+        return fake_clients[transport.base_url]
+
+    monkeypatch.setattr(client_module, "_client_for_transport", _fake_client_for_transport)
+
+    status = DoclibClient(endpoint_path=endpoint).get_server_status()
+
+    assert status.server_id == "expected-server"
+    assert fake_clients[first_url].paths == ["/api/v1/server/status"]
+    assert fake_clients[second_url].paths == ["/api/v1/server/status", "/api/v1/server/status"]

--- a/tests/unittest/test_errors.py
+++ b/tests/unittest/test_errors.py
@@ -41,6 +41,7 @@ DOCLIB_CONTRACT_ERROR_CODES = {
     "quality_tier_unavailable",
     "rule_not_found",
     "scan_not_found",
+    "server_instance_mismatch",
     "tier_mismatch",
     "tier_not_cached",
     "watch_not_found",
@@ -79,6 +80,7 @@ def test_doclib_error_code_types_are_stable() -> None:
     assert error_type_for("parse_json_write_failed") == "api_error"
     assert error_type_for("read_metadata_failed") == "api_error"
     assert error_type_for("scan_failed") == "api_error"
+    assert error_type_for("server_instance_mismatch") == "api_error"
 
 
 def test_http_status_for_error_codes_is_stable() -> None:


### PR DESCRIPTION
## Summary

- make the current `MINERU_HOME` endpoint file the sole source for default Doclib transport discovery
- add endpoint schema v2 with a per-process `server_id` and expose the same ID through server status
- validate discovered transports before business requests and reject stale or reused endpoints with `server_instance_mismatch`
- preserve explicit `socket_path` and `base_url` as caller-selected overrides
- document the discovery contract and add endpoint, fallback, lifecycle, and error-code coverage

Endpoint v1 files are intentionally treated as invalid because they cannot prove which server instance wrote them. PID and `mineru_home` remain diagnostic fields and do not participate in identity validation.

## Verification

- `ruff check` passed for changed implementation and focused test files
- `ruff format --check` passed for changed Python files
- `pytest tests/unittest -q`: 814 passed
- real-process check confirmed that a copied endpoint with a modified `server_id` is rejected and cannot stop the original server

Related to #5298