### PR TITLE
Fix PPTX chart stalls and render charts as SVG

### DIFF
--- a/mineru/backend/office/mkcontent/output_builders.py
+++ b/mineru/backend/office/mkcontent/output_builders.py
@@ -46,6 +46,11 @@ def _format_embedded_html(html: str, img_buket_path: str) -> str:
     return _replace_eq_tags_in_table_html(_prefix_table_img_src(html, img_buket_path))
 
 
+def _build_visual_details_block(content: str, summary: str) -> str:
+    """Preserve structured visual content without replacing the rendered visual."""
+    return f"<details>\n<summary>{summary}</summary>\n\n{content}\n\n</details>"
+
+
 def _build_media_path(img_buket_path: str, image_path: str) -> str:
     """构造图片展示路径，空图片路径保持为空。"""
     if not image_path:
@@ -413,11 +418,20 @@ def mk_blocks_to_markdown(para_blocks, make_mode, img_buket_path='', page_idx=No
                 continue
             elif make_mode == MakeMode.MM_MD:
                 image_path, chart_content = get_body_data(para_block)
-                if chart_content:
-                    para_text += f"\n{_format_embedded_html(chart_content, img_buket_path)}\n"
-                elif image_path:
+                if image_path:
                     para_text += f"![]({_build_media_path(img_buket_path, image_path)})"
-                else:
+                if chart_content:
+                    formatted_content = _format_embedded_html(
+                        chart_content,
+                        img_buket_path,
+                    )
+                    if image_path:
+                        formatted_content = _build_visual_details_block(
+                            formatted_content,
+                            "chart content",
+                        )
+                    para_text += f"\n{formatted_content}\n"
+                if not image_path and not chart_content:
                     continue
                 for caption_text in _collect_caption_texts(
                     para_block,

--- a/mineru/backend/utils/office_chart.py
+++ b/mineru/backend/utils/office_chart.py
@@ -1,4 +1,5 @@
 # Copyright (c) Opendatalab. All rights reserved.
+import base64
 import math
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
@@ -10,12 +11,41 @@ from lxml import etree
 from openpyxl import load_workbook
 from openpyxl.utils.cell import range_to_tuple
 from openpyxl.utils.datetime import MAC_EPOCH, WINDOWS_EPOCH, from_excel
+from reportlab.graphics import renderSVG
+from reportlab.graphics.charts.barcharts import VerticalBarChart
+from reportlab.graphics.charts.lineplots import LinePlot
+from reportlab.graphics.shapes import Drawing, Group, Line, Rect, String
+from reportlab.lib import colors
 
 
 _CHART_NS: Final = "http://schemas.openxmlformats.org/drawingml/2006/chart"
 _DRAWING_NS: Final = "http://schemas.openxmlformats.org/drawingml/2006/main"
 _NS: Final = {"c": _CHART_NS, "a": _DRAWING_NS}
 _MAX_CACHE_INDEX_SPAN: Final = 100_000
+_DEFAULT_CHART_WIDTH: Final = 960
+_DEFAULT_CHART_HEIGHT: Final = 540
+_CHART_PALETTE: Final = (
+    "4472C4",
+    "ED7D31",
+    "70AD47",
+    "A5A5A5",
+    "FFC000",
+    "5B9BD5",
+    "C00000",
+    "00B050",
+)
+_SCHEME_COLORS: Final = {
+    "dk1": "000000",
+    "lt1": "FFFFFF",
+    "dk2": "1F497D",
+    "lt2": "EEECE1",
+    "accent1": "4F81BD",
+    "accent2": "C0504D",
+    "accent3": "9BBB59",
+    "accent4": "8064A2",
+    "accent5": "4BACC6",
+    "accent6": "F79646",
+}
 _PLOT_TAGS: Final = (
     "areaChart",
     "area3DChart",
@@ -49,6 +79,9 @@ class SeriesSpec:
     cached_x_values: list[str] = field(default_factory=list)
     cached_values: list[str] = field(default_factory=list)
     cached_bubble_sizes: list[str] = field(default_factory=list)
+    line_color: str | None = None
+    line_dash: str | None = None
+    line_width: float | None = None
 
 
 @dataclass
@@ -62,6 +95,12 @@ class ChartSpec:
     has_date_axis: bool = False
     date_1904: bool = False
     series: list[SeriesSpec] = field(default_factory=list)
+    x_axis_min: float | None = None
+    x_axis_max: float | None = None
+    x_axis_major_unit: float | None = None
+    y_axis_min: float | None = None
+    y_axis_max: float | None = None
+    y_axis_major_unit: float | None = None
 
 
 def html_table_from_excel_bytes(excel_bytes: bytes) -> str:
@@ -178,6 +217,329 @@ def extract_chart_html_from_ooxml(chart_xml: bytes, workbook_bytes: bytes | None
     return chart_cache_html
 
 
+def render_chart_svg_from_ooxml(
+    chart_xml: bytes,
+    width: int = _DEFAULT_CHART_WIDTH,
+    height: int = _DEFAULT_CHART_HEIGHT,
+) -> str:
+    """Render supported OOXML charts as an SVG data URI using cached display data."""
+    spec = parse_chart_spec_from_ooxml(chart_xml)
+    if spec is None or not spec.series:
+        return ""
+
+    drawing = _build_chart_drawing(spec, width, height)
+    if drawing is None:
+        return ""
+
+    svg = renderSVG.drawToString(drawing)
+    encoded = base64.b64encode(svg.encode("utf-8")).decode("ascii")
+    return f"data:image/svg+xml;base64,{encoded}"
+
+
+def _build_chart_drawing(spec: ChartSpec, width: int, height: int) -> Drawing | None:
+    width = max(int(width), 320)
+    height = max(int(height), 240)
+    if spec.plot_kind == "scatter":
+        return _build_scatter_chart_drawing(spec, width, height)
+    if spec.chart_type in {"barChart", "bar3DChart"}:
+        return _build_bar_chart_drawing(spec, width, height)
+    return None
+
+
+def _chart_number(value: Any) -> float | None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _scatter_series_data(
+    spec: ChartSpec,
+) -> list[tuple[SeriesSpec, str, list[tuple[float, float]]]]:
+    series_data = []
+    for index, series in enumerate(spec.series, start=1):
+        points = []
+        for raw_x, raw_y in zip(series.cached_x_values, series.cached_values):
+            x_value = _chart_number(raw_x)
+            y_value = _chart_number(raw_y)
+            if x_value is not None and y_value is not None:
+                points.append((x_value, y_value))
+        if points:
+            series_data.append((series, _resolve_series_name(series, index), points))
+    return series_data
+
+
+def _category_series_data(
+    spec: ChartSpec,
+) -> tuple[list[str], list[tuple[SeriesSpec, str, list[float]]]]:
+    categories = next(
+        (series.cached_categories for series in spec.series if series.cached_categories),
+        [],
+    )
+    row_count = max(
+        len(categories),
+        max((len(series.cached_values) for series in spec.series), default=0),
+    )
+    if row_count == 0:
+        return [], []
+    if not categories:
+        categories = [str(index) for index in range(1, row_count + 1)]
+    elif len(categories) < row_count:
+        categories = [*categories, *[""] * (row_count - len(categories))]
+
+    series_data = []
+    for index, series in enumerate(spec.series, start=1):
+        values = []
+        for raw_value in series.cached_values:
+            value = _chart_number(raw_value)
+            values.append(value if value is not None else 0.0)
+        values.extend([0.0] * (row_count - len(values)))
+        series_data.append((series, _resolve_series_name(series, index), values))
+    return categories, series_data
+
+
+def _series_color(series: SeriesSpec, index: int):
+    color_value = series.line_color or _CHART_PALETTE[index % len(_CHART_PALETTE)]
+    return colors.HexColor(f"#{color_value}")
+
+
+def _line_dash_array(dash_name: str | None) -> list[int] | None:
+    if dash_name in {"dash", "sysDash", "lgDash"}:
+        return [8, 5]
+    if dash_name in {"dot", "sysDot"}:
+        return [2, 4]
+    if dash_name in {"dashDot", "sysDashDot", "lgDashDot"}:
+        return [8, 4, 2, 4]
+    if dash_name in {"lgDashDotDot", "sysDashDotDot"}:
+        return [10, 4, 2, 4, 2, 4]
+    return None
+
+
+def _configure_value_axis(axis, value_min, value_max, major_unit) -> None:
+    axis.visibleGrid = True
+    axis.gridStrokeColor = colors.HexColor("#D9D9D9")
+    axis.gridStrokeWidth = 0.6
+    axis.gridStrokeDashArray = [1, 2]
+    axis.strokeColor = colors.HexColor("#A6A6A6")
+    axis.labels.fillColor = colors.HexColor("#262626")
+    axis.labels.fontSize = 10
+    if value_min is not None:
+        axis.valueMin = value_min
+    if value_max is not None:
+        axis.valueMax = value_max
+    if major_unit is not None and major_unit > 0:
+        axis.valueStep = major_unit
+
+
+def _add_chart_title_and_legend(
+    drawing: Drawing,
+    spec: ChartSpec,
+    series_info: list[tuple[SeriesSpec, str]],
+    width: int,
+    height: int,
+    *,
+    bar_swatch: bool = False,
+) -> float:
+    drawing.add(
+        String(
+            width / 2,
+            height - 27,
+            spec.title,
+            textAnchor="middle",
+            fontName="Helvetica",
+            fontSize=17,
+            fillColor=colors.black,
+        )
+    )
+    if not series_info:
+        return height - 55
+
+    columns = min(3, max(1, math.ceil(len(series_info) / 2)))
+    rows = math.ceil(len(series_info) / columns)
+    item_width = (width - 140) / columns
+    for index, (series, name) in enumerate(series_info):
+        column = index % columns
+        row = index // columns
+        x = 70 + column * item_width
+        y = height - 57 - row * 19
+        color = _series_color(series, index)
+        if bar_swatch:
+            drawing.add(Rect(x, y - 4, 24, 9, fillColor=color, strokeColor=color))
+        else:
+            legend_line = Line(
+                x,
+                y,
+                x + 28,
+                y,
+                strokeColor=color,
+                strokeWidth=series.line_width or 2,
+            )
+            dash_array = _line_dash_array(series.line_dash)
+            if dash_array:
+                legend_line.strokeDashArray = dash_array
+            drawing.add(legend_line)
+        drawing.add(
+            String(
+                x + 35,
+                y - 4,
+                name,
+                fontName="Helvetica",
+                fontSize=10,
+                fillColor=colors.HexColor("#262626"),
+            )
+        )
+    return height - 68 - (rows - 1) * 19
+
+
+def _add_axis_titles(
+    drawing: Drawing,
+    spec: ChartSpec,
+    chart_left: float,
+    chart_bottom: float,
+    chart_width: float,
+    chart_height: float,
+) -> None:
+    if spec.x_axis_title:
+        drawing.add(
+            String(
+                chart_left + chart_width / 2,
+                22,
+                spec.x_axis_title,
+                textAnchor="middle",
+                fontName="Helvetica",
+                fontSize=12,
+            )
+        )
+    if spec.value_axis_title:
+        axis_title_group = Group()
+        axis_title_group.add(
+            String(
+                0,
+                0,
+                spec.value_axis_title,
+                textAnchor="middle",
+                fontName="Helvetica",
+                fontSize=12,
+            )
+        )
+        axis_title_group.transform = (
+            0,
+            1,
+            -1,
+            0,
+            24,
+            chart_bottom + chart_height / 2,
+        )
+        drawing.add(axis_title_group)
+
+
+def _build_scatter_chart_drawing(spec: ChartSpec, width: int, height: int) -> Drawing | None:
+    series_data = _scatter_series_data(spec)
+    if not series_data:
+        return None
+
+    drawing = Drawing(width, height)
+    drawing.add(Rect(0, 0, width, height, fillColor=colors.white, strokeColor=None))
+    series_info = [(series, name) for series, name, _ in series_data]
+    chart_top = _add_chart_title_and_legend(drawing, spec, series_info, width, height)
+    chart_left = 72
+    chart_bottom = 58
+    chart_width = width - chart_left - 28
+    chart_height = max(chart_top - chart_bottom, 100)
+
+    chart = LinePlot()
+    chart.x = chart_left
+    chart.y = chart_bottom
+    chart.width = chart_width
+    chart.height = chart_height
+    chart.data = [points for _, _, points in series_data]
+    chart.joinedLines = True
+    _configure_value_axis(
+        chart.xValueAxis,
+        spec.x_axis_min,
+        spec.x_axis_max,
+        spec.x_axis_major_unit,
+    )
+    _configure_value_axis(
+        chart.yValueAxis,
+        spec.y_axis_min,
+        spec.y_axis_max,
+        spec.y_axis_major_unit,
+    )
+    for index, (series, _, _) in enumerate(series_data):
+        chart.lines[index].strokeColor = _series_color(series, index)
+        chart.lines[index].strokeWidth = series.line_width or 2
+        dash_array = _line_dash_array(series.line_dash)
+        if dash_array:
+            chart.lines[index].strokeDashArray = dash_array
+
+    drawing.add(chart)
+    _add_axis_titles(
+        drawing,
+        spec,
+        chart_left,
+        chart_bottom,
+        chart_width,
+        chart_height,
+    )
+    return drawing
+
+
+def _build_bar_chart_drawing(spec: ChartSpec, width: int, height: int) -> Drawing | None:
+    categories, series_data = _category_series_data(spec)
+    if not series_data:
+        return None
+
+    drawing = Drawing(width, height)
+    drawing.add(Rect(0, 0, width, height, fillColor=colors.white, strokeColor=None))
+    series_info = [(series, name) for series, name, _ in series_data]
+    chart_top = _add_chart_title_and_legend(
+        drawing,
+        spec,
+        series_info,
+        width,
+        height,
+        bar_swatch=True,
+    )
+    chart_left = 72
+    chart_bottom = 58
+    chart_width = width - chart_left - 28
+    chart_height = max(chart_top - chart_bottom, 100)
+
+    chart = VerticalBarChart()
+    chart.x = chart_left
+    chart.y = chart_bottom
+    chart.width = chart_width
+    chart.height = chart_height
+    chart.data = [values for _, _, values in series_data]
+    chart.categoryAxis.categoryNames = categories
+    chart.categoryAxis.labels.fontSize = 9
+    chart.categoryAxis.labels.fillColor = colors.HexColor("#262626")
+    chart.categoryAxis.strokeColor = colors.HexColor("#A6A6A6")
+    _configure_value_axis(
+        chart.valueAxis,
+        spec.y_axis_min,
+        spec.y_axis_max,
+        spec.y_axis_major_unit,
+    )
+    for index, (series, _, _) in enumerate(series_data):
+        color = _series_color(series, index)
+        chart.bars[index].fillColor = color
+        chart.bars[index].strokeColor = color
+
+    drawing.add(chart)
+    _add_axis_titles(
+        drawing,
+        spec,
+        chart_left,
+        chart_bottom,
+        chart_width,
+        chart_height,
+    )
+    return drawing
+
+
 def parse_chart_spec_from_ooxml(chart_xml: bytes) -> ChartSpec | None:
     try:
         root = etree.fromstring(
@@ -222,21 +584,35 @@ def parse_chart_spec_from_ooxml(chart_xml: bytes) -> ChartSpec | None:
 
     x_axis_title = ""
     value_axis_title = ""
+    x_axis_min = x_axis_max = x_axis_major_unit = None
+    y_axis_min = y_axis_max = y_axis_major_unit = None
     if plot_kind in {"scatter", "bubble"}:
+        x_axis_found = False
+        y_axis_found = False
         for axis in plot_area.findall("c:valAx", namespaces=_NS):
             axis_pos = axis.find("c:axPos", namespaces=_NS)
             axis_position = axis_pos.get("val") if axis_pos is not None else ""
             title = _extract_title_text(axis.find("c:title", namespaces=_NS))
-            if axis_position == "b" and not x_axis_title:
+            axis_min, axis_max, major_unit = _extract_axis_scale(axis)
+            if axis_position == "b" and not x_axis_found:
                 x_axis_title = title
-            elif axis_position == "l" and not value_axis_title:
+                x_axis_min = axis_min
+                x_axis_max = axis_max
+                x_axis_major_unit = major_unit
+                x_axis_found = True
+            elif axis_position == "l" and not y_axis_found:
                 value_axis_title = title
+                y_axis_min = axis_min
+                y_axis_max = axis_max
+                y_axis_major_unit = major_unit
+                y_axis_found = True
         if not x_axis_title:
             x_axis_title = category_axis_title
     else:
         axis = plot_area.find("c:valAx", namespaces=_NS)
         if axis is not None:
             value_axis_title = _extract_title_text(axis.find("c:title", namespaces=_NS))
+            y_axis_min, y_axis_max, y_axis_major_unit = _extract_axis_scale(axis)
 
     series_specs = []
     for _, plot_element in plot_elements:
@@ -269,6 +645,9 @@ def parse_chart_spec_from_ooxml(chart_xml: bytes) -> ChartSpec | None:
                     cached_bubble_sizes=_extract_reference_cache(
                         series_element.find("c:bubbleSize", namespaces=_NS)
                     ),
+                    line_color=_extract_series_line_color(series_element),
+                    line_dash=_extract_series_line_dash(series_element),
+                    line_width=_extract_series_line_width(series_element),
                 )
             )
 
@@ -286,6 +665,12 @@ def parse_chart_spec_from_ooxml(chart_xml: bytes) -> ChartSpec | None:
         has_date_axis=has_date_axis,
         date_1904=_chart_uses_date_1904(root),
         series=series_specs,
+        x_axis_min=x_axis_min,
+        x_axis_max=x_axis_max,
+        x_axis_major_unit=x_axis_major_unit,
+        y_axis_min=y_axis_min,
+        y_axis_max=y_axis_max,
+        y_axis_major_unit=y_axis_major_unit,
     )
 
 
@@ -724,6 +1109,62 @@ def _extract_title_text(title_element) -> str:
         return ""
     texts = title_element.findall(".//a:t", namespaces=_NS)
     return "".join(text.text or "" for text in texts).strip()
+
+
+def _float_xml_value(element) -> float | None:
+    if element is None:
+        return None
+    try:
+        value = float(element.get("val"))
+    except (TypeError, ValueError):
+        return None
+    return value if math.isfinite(value) else None
+
+
+def _extract_axis_scale(axis) -> tuple[float | None, float | None, float | None]:
+    if axis is None:
+        return None, None, None
+    return (
+        _float_xml_value(axis.find("c:scaling/c:min", namespaces=_NS)),
+        _float_xml_value(axis.find("c:scaling/c:max", namespaces=_NS)),
+        _float_xml_value(axis.find("c:majorUnit", namespaces=_NS)),
+    )
+
+
+def _extract_series_line_color(series_element) -> str | None:
+    line = series_element.find("c:spPr/a:ln", namespaces=_NS)
+    if line is None:
+        return None
+    srgb_color = line.find("a:solidFill/a:srgbClr", namespaces=_NS)
+    if srgb_color is not None:
+        raw_color = (srgb_color.get("val") or "").upper()
+        if len(raw_color) == 6 and all(char in "0123456789ABCDEF" for char in raw_color):
+            return raw_color
+    scheme_color = line.find("a:solidFill/a:schemeClr", namespaces=_NS)
+    if scheme_color is not None:
+        return _SCHEME_COLORS.get(scheme_color.get("val") or "")
+    return None
+
+
+def _extract_series_line_dash(series_element) -> str | None:
+    line = series_element.find("c:spPr/a:ln", namespaces=_NS)
+    if line is None:
+        return None
+    dash = line.find("a:prstDash", namespaces=_NS)
+    return dash.get("val") if dash is not None else None
+
+
+def _extract_series_line_width(series_element) -> float | None:
+    line = series_element.find("c:spPr/a:ln", namespaces=_NS)
+    if line is None:
+        return None
+    try:
+        width = float(line.get("w")) / 12_700.0
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(width) or width <= 0:
+        return None
+    return width
 
 
 def _find_reference_element(container):

--- a/mineru/backend/utils/office_chart.py
+++ b/mineru/backend/utils/office_chart.py
@@ -517,23 +517,34 @@ def _read_formula_vector(workbook, formula: str):
 
     sheet_name, min_col, min_row, max_col, max_row = parsed
 
+    if min_col != max_col and min_row != max_row:
+        return None
+
     try:
         worksheet = workbook[sheet_name]
     except KeyError:
         return None
 
-    if min_col != max_col and min_row != max_row:
-        return None
-
-    values = []
+    rows = worksheet.iter_rows(
+        min_row=min_row,
+        max_row=max_row,
+        min_col=min_col,
+        max_col=max_col,
+        values_only=True,
+    )
     if min_col == max_col:
-        for row_idx in range(min_row, max_row + 1):
-            values.append(worksheet.cell(row=row_idx, column=min_col).value)
+        values = [row[0] for row in rows]
     else:
-        for col_idx in range(min_col, max_col + 1):
-            values.append(worksheet.cell(row=min_row, column=col_idx).value)
+        values = list(next(rows, ()))
 
-    return sheet_name, values
+    return sheet_name, _trim_trailing_empty_series_values(values)
+
+
+def _trim_trailing_empty_series_values(values: list[Any]) -> list[Any]:
+    end = len(values)
+    while end > 0 and values[end - 1] in (None, ""):
+        end -= 1
+    return values[:end]
 
 
 def _read_formula_scalar(workbook, formula: str) -> str | None:

--- a/mineru/model/pptx/pptx_converter.py
+++ b/mineru/model/pptx/pptx_converter.py
@@ -19,7 +19,10 @@ from mineru.backend.utils.office_image import (
     serialize_vector_image_with_placeholder,
 )
 from mineru.model.docx.tools.math.omml import oMath2Latex
-from mineru.backend.utils.office_chart import extract_chart_html_from_ooxml
+from mineru.backend.utils.office_chart import (
+    extract_chart_html_from_ooxml,
+    render_chart_svg_from_ooxml,
+)
 from mineru.model.office_stream import read_stream_bytes_from_start, rewind_stream
 from mineru.model.pptx.package_normalizer import normalize_pptx_package
 from mineru.model.pptx.xycut_pp_sorter import sort_entries
@@ -703,21 +706,39 @@ class PptxConverter:
         except Exception as e:
             logger.warning(f"Warning: chart workbook cannot be loaded: {e}")
 
+        chart_html = ""
         try:
             chart_html = extract_chart_html_from_ooxml(chart_xml, workbook_bytes)
         except Exception as e:
             logger.warning(f"Warning: chart HTML cannot be extracted: {e}")
+
+        chart_image = ""
+        try:
+            chart_width = 960
+            aspect_ratio = (
+                float(shape.height) / float(shape.width)
+                if shape.width
+                else 540 / chart_width
+            )
+            chart_height = max(320, min(720, round(chart_width * aspect_ratio)))
+            chart_image = render_chart_svg_from_ooxml(
+                chart_xml,
+                width=chart_width,
+                height=chart_height,
+            )
+        except Exception as e:
+            logger.warning(f"Warning: chart SVG cannot be rendered: {e}")
+
+        if not chart_html and not chart_image:
             return
 
-        if not chart_html:
-            return
-
-        self.cur_page.append(
-            {
-                "type": BlockType.CHART,
-                "content": chart_html,
-            }
-        )
+        chart_block = {
+            "type": BlockType.CHART,
+            "content": chart_html,
+        }
+        if chart_image:
+            chart_block["image_base64"] = chart_image
+        self.cur_page.append(chart_block)
 
     def _handle_pictures(self, shape):
         image_data = self._get_shape_image_data(shape)

--- a/tests/unittest/test_office_chart.py
+++ b/tests/unittest/test_office_chart.py
@@ -1,0 +1,103 @@
+# Copyright (c) Opendatalab. All rights reserved.
+from io import BytesIO
+from typing import Any, Iterator
+
+from openpyxl import Workbook, load_workbook
+
+from mineru.backend.utils.office_chart import (
+    ChartSpec,
+    SeriesSpec,
+    _read_formula_vector,
+    render_chart_html_from_workbook,
+)
+
+
+class _StreamingWorksheet:
+    def __init__(self) -> None:
+        self.iter_rows_calls = 0
+
+    def iter_rows(self, **kwargs: Any) -> Iterator[tuple[Any, ...]]:
+        self.iter_rows_calls += 1
+        assert kwargs == {
+            "min_row": 4,
+            "max_row": 50_000,
+            "min_col": 1,
+            "max_col": 1,
+            "values_only": True,
+        }
+        yield (1,)
+        yield (None,)
+        yield (2,)
+        yield (None,)
+
+    def cell(self, **kwargs: Any) -> None:
+        raise AssertionError(f"cell() must not be used for streaming worksheets: {kwargs}")
+
+
+def _save_workbook(workbook: Workbook) -> bytes:
+    stream = BytesIO()
+    workbook.save(stream)
+    workbook.close()
+    return stream.getvalue()
+
+
+def test_read_formula_vector_streams_range_once_and_trims_empty_tail() -> None:
+    worksheet = _StreamingWorksheet()
+    workbook = {"Data": worksheet}
+
+    result = _read_formula_vector(workbook, "Data!$A$4:$A$50000")
+
+    assert result == ("Data", [1, None, 2])
+    assert worksheet.iter_rows_calls == 1
+
+
+def test_read_formula_vector_preserves_internal_empty_horizontal_cells() -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    worksheet.title = "Data"
+    worksheet["B2"] = 1
+    worksheet["D2"] = 3
+    workbook_bytes = _save_workbook(workbook)
+
+    read_only_workbook = load_workbook(
+        BytesIO(workbook_bytes),
+        data_only=True,
+        read_only=True,
+    )
+    try:
+        result = _read_formula_vector(read_only_workbook, "Data!$B$2:$Z$2")
+    finally:
+        read_only_workbook.close()
+
+    assert result == ("Data", [1, None, 3])
+
+
+def test_render_scatter_chart_ignores_empty_formula_tail() -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    worksheet.title = "Data"
+    worksheet.append(["Time", "Voltage"])
+    worksheet.append([1, 3.7])
+    worksheet.append([2, 3.6])
+    workbook_bytes = _save_workbook(workbook)
+    spec = ChartSpec(
+        chart_type="scatterChart",
+        plot_kind="scatter",
+        x_axis_title="Time",
+        series=[
+            SeriesSpec(
+                literal_name="Voltage",
+                x_formula="Data!$A$2:$A$50000",
+                y_formula="Data!$B$2:$B$50000",
+            )
+        ],
+    )
+
+    html = render_chart_html_from_workbook(spec, workbook_bytes)
+
+    assert html == (
+        "<table><thead><tr><th>Time</th><th>Voltage</th></tr></thead><tbody>"
+        "<tr><td>1</td><td>3.7</td></tr>"
+        "<tr><td>2</td><td>3.6</td></tr>"
+        "</tbody></table>"
+    )

--- a/tests/unittest/test_office_chart_rendering.py
+++ b/tests/unittest/test_office_chart_rendering.py
@@ -1,0 +1,111 @@
+# Copyright (c) Opendatalab. All rights reserved.
+import base64
+
+from mineru.backend.office.mkcontent.output_builders import mk_blocks_to_markdown
+from mineru.backend.utils.office_chart import (
+    parse_chart_spec_from_ooxml,
+    render_chart_svg_from_ooxml,
+)
+from mineru.utils.enum_class import BlockType, ContentType, MakeMode
+
+
+_SCATTER_CHART_XML = b"""<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:title><c:tx><c:rich><a:p><a:r><a:t>Discharge Curve</a:t></a:r></a:p></c:rich></c:tx></c:title>
+    <c:plotArea>
+      <c:scatterChart>
+        <c:ser>
+          <c:tx><c:v>Cell 1</c:v></c:tx>
+          <c:spPr><a:ln w="25400"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:prstDash val="dash"/></a:ln></c:spPr>
+          <c:xVal><c:numRef><c:numCache>
+            <c:pt idx="0"><c:v>0</c:v></c:pt>
+            <c:pt idx="1"><c:v>1</c:v></c:pt>
+            <c:pt idx="2"><c:v>2</c:v></c:pt>
+          </c:numCache></c:numRef></c:xVal>
+          <c:yVal><c:numRef><c:numCache>
+            <c:pt idx="0"><c:v>4.1</c:v></c:pt>
+            <c:pt idx="1"><c:v>3.7</c:v></c:pt>
+            <c:pt idx="2"><c:v>2.8</c:v></c:pt>
+          </c:numCache></c:numRef></c:yVal>
+        </c:ser>
+      </c:scatterChart>
+      <c:valAx>
+        <c:scaling><c:min val="0"/><c:max val="2"/></c:scaling>
+        <c:axPos val="b"/>
+        <c:title><c:tx><c:rich><a:p><a:r><a:t>Capacity</a:t></a:r></a:p></c:rich></c:tx></c:title>
+        <c:majorUnit val="1"/>
+      </c:valAx>
+      <c:valAx>
+        <c:scaling><c:min val="2.5"/><c:max val="4.5"/></c:scaling>
+        <c:axPos val="l"/>
+        <c:title><c:tx><c:rich><a:p><a:r><a:t>Voltage</a:t></a:r></a:p></c:rich></c:tx></c:title>
+        <c:majorUnit val="0.5"/>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>
+"""
+
+
+def test_render_scatter_chart_svg_preserves_visual_properties() -> None:
+    spec = parse_chart_spec_from_ooxml(_SCATTER_CHART_XML)
+
+    assert spec is not None
+    assert spec.title == "Discharge Curve"
+    assert spec.x_axis_title == "Capacity"
+    assert spec.value_axis_title == "Voltage"
+    assert (spec.x_axis_min, spec.x_axis_max, spec.x_axis_major_unit) == (0, 2, 1)
+    assert (spec.y_axis_min, spec.y_axis_max, spec.y_axis_major_unit) == (2.5, 4.5, 0.5)
+    assert spec.series[0].line_color == "FF0000"
+    assert spec.series[0].line_dash == "dash"
+    assert spec.series[0].line_width == 2
+
+    image_data_uri = render_chart_svg_from_ooxml(_SCATTER_CHART_XML)
+    prefix, encoded_svg = image_data_uri.split(",", 1)
+    svg = base64.b64decode(encoded_svg).decode("utf-8")
+
+    assert prefix == "data:image/svg+xml;base64"
+    assert "<svg" in svg
+    assert "Discharge Curve" in svg
+    assert "Capacity" in svg
+    assert "Voltage" in svg
+    assert "Cell 1" in svg
+    assert "rgb(100%,0%,0%)" in svg.replace(" ", "").lower()
+    assert "stroke-dasharray" in svg
+
+    assert "matrix(0,1,-1,0" in svg.replace(" ", "")
+
+def test_chart_markdown_prefers_image_and_folds_structured_content() -> None:
+    chart_html = "<table><tbody><tr><td>4.1</td></tr></tbody></table>"
+    chart_block = {
+        "type": BlockType.CHART,
+        "blocks": [
+            {
+                "type": BlockType.CHART_BODY,
+                "lines": [
+                    {
+                        "spans": [
+                            {
+                                "type": ContentType.CHART,
+                                "image_path": "chart.svg",
+                                "content": chart_html,
+                            }
+                        ]
+                    }
+                ],
+            }
+        ],
+    }
+
+    markdown = mk_blocks_to_markdown(
+        [chart_block],
+        MakeMode.MM_MD,
+        "images",
+    )
+
+    assert len(markdown) == 1
+    assert markdown[0].startswith("![](images/chart.svg)")
+    assert "<details>" in markdown[0]
+    assert "<summary>chart content</summary>" in markdown[0]
+    assert chart_html in markdown[0]


### PR DESCRIPTION
## Motivation

PPTX charts backed by embedded workbooks can stall when series formulas span many rows. After that performance issue was fixed, Office Markdown still replaced native charts with their extracted HTML data tables, so the visual chart was lost.

## Modification

- Read each one-dimensional chart formula range with a single iter_rows() stream and trim only trailing empty values.
- Parse chart titles, axis titles and scales, series colors, line widths, and dash styles from OOXML.
- Render supported scatter and bar charts from cached OOXML data as SVG images.
- Carry the SVG through the Office middle JSON image pipeline while preserving extracted HTML chart data.
- Emit the chart image first in multimodal Markdown and keep structured chart data in a collapsible chart content details block.
- Add regression coverage for streaming workbook reads, SVG visual properties, rotated value-axis labels, and Markdown image priority.

## BC-breaking

No. Structured chart content remains available in middle JSON and content-list output. Multimodal Markdown now shows the chart image first and retains the HTML data table in a collapsible details block.

## Testing

- Targeted Pytest: 5 passed.
- Ruff passes for all changed source and test files, excluding the module's existing ANN baseline.
- A 25-slide regression PPTX containing 16 charts completes Office parsing in about 3 seconds and produces SVG image paths for all 16 chart blocks.
- Slide 24 produces exactly two SVG charts. Headless-browser screenshots verified curve shape, legends, axis ranges and titles, colors, and solid/dashed line styles against the source slide.

## Checklist

- [x] Lint checks pass for changed code, excluding the module's existing ANN baseline.
- [x] The performance bug and visual-output bug are covered by unit tests.
- [x] The modification is covered by a real-document regression test and visual screenshot inspection.
- [x] No new runtime dependency is required; reportlab is already declared by the project.