### PR TITLE
Fix docx tables silently dropped when cells contain non-text special characters

### DIFF
--- a/mineru/model/docx/docx_converter.py
+++ b/mineru/model/docx/docx_converter.py
@@ -897,9 +897,9 @@ class DocxConverter:
                 try:
                     # 处理表格元素
                     self._handle_tables(element)
-                except Exception:
-                    # 如果表格解析失败，记录调试信息
-                    logger.debug("could not parse a table, broken docx table")
+                except Exception as e:
+                    # 表格解析失败会静默丢失整张表，需以 warning 级别暴露异常详情
+                    logger.warning(f"Could not parse a table, broken docx table: {e}")
             # 检查图片元素
             elif picture_refs:
                 # 判断图片是否为锚定（浮动）图片
@@ -1081,12 +1081,62 @@ class DocxConverter:
         )
 
     @staticmethod
+    def _xml_table_char_fragment(node: Any) -> str:
+        """渲染单个字符级 OOXML 元素为可见文本，与 Mammoth 的 HTML 渲染对齐。
+
+        仅拼接 w:t 文本会漏掉 <w:noBreakHyphen/>、<w:sym/> 等非文本字符元素，
+        导致 XML 侧表格签名（如 "NCICTCAE"）与 Mammoth 渲染结果
+        （"NCI‑CTCAE"）不一致，表格对齐失败后回退到孤立 XML 解析，
+        遇到含编号列表的表格会抛异常而整表被静默丢弃。
+
+        w:sym 按 Mammoth symbol handler 的 dingbats 映射渲染：未映射的
+        (font, char) 组合 Mammoth 会渲染为空，签名同样必须为空，
+        否则会引入反向失配导致表格走回退路径。
+        """
+        w_ns = DocxConverter._BLIP_NAMESPACES["w"]
+        if node.tag == f"{{{w_ns}}}t":
+            return node.text or ""
+        if node.tag == f"{{{w_ns}}}noBreakHyphen":
+            # NON-BREAKING HYPHEN U+2011，与 Mammoth 的 HTML 渲染一致
+            return "‑"
+        if node.tag == f"{{{w_ns}}}softHyphen":
+            # SOFT HYPHEN U+00AD，与 Mammoth 的 HTML 渲染一致
+            return "­"
+        if node.tag == f"{{{w_ns}}}sym":
+            try:
+                from mammoth.docx.dingbats import dingbats
+            except ImportError:
+                return ""
+            font = node.get(f"{{{w_ns}}}font", "")
+            char = node.get(f"{{{w_ns}}}char", "")
+            try:
+                code = dingbats.get((font, int(char, 16)))
+                if code is None and re.match(r"^F0..", char):
+                    code = dingbats.get((font, int(char[2:], 16)))
+            except (TypeError, ValueError):
+                return ""
+            return chr(code) if code is not None else ""
+        return ""
+
+    @staticmethod
     def _xml_table_signature(xml_table) -> dict:
