### PR TITLE
feat: add offset pagination to find

### DIFF
--- a/docs/next/cli/mineru-e2e-test-cases.md
+++ b/docs/next/cli/mineru-e2e-test-cases.md
@@ -2302,7 +2302,7 @@ mineru find "sample" --limit 1 --json
 - exit code = 0
 - stdout 为可直接解析的 JSON
 - limit 生效，单次返回结果数量不超过 1
-- `find` 当前只承诺文件名查询、扩展名过滤、limit 和 JSON 输出；offset 契约单独由 SEARCH-013 覆盖
+- `find` 承诺文件名查询、扩展名过滤、limit、offset 和 JSON 输出；分页契约由 SEARCH-013 覆盖
 
 ### SEARCH-008 search type filter
 
@@ -3160,13 +3160,15 @@ mineru list docs --file-type docx --limit 20 --json
 命令:
 
 ```bash
+mineru find "sample" --limit 1 --offset 0 --json
 mineru find "sample" --limit 1 --offset 1 --json
 ```
 
 预期:
 
-- 如果 CLI 设计支持 find offset，exit code = 0，stdout 为可直接解析的 JSON，返回数量不超过 1
-- 如果 CLI 设计不支持 find offset，exit code != 0，输出包含 no such option、unknown option 或等价错误
+- 两条命令 exit code = 0，stdout 均为可直接解析的 JSON，返回数量均不超过 1
+- 如果至少有两条匹配结果，两页的 filename/path 组合不重复
+- 重复执行相同命令时，结果顺序保持一致
 - 不包含 Python traceback
 
 ### PARSE-016 page range 边界

--- a/docs/next/cli/mineru-library.md
+++ b/docs/next/cli/mineru-library.md
@@ -55,6 +55,7 @@ JSON 输出中的每条结果至少包含:
 ```bash
 mineru find "report"
 mineru find "report" --ext pdf
+mineru find "report" --limit 20 --offset 20
 ```
 
 行为：
@@ -63,7 +64,8 @@ mineru find "report" --ext pdf
 - 支持按 `ext` 过滤。
 - 可返回同一 SHA256 的多个路径。
 - 可用于解析前确认目标文件。
-- 当前 `find` 只暴露 `--ext`、`--limit/-n` 和 `--json`。
+- 支持通过 `--limit/-n` 和 `--offset` 对过滤后的结果稳定分页。
+- 当前 `find` 暴露 `--ext`、`--limit/-n`、`--offset` 和 `--json`。
 
 `find` JSON 输出中的每条结果至少包含:
 

--- a/mineru/cli/commands/search.py
+++ b/mineru/cli/commands/search.py
@@ -47,12 +47,13 @@ def find_cmd(
     query: str = typer.Argument(..., help="Filename search query"),
     ext: str | None = typer.Option(None, "--ext", help=f"File extension filter: {FILE_EXTS}"),
     limit: int = typer.Option(50, "--limit", "-n", help="Max results"),
+    offset: int = typer.Option(0, "--offset", help="Result offset"),
     json_mode: bool = typer.Option(False, "--json", help="JSON output"),
 ) -> None:
     """Search filenames only (not document content)."""
     run_cli(
         CliContext(json_mode=json_mode),
-        lambda: DoclibClient(timeout=10).find(query, ext=ext, limit=limit),
+        lambda: DoclibClient(timeout=10).find(query, ext=ext, limit=limit, offset=offset),
         render=_render_find_results,
     )
 

