### PR TITLE
fix: escape HTML-like tags in plain Markdown text

### DIFF
--- a/mineru/backend/utils/markdown_utils.py
+++ b/mineru/backend/utils/markdown_utils.py
@@ -3,7 +3,7 @@
 import re
 from html import escape
 
-CONSERVATIVE_MARKDOWN_SPECIAL_CHARS = ("*", "_", "`", "~", "$")
+CONSERVATIVE_MARKDOWN_SPECIAL_CHARS = ("*", "_", "`", "~", "$", "<")
 TEXT_BLOCK_MARKDOWN_PREFIX_RE = re.compile(
     r"^(?P<indent>[ \t]{0,3})(?P<marker>#{1,6}|[+-])(?=[ \t])"
 )

--- a/tests/unittest/test_markdown_utils.py
+++ b/tests/unittest/test_markdown_utils.py
@@ -1,0 +1,31 @@
+# Copyright (c) Opendatalab. All rights reserved.
+
+from mineru.backend.utils.markdown_utils import escape_conservative_markdown_text
+
+
+def test_escape_html_like_placeholders_in_plain_text() -> None:
+    content = "-a <address>, then -p <port>"
+
+    assert escape_conservative_markdown_text(content) == (
+        r"-a \<address>, then -p \<port>"
+    )
+
+
+def test_preserve_existing_angle_bracket_escape() -> None:
+    content = r"-a \<address>"
+
+    assert escape_conservative_markdown_text(content) == content
+
+
+def test_escape_angle_bracket_after_even_backslashes() -> None:
+    content = r"-a \\<address>"
+
+    assert escape_conservative_markdown_text(content) == r"-a \\\<address>"
+
+
+def test_preserve_existing_conservative_markdown_escaping() -> None:
+    content = "*value* _name_ `code` ~old~ $x$"
+
+    assert escape_conservative_markdown_text(content) == (
+        r"\*value\* \_name\_ \`code\` \~old\~ \$x\$"
+    )


### PR DESCRIPTION
## Motivation

Plain extracted text such as `-a <address>` currently passes through unchanged. Markdown renderers interpret `<address>` as raw HTML, so the placeholder is hidden or removed from rendered output.

Fixes #5360.

## Modification

- Treat an unescaped `<` as a conservative Markdown special character, producing `\<` in plain-text output.
- Preserve the existing odd/even backslash behavior so already escaped placeholders are not double-escaped.
- Add focused regression tests for repeated placeholders, existing escapes, even backslashes, and the existing conservative special-character set.
- Leave code blocks and intentional table/algorithm HTML on their existing rendering paths.

## BC-breaking

No public API changes. The generated Markdown source gains a backslash before unescaped `<` characters in plain text; rendered text remains the same literal content.

## Tests

- `PYTHONPATH=. uv run --python 3.12 --with pytest --no-project pytest -q -o addopts='' tests/unittest/test_markdown_utils.py` (4 passed)
- `uvx ruff check --ignore ANN001 mineru/backend/utils/markdown_utils.py tests/unittest/test_markdown_utils.py` (passed; `ANN001` is an existing annotation warning in the touched source file)
- CommonMark rendering smoke test confirmed `\<address>` renders as literal `&lt;address&gt;`, not an HTML element.
- Full model/GPU end-to-end parsing was not run because this change is isolated to the pure Markdown escaping utility.

## Checklist

**Before PR**:

- [x] Ruff was run on the modified files.
- [x] The reported bug is covered by focused unit tests.
- [x] Existing conservative escaping behavior is covered by a regression test.
- [x] No documentation change is required for this narrowly scoped bug fix.

**After PR**:

- [x] The behavior was verified with a CommonMark renderer.
- [x] CLA has been signed and all committers have signed the CLA in this PR.