-        """提取 XML 表格的轻量签名，用于与 Mammoth HTML 表格对齐。"""
+        """提取 XML 表格的轻量签名，用于与 Mammoth HTML 表格对齐。
+
+        按文档顺序渲染 w:t 文本及 w:noBreakHyphen/w:softHyphen/w:sym 等
+        特殊字符元素，使签名文本与 Mammoth 渲染结果一致；仅取 w 命名空间
+        的 t，排除 OMML 公式的 m:t（Mammoth 会静默丢弃公式，两者保持一致）。
+        """
+        w_ns = DocxConverter._BLIP_NAMESPACES["w"]
+        char_tags = (
+            f"{{{w_ns}}}t",
+            f"{{{w_ns}}}noBreakHyphen",
+            f"{{{w_ns}}}softHyphen",
+            f"{{{w_ns}}}sym",
+        )
         text = "".join(
-            node.text or ""
-            for node in xml_table.xpath('.//*[local-name()="t"]')
-            if node.text
+            DocxConverter._xml_table_char_fragment(node)
+            for node in xml_table.iter()
+            if node.tag in char_tags
         )
         return {
             "row_count": len(xml_table.xpath('./*[local-name()="tr"]')),

--- a/tests/unittest/test_docx_special_char_tables.py
+++ b/tests/unittest/test_docx_special_char_tables.py
@@ -1,0 +1,216 @@
+# Copyright (c) Opendatalab. All rights reserved.
+import sys
+import types
+from io import BytesIO
+
+from lxml import etree
+
+office_image = types.ModuleType("mineru.backend.utils.office_image")
+office_image.serialize_office_image = lambda *args, **kwargs: None
+sys.modules.setdefault("mineru.backend.utils.office_image", office_image)
+
+office_chart = types.ModuleType("mineru.backend.utils.office_chart")
+office_chart.extract_chart_html_from_ooxml = lambda *args, **kwargs: ""
+sys.modules.setdefault("mineru.backend.utils.office_chart", office_chart)
+
+from docx import Document
+from docx.oxml.ns import qn
+
+from mineru.model.docx.docx_converter import DocxConverter
+
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+M_NS = "http://schemas.openxmlformats.org/officeDocument/2006/math"
+NO_BREAK_HYPHEN = "‑"  # NON-BREAKING HYPHEN
+
+
+def _save_docx_bytes(doc: Document) -> bytes:
+    buffer = BytesIO()
+    doc.save(buffer)
+    return buffer.getvalue()
+
+
+def _convert_docx_bytes(file_bytes: bytes) -> list[dict]:
+    converter = DocxConverter()
+    converter.convert(BytesIO(file_bytes))
+    return [block for page in converter.pages for block in page]
+
+
+def _table_blocks(blocks: list[dict]) -> list[dict]:
+    return [b for b in blocks if b["type"] == "table"]
+
+
+def _build_docx_with_no_break_hyphen_table() -> bytes:
+    """表格单元格同时含 <w:noBreakHyphen/> 与编号列表，是整表丢失的复现用例。"""
+    doc = Document()
+    doc.add_heading("1 项目概述", level=1)
+
+    table = doc.add_table(rows=2, cols=2)
+    p = table.cell(0, 0).paragraphs[0]
+    r = p.add_run("NCI")
+    etree.SubElement(r._r, qn("w:noBreakHyphen"))
+    p.add_run("CTCAE 标准")
+    p2 = table.cell(0, 1).paragraphs[0]
+    p2.style = doc.styles["List Number"]
+    p2.add_run("第一条编号内容")
+
+    doc.add_heading("2 进度安排", level=1)
+    t2 = doc.add_table(rows=1, cols=2)
+    t2.cell(0, 0).paragraphs[0].add_run("里程碑")
+    t2.cell(0, 1).paragraphs[0].add_run("2026-08-01")
+    return _save_docx_bytes(doc)
+
+
+def _build_docx_with_sym_table() -> bytes:
+    """单元格含已映射 <w:sym>（(Symbol, 0x0022) → ∀）与编号列表的表格。"""
+    doc = Document()
+    doc.add_heading("符号表格", level=1)
+    table = doc.add_table(rows=1, cols=2)
+    p = table.cell(0, 0).paragraphs[0]
+    r = p.add_run("符号")
+    etree.SubElement(
+        r._r,
+        qn("w:sym"),
+        {qn("w:char"): "0022", qn("w:font"): "Symbol"},
+    )
+    p.add_run("结束")
+    p2 = table.cell(0, 1).paragraphs[0]
+    p2.style = doc.styles["List Number"]
+    p2.add_run("编号项")
+    return _save_docx_bytes(doc)
+
+
+def _build_docx_with_unmapped_sym_table() -> bytes:
+    """单元格含未映射 <w:sym>（(Symbol, 0xF0B7)，Mammoth 渲染为空）的表格。"""
+    doc = Document()
+    doc.add_heading("符号表格", level=1)
+    table = doc.add_table(rows=1, cols=2)
+    p = table.cell(0, 0).paragraphs[0]
+    r = p.add_run("符号")
+    etree.SubElement(
+        r._r,
+        qn("w:sym"),
+        {qn("w:char"): "F0B7", qn("w:font"): "Symbol"},
+    )
+    p.add_run("结束")
+    p2 = table.cell(0, 1).paragraphs[0]
+    p2.style = doc.styles["List Number"]
+    p2.add_run("编号项")
+    return _save_docx_bytes(doc)
+
+
+def _build_docx_with_plain_table() -> bytes:
+    """普通表格对照用例。"""
+    doc = Document()
+    doc.add_heading("对照", level=1)
+    table = doc.add_table(rows=1, cols=2)
+    table.cell(0, 0).paragraphs[0].add_run("APTT")
+    table.cell(0, 1).paragraphs[0].add_run("部分凝血酶时间")
+    return _save_docx_bytes(doc)
+
+
+def test_no_break_hyphen_table_not_lost():
+    blocks = _convert_docx_bytes(_build_docx_with_no_break_hyphen_table())
+    tables = _table_blocks(blocks)
+    assert len(tables) == 2
+
+    first_html = tables[0]["content"]
+    # 不间断连字符经 Mammoth 渲染保留，证明表格走了完整预解析路径而非被丢弃
+    assert f"NCI{NO_BREAK_HYPHEN}CTCAE" in first_html
+    # 单元格内编号列表由 Mammoth 渲染为列表，而非回退后的纯文本
+    assert "<li>" in first_html
+    assert "第一条编号内容" in first_html
+
+    second_html = tables[1]["content"]
+    assert "里程碑" in second_html
+    assert "2026-08-01" in second_html
+
+
+def test_mapped_sym_table_takes_mammoth_path():
+    blocks = _convert_docx_bytes(_build_docx_with_sym_table())
+    tables = _table_blocks(blocks)
+    assert len(tables) == 1
+    html = tables[0]["content"]
+    # Mammoth 按 dingbats 映射渲染 (Symbol, 0x0022) → ∀（U+2200）
+    assert "∀" in html
+    # 编号列表由 Mammoth 渲染，证明表格走了完整预解析路径
+    assert "<li>" in html
+
+
+def test_unmapped_sym_table_with_numbering_not_lost():
+    """未映射的 w:sym Mammoth 渲染为空，签名也必须为空，否则表格会被丢弃。"""
+    blocks = _convert_docx_bytes(_build_docx_with_unmapped_sym_table())
+    tables = _table_blocks(blocks)
+    assert len(tables) == 1
+    html = tables[0]["content"]
+    assert "符号" in html and "结束" in html
+    assert "<li>" in html
+
+
+def test_plain_table_still_emitted():
+    blocks = _convert_docx_bytes(_build_docx_with_plain_table())
+    tables = _table_blocks(blocks)
+    assert len(tables) == 1
+    assert "APTT" in tables[0]["content"]
+
+
+def test_xml_table_signature_renders_special_chars():
+    """签名文本必须与 Mammoth 渲染一致：noBreakHyphen→U+2011、softHyphen→U+00AD。"""
+    doc = Document()
+    table = doc.add_table(rows=1, cols=2)
+    p = table.cell(0, 0).paragraphs[0]
+    r = p.add_run("NCI")
+    etree.SubElement(r._r, qn("w:noBreakHyphen"))
+    p.add_run("CTCAE")
+    p2 = table.cell(0, 1).paragraphs[0]
+    r2 = p2.add_run("软连")
+    etree.SubElement(r2._r, qn("w:softHyphen"))
+    p2.add_run("字符")
+
+    sig = DocxConverter._xml_table_signature(table._tbl)
+    assert f"NCI{NO_BREAK_HYPHEN}CTCAE" in sig["text"]
+    assert "软连­字符" in sig["text"]
+
+
+def test_xml_table_signature_renders_sym_like_mammoth():
+    """w:sym 按 Mammoth dingbats 映射渲染：已映射输出字符，未映射输出空。"""
+    doc = Document()
+    table = doc.add_table(rows=1, cols=2)
+    p = table.cell(0, 0).paragraphs[0]
+    r = p.add_run("映射")
+    etree.SubElement(
+        r._r,
+        qn("w:sym"),
+        {qn("w:char"): "0022", qn("w:font"): "Symbol"},
+    )
+    p.add_run("结束")
+    p2 = table.cell(0, 1).paragraphs[0]
+    r2 = p2.add_run("未映射")
+    etree.SubElement(
+        r2._r,
+        qn("w:sym"),
+        {qn("w:char"): "F0B7", qn("w:font"): "Symbol"},
+    )
+
+    sig = DocxConverter._xml_table_signature(table._tbl)
+    # (Symbol, 0x0022) → ∀（U+2200）
+    assert "映射∀结束" in sig["text"]
+    # (Symbol, 0xF0B7) 未映射，Mammoth 渲染为空，签名也必须为空
+    assert "未映射" in sig["text"]
+    assert "" not in sig["text"]
+
+
+def test_xml_table_signature_excludes_omml_equation_text():
+    """OMML 公式的 m:t 不计入签名，与 Mammoth 丢弃公式的行为保持一致。"""
+    doc = Document()
+    table = doc.add_table(rows=1, cols=2)
+    p = table.cell(0, 0).paragraphs[0]
+    r = p.add_run("正文")
+    omath = etree.SubElement(r._r, qn("m:oMath"))
+    omr = etree.SubElement(omath, qn("m:r"))
+    etree.SubElement(omr, qn("m:t")).text = "E=mc2"
+    table.cell(0, 1).paragraphs[0].add_run("单元格")
+
+    sig = DocxConverter._xml_table_signature(table._tbl)
+    assert "正文" in sig["text"]
+    assert "E=mc2" not in sig["text"]


### PR DESCRIPTION
## Summary

Fixes docx tables being **silently dropped** when their cells contain non-text character elements (`<w:noBreakHyphen/>`, `<w:sym/>`, `<w:softHyphen/>`) together with numbered lists (reported in #5357).

Root cause: `_xml_table_signature` only joined `w:t` text, so the XML-side signature (e.g. `NCICTCAE`) diverged from mammoth's rendering (`NCI‑CTCAE`, U+2011). Alignment failed, the isolated fallback parse crashed on cells with numbered lists (`numbering` context missing), and the exception was swallowed — the whole table vanished.

Changes:
- `_xml_table_signature` now renders character elements in document order (`w:t`, `w:noBreakHyphen`→U+2011, `w:softHyphen`→U+00AD, `w:sym`), matching mammoth's HTML rendering, so affected tables take the full-quality mammoth pre-parse path.
- `w:sym` replicates mammoth's `symbol` handler dingbats mapping (incl. the `F0..` low-byte fallback); unmapped syms render empty on **both** sides so they can't introduce a reverse mismatch.
- OMML `m:t` excluded from the signature (mammoth silently drops equations).
- Table parse failures logged at `warning` level with exception details instead of `debug`, so future silent drops become observable.

## Why PR #5243 does not cover this root cause

PR #5243 ("Preserve complex nested DOCX tables") hardens the *isolated fallback*: when the fallback parse crashes it now builds plain-text HTML from raw XML instead of dropping the table. That prevents loss but does **not** fix the root cause:

- The signature text mismatch (`w:t`-only vs mammoth rendering) remains, so affected tables still fail mammoth alignment and land in the degraded fallback path.
- The fallback output is plain text — verified on the affected tables of a real 31-table document: `<strong>`, `<li>`, `<a>`, `<sup>` are all absent (bold, list numbering, hyperlinks and superscripts lost), whereas with this PR those tables take the full mammoth path with formatting preserved (e.g. 40 `<strong>`, 87 `<li>` on the summary table).

The two changes are complementary: #5243 is the safety net (table never lost), this PR is the root-cause fix (tables keep full quality). They are orthogonal and apply cleanly in either merge order.

## Test Plan

```bash
PYTHONPATH=. python -m pytest tests/unittest/test_docx_special_char_tables.py -q -o addopts=''
```

- 7 regression tests: noBreakHyphen + numbered list, mapped sym, unmapped sym + numbered list, softHyphen, plain-table control, OMML `m:t` exclusion.
- On clean master 6/7 fail; with this fix 7/7 pass.
- Verified on a real document with 31 tables: all 31 emitted, the 3 previously-lost tables keep full formatting.

Fixes #5357
