### PR TITLE
fix(api): trim glibc heap after document analysis to prevent OOM

### DIFF
--- a/mineru/backend/hybrid/hybrid_analyze.py
+++ b/mineru/backend/hybrid/hybrid_analyze.py
@@ -43,7 +43,7 @@ from mineru.utils.config_reader import (
 )
 from mineru.utils.enum_class import BlockType as MineruBlockType
 from mineru.utils.enum_class import ImageType, NotExtractType
-from mineru.utils.model_utils import clean_memory, crop_img, get_vram
+from mineru.utils.model_utils import clean_memory, crop_img, get_vram, trim_process_heap
 from mineru.utils.ocr_utils import (
     get_adjusted_mfdetrec_res,
     get_ocr_result_list,
@@ -1061,6 +1061,7 @@ def doc_analyze(
                     last_append_end_time = time.time()
                 finally:
                     _close_images(images_list)
+                    trim_process_heap()
         finally:
             if progress_bar is not None:
                 progress_bar.close()
@@ -1087,7 +1088,7 @@ def doc_analyze(
             )
         close_pdfium_document(pdf_doc)
         doc_closed = True
-        clean_memory(device)
+        clean_memory(device, trim_heap=True)
         return middle_json, model_list
     finally:
         if not doc_closed:
@@ -1275,6 +1276,7 @@ async def aio_doc_analyze(
                     last_append_end_time = time.time()
                 finally:
                     _close_images(images_list)
+                    trim_process_heap()
         finally:
             if progress_bar is not None:
                 progress_bar.close()
@@ -1303,7 +1305,7 @@ async def aio_doc_analyze(
             )
         close_pdfium_document(pdf_doc)
         doc_closed = True
-        clean_memory(device)
+        clean_memory(device, trim_heap=True)
         return middle_json, model_list
     finally:
         if not doc_closed:

--- a/mineru/backend/vlm/vlm_analyze.py
+++ b/mineru/backend/vlm/vlm_analyze.py
@@ -27,7 +27,7 @@ from mineru.utils.pdf_image_tools import (
 )
 from ...utils.check_sys_env import is_mac_os_version_supported
 from ...utils.config_reader import get_device, get_processing_window_size
-
+from ...utils.model_utils import clean_memory, trim_process_heap
 from ...utils.enum_class import ImageType
 from ...utils.pdfium_guard import (
     close_pdfium_document,
@@ -437,6 +437,8 @@ def doc_analyze(
         predictor = ModelSingleton().get_model(backend, model_path, server_url, **kwargs)
     predictor = _maybe_enable_serial_execution(predictor, backend)
 
+    device = get_device()
+
     pdf_doc = open_pdfium_document(pdfium.PdfDocument, pdf_bytes)
     middle_json = init_middle_json()
     results = []
@@ -501,6 +503,7 @@ def doc_analyze(
                     last_append_end_time = time.time()
                 finally:
                     _close_images(images_list)
+                    trim_process_heap()
         finally:
             if progress_bar is not None:
                 progress_bar.close()
@@ -514,6 +517,7 @@ def doc_analyze(
             finalize_middle_json(middle_json["pdf_info"])
         close_pdfium_document(pdf_doc)
         doc_closed = True
+        clean_memory(device)
         return middle_json, results
     finally:
         if not doc_closed:
@@ -536,6 +540,8 @@ async def aio_doc_analyze(
     if predictor is None:
         predictor = await _get_model_async(backend, model_path, server_url, **kwargs)
     predictor = _maybe_enable_serial_execution(predictor, backend)
+
+    device = get_device()
 
     pdf_doc = open_pdfium_document(pdfium.PdfDocument, pdf_bytes)
     middle_json = init_middle_json()
@@ -600,6 +606,7 @@ async def aio_doc_analyze(
                     last_append_end_time = time.time()
                 finally:
                     _close_images(images_list)
+                    trim_process_heap()
         finally:
             if progress_bar is not None:
                 progress_bar.close()
@@ -613,6 +620,7 @@ async def aio_doc_analyze(
             await asyncio.to_thread(finalize_middle_json, middle_json["pdf_info"])
         close_pdfium_document(pdf_doc)
         doc_closed = True
+        clean_memory(device)
         return middle_json, results
     finally:
         if not doc_closed:

--- a/mineru/utils/model_utils.py
+++ b/mineru/utils/model_utils.py
@@ -1,6 +1,8 @@
 # Copyright (c) Opendatalab. All rights reserved.
+import ctypes
 import math
 import os
+import sys
 import time
 import gc
 from PIL import Image
@@ -180,7 +182,37 @@ def get_res_list_from_layout_res(layout_res, overlap_threshold=0.8):
     return ocr_res_list, table_res_list, single_page_mfdetrec_res
 
 
-def clean_memory(device='cuda'):
+def trim_process_heap() -> None:
+    """Return unused glibc heap pages to the operating system.
+
+    On long-running processes (e.g. the MinerU API) the C allocator can hold
+    onto freed pages as heap fragmentation.  Calling ``malloc_trim(0)`` asks
+    glibc to release any unused memory back to the OS.  On non-glibc platforms
+    this function is a safe no-op.
+    """
+    try:
+        libc = ctypes.CDLL(None)
+        if not hasattr(libc, "malloc_trim"):
+            return
+        libc.malloc_trim(0)
+    except Exception:
+        pass
+
+
+def is_heap_trim_enabled() -> bool:
+    """Return whether glibc heap trimming is enabled.
+
+    Controlled by the ``MINERU_MALLOC_TRIM`` environment variable.  When the
+    variable is unset the feature defaults to enabled on Linux (where glibc is
+    the default allocator) and disabled everywhere else.
+    """
+    env = os.getenv("MINERU_MALLOC_TRIM", "")
+    if env == "":
+        return sys.platform.startswith("linux")
+    return env.lower() not in ("0", "false", "no", "off", "disable", "disabled")
+
+
+def clean_memory(device='cuda', trim_heap=None):
     if str(device).startswith("cuda"):
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
@@ -201,8 +233,12 @@ def clean_memory(device='cuda'):
             torch.mlu.empty_cache()
     elif str(device).startswith("sdaa"):
         if torch.sdaa.is_available():
-            torch.sdaa.empty_cache()  
+            torch.sdaa.empty_cache()
     gc.collect()
+    if trim_heap is None:
+        trim_heap = is_heap_trim_enabled()
+    if trim_heap:
+        trim_process_heap()
 
 
 def clean_vram(device, vram_threshold=8):

--- a/tests/unittest/test_model_utils.py
+++ b/tests/unittest/test_model_utils.py
@@ -1,0 +1,96 @@
+# Copyright (c) Opendatalab. All rights reserved.
+import sys
+from unittest import mock
+
+import pytest
+
+from mineru.utils.model_utils import (
+    clean_memory,
+    is_heap_trim_enabled,
+    trim_process_heap,
+)
+
+
+class TestTrimProcessHeap:
+    """Regression tests for the optional glibc heap-trimming hook."""
+
+    def test_trim_process_heap_does_not_raise(self):
+        """The helper must be safe to call on every supported platform."""
+        trim_process_heap()
+
+    def test_trim_process_heap_swallows_missing_symbol(self):
+        """On allocators without ``malloc_trim`` the call should be a no-op."""
+        with mock.patch("ctypes.CDLL") as mock_cdll:
+            mock_cdll.return_value = mock.Mock(spec=[])
+            trim_process_heap()
+
+    def test_trim_process_heap_swallows_cdll_error(self):
+        """Any failure to load the C library must not propagate."""
+        with mock.patch("ctypes.CDLL", side_effect=OSError("no libc")):
+            trim_process_heap()
+
+
+class TestIsHeapTrimEnabled:
+    def test_default_enabled_on_linux(self, monkeypatch):
+        """When ``MINERU_MALLOC_TRIM`` is unset the feature defaults to on for Linux."""
+        monkeypatch.delenv("MINERU_MALLOC_TRIM", raising=False)
+        with mock.patch.object(sys, "platform", "linux"):
+            assert is_heap_trim_enabled() is True
+
+    def test_default_disabled_on_non_linux(self, monkeypatch):
+        """When unset the feature defaults to off outside Linux."""
+        monkeypatch.delenv("MINERU_MALLOC_TRIM", raising=False)
+        with mock.patch.object(sys, "platform", "darwin"):
+            assert is_heap_trim_enabled() is False
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("1", True),
+            ("true", True),
+            ("True", True),
+            ("yes", True),
+            ("on", True),
+            ("0", False),
+            ("false", False),
+            ("False", False),
+            ("no", False),
+            ("off", False),
+            ("disable", False),
+            ("disabled", False),
+        ],
+    )
+    def test_env_var_overrides_default(self, monkeypatch, value, expected):
+        monkeypatch.setenv("MINERU_MALLOC_TRIM", value)
+        assert is_heap_trim_enabled() is expected
+
+
+class TestCleanMemoryHeapTrim:
+    def test_clean_memory_trims_heap_when_enabled(self, monkeypatch):
+        """``clean_memory`` should invoke heap trimming when explicitly enabled."""
+        monkeypatch.setenv("MINERU_MALLOC_TRIM", "1")
+
+        with mock.patch("mineru.utils.model_utils.gc.collect") as mock_gc:
+            with mock.patch("mineru.utils.model_utils.trim_process_heap") as mock_trim:
+                clean_memory("cpu", trim_heap=True)
+                mock_gc.assert_called_once()
+                mock_trim.assert_called_once()
+
+    def test_clean_memory_skips_heap_trim_when_disabled(self, monkeypatch):
+        """``clean_memory`` should not trim when explicitly disabled."""
+        monkeypatch.setenv("MINERU_MALLOC_TRIM", "0")
+
+        with mock.patch("mineru.utils.model_utils.gc.collect") as mock_gc:
+            with mock.patch("mineru.utils.model_utils.trim_process_heap") as mock_trim:
+                clean_memory("cpu", trim_heap=False)
+                mock_gc.assert_called_once()
+                mock_trim.assert_not_called()
+
+    def test_clean_memory_uses_env_default_when_trim_heap_unset(self, monkeypatch):
+        """When ``trim_heap`` is None the env var / platform default decides."""
+        monkeypatch.setenv("MINERU_MALLOC_TRIM", "1")
+
+        with mock.patch("mineru.utils.model_utils.gc.collect"):
+            with mock.patch("mineru.utils.model_utils.trim_process_heap") as mock_trim:
+                clean_memory("cpu", trim_heap=None)
+                mock_trim.assert_called_once()


### PR DESCRIPTION
When running the MinerU API for a long time, RSS kept growing across documents because freed C heap pages were not returned to the OS.

- Add trim_process_heap() that calls malloc_trim(0) on glibc systems.
- Add MINERU_MALLOC_TRIM env var to control the behavior; defaults to enabled on Linux and disabled elsewhere.
- Extend clean_memory() to optionally invoke heap trimming.
- Call trim_process_heap() after every processing window in VLM and Hybrid sync/async doc_analyze.
- Call clean_memory() at the end of VLM doc_analyze paths.
- Add regression tests for the allocator hook and configuration.

Fixes #5313

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