--- a/mineru/doclib/base.py
+++ b/mineru/doclib/base.py
@@ -334,11 +334,11 @@ class DoclibInterface(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def find(self, query: str, *, ext: str | None = None, limit: int = 50) -> FindResponse:
+    def find(self, query: str, *, ext: str | None = None, limit: int = 50, offset: int = 0) -> FindResponse:
         """Search filenames.
 
         Raises:
-            InvalidRequestError: when query, ext, or limit is invalid.
+            InvalidRequestError: when query, ext, limit, or offset is invalid.
             MineruError: for search backend failures.
         """
         raise NotImplementedError()
@@ -705,7 +705,7 @@ class AsyncDoclibInterface(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    async def find(self, query: str, *, ext: str | None = None, limit: int = 50) -> FindResponse:
+    async def find(self, query: str, *, ext: str | None = None, limit: int = 50, offset: int = 0) -> FindResponse:
         """Async version of ``DoclibInterface.find``."""
         raise NotImplementedError()
 

--- a/mineru/doclib/client.py
+++ b/mineru/doclib/client.py
@@ -301,8 +301,11 @@ class DoclibClient(DoclibInterface):
         )
 
     @route("GET", "/find", tags=("search",))
-    def find(self, query: str, *, ext: str | None = None, limit: int = 50) -> FindResponse:
-        return self._request_model(FindResponse, params={"query": query, "ext": ext, "limit": limit})
+    def find(self, query: str, *, ext: str | None = None, limit: int = 50, offset: int = 0) -> FindResponse:
+        return self._request_model(
+            FindResponse,
+            params={"query": query, "ext": ext, "limit": limit, "offset": offset},
+        )
 
     @route("GET", "/files/by-path", tags=("files",))
     def get_file_by_path(self, path: str) -> FileInfoResponse:

--- a/mineru/doclib/core/fts.py
+++ b/mineru/doclib/core/fts.py
@@ -120,7 +120,7 @@ class FTSManager:
                     "SELECT file_id, ext, "
                     "snippet(fts_filenames, 1, '<mark>', '</mark>', '...', 40) AS snippet "
                     "FROM fts_filenames WHERE fts_filenames MATCH ? "
-                    "ORDER BY rank LIMIT ?",
+                    "ORDER BY rank, file_id LIMIT ?",
                     (fts_query, limit),
                 ),
             )

--- a/mineru/doclib/server.py
+++ b/mineru/doclib/server.py
@@ -802,7 +802,7 @@ class DoclibServer(AsyncDoclibInterface):
             raise
 
     @route("GET", "/find", tags=("search",))
-    async def find(self, query: str, *, ext: str | None = None, limit: int = 50) -> FindResponse:
+    async def find(self, query: str, *, ext: str | None = None, limit: int = 50, offset: int = 0) -> FindResponse:
         start_ms = _now_ms()
         await _record_telemetry_count(self.state, "find.request.count")
         try:
@@ -810,6 +810,7 @@ class DoclibServer(AsyncDoclibInterface):
                 query=query,
                 ext=ext,
                 limit=limit,
+                offset=offset,
                 refresh_file=self.state.parse_svc.refresh_file,
             )
             response = FindResponse(results=[_find_result(row) for row in results], total=total, query=query)

--- a/mineru/doclib/services/search_svc.py
+++ b/mineru/doclib/services/search_svc.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from .parse_svc import FileRefreshResult
 
 FilenamePathProbe = Callable[[str], Awaitable["FileRefreshResult"]]
+FILENAME_SEARCH_CANDIDATE_LIMIT = 200
 
 
 class SearchService:
@@ -113,10 +114,16 @@ class SearchService:
     # ── filename search ─────────────────────────────────────────
 
     async def search_filenames(
-        self, query: str, ext: str | None = None, limit: int = 50, *, refresh_file: FilenamePathProbe | None = None
+        self,
+        query: str,
+        ext: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+        *,
+        refresh_file: FilenamePathProbe | None = None,
     ) -> tuple[list[FilenameSearchResultRow], int]:
         """Search filenames only. Returns (results, total_count)."""
-        rows = await self.fts.search_filenames(query, limit=limit)
+        rows = await self.fts.search_filenames(query, limit=FILENAME_SEARCH_CANDIDATE_LIMIT)
         if not rows:
             return [], 0
 
@@ -160,7 +167,7 @@ class SearchService:
             )
 
         total = len(results)
