### PR TITLE
Add fastapi-offline to support offline FastAPI docs

### DIFF
--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -17,10 +17,10 @@ from typing import Annotated, Any, Optional
 
 import click
 import uvicorn
+from fastapi_offline import FastAPIOffline as FastAPI
 from fastapi import (
     BackgroundTasks,
     Depends,
-    FastAPI,
     HTTPException,
     Request,
     UploadFile,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "lxml>=4.0.0,<7.0.0",
     "openpyxl>=3.1.5,<4",
     "fastapi",
+    "fastapi-offline",
     "python-multipart",
     "uvicorn",
 ]


### PR DESCRIPTION
## Motivation

Add fastapi-offline in cli/fast-api.py to support offline fastapi docs

## Modification

add fastapi-offline in cli/fast-api.py and add requirements in pyproject.toml

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

when start minerU-api, docs can be shown in offline environments.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