-        return results, total
+        return results[offset : offset + limit], total
 
     async def _filter_probe_stale_filename_rows(
         self,

--- a/tests/unittest/test_cli_next_command_design.py
+++ b/tests/unittest/test_cli_next_command_design.py
@@ -187,8 +187,28 @@ def test_search_and_find_help_list_filter_values() -> None:
     for token in dict.fromkeys(FILE_TYPE_BY_EXTENSION.values()):
         assert token in search_result.output
     assert "File extension filter:" in find_result.output
+    assert "--offset" in find_result.output
     for token in FILE_TYPE_BY_EXTENSION:
         assert token in find_result.output
+
+
+def test_find_passes_pagination_options_to_client(monkeypatch: Any) -> None:
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    class _Client:
+        def __init__(self, *, timeout: int) -> None:
+            assert timeout == 10
+
+        def find(self, query: str, **kwargs: Any) -> FindResponse:
+            calls.append((query, kwargs))
+            return FindResponse(results=[], total=0, query=query)
+
+    monkeypatch.setattr(search_mod, "DoclibClient", _Client)
+
+    result = runner.invoke(app, ["find", "sample", "--limit", "2", "--offset", "1", "--json"])
+
+    assert result.exit_code == 0
+    assert calls == [("sample", {"ext": None, "limit": 2, "offset": 1})]
 
 
 def test_print_error_uses_single_rich_render(monkeypatch: Any) -> None:

--- a/tests/unittest/test_doclib_cache_semantics.py
+++ b/tests/unittest/test_doclib_cache_semantics.py
@@ -2379,6 +2379,40 @@ def test_find_filters_by_ext(tmp_path: Path) -> None:
     asyncio.run(_run())
 
 
+def test_find_paginates_after_filtering(tmp_path: Path) -> None:
+    async def _run() -> None:
+        db = DatabaseManager(str(tmp_path / "doclib.db"))
+        await db.initialize()
+        fts = FTSManager(db)
+        service = SearchService(db, fts)
+        now = 1000
+        filenames = ("sample-1.pdf", "sample-2.docx", "sample-3.pdf")
+
+        for index, filename in enumerate(filenames, start=1):
+            ext = filename.rsplit(".", maxsplit=1)[1]
+            sha256 = str(index) * 64
+            await db.execute(
+                "INSERT INTO docs (sha256, short_id, size_bytes, file_type, page_count, first_seen_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (sha256, sha256[:7], 10, ext, index, now, now),
+            )
+            file_id = await db.execute_insert(
+                "INSERT INTO files (path, filename, ext, size_bytes, mtime_ms, sha256, status, first_seen_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (str(tmp_path / filename), filename, ext, 10, now, sha256, "active", now, now),
+            )
+            await fts.upsert_filename(file_id, filename, ext)
+
+        first_page, first_total = await service.search_filenames("sample", ext="pdf", limit=1, offset=0)
+        second_page, second_total = await service.search_filenames("sample", ext="pdf", limit=1, offset=1)
+
+        assert first_total == second_total == 2
+        assert [row["filename"] for row in first_page] == ["sample-1.pdf"]
+        assert [row["filename"] for row in second_page] == ["sample-3.pdf"]
+
+    asyncio.run(_run())
+
+
 def test_find_probes_and_filters_deleted_paths_without_rescan(tmp_path: Path) -> None:
     async def _run() -> None:
         db = DatabaseManager(str(tmp_path / "doclib.db"))

--- a/tests/unittest/test_doclib_interface_contract.py
+++ b/tests/unittest/test_doclib_interface_contract.py
@@ -180,6 +180,13 @@ def test_list_methods_expose_consistent_pagination_contract() -> None:
         assert "offset" in signature.parameters, method_name
 
 
+def test_search_methods_expose_consistent_pagination_contract() -> None:
+    for method_name in ("search", "find"):
+        signature = inspect.signature(getattr(DoclibInterface, method_name))
+        assert "limit" in signature.parameters, method_name
+        assert "offset" in signature.parameters, method_name
+
+
 def test_interface_app_uses_doclib_server_routes(tmp_path) -> None:
     cfg = PatchedConfig(doclib={"log": {"dir": str(tmp_path / "logs")}})
 


### PR DESCRIPTION
## Motivation

`mineru find` supports limiting filename-search results but does not expose an offset, so callers cannot page through matching files consistently. This PR adds offset pagination to `find` and aligns its public interface with content search.

Closes #5301.

## Modification

- Add `--offset` to the `mineru find` CLI and forward it through the sync/async interfaces, HTTP client, server, and search service.
- Apply extension and active/stale-file filtering before pagination, while preserving the total count of filtered matches.
- Add a deterministic `file_id` tie-breaker to filename FTS ordering so repeated page requests remain stable.
- Add interface, CLI, and filtering/pagination unit coverage.
- Document the new option and its end-to-end pagination expectations.

## BC-breaking (Optional)

No. The new `offset` argument defaults to `0`, preserving existing behavior.

## Use cases (Optional)

```bash
mineru find "report" --ext pdf --limit 20 --offset 20 --json
```

This returns the second page of PDF filename matches after filtering.

## Testing

- 8 focused CLI/interface/service pagination tests passed.
- 889 remaining unit tests passed in the local environment (2 unrelated dependency-compatibility baseline tests deselected).
- Ruff checks, formatting checks, and `git diff --check` passed.
- A real local CLI/server flow with interleaved PDF/DOCX matches verified distinct, repeatable offset pages and the filtered total.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
