### PR TITLE
fix: support filename prefix search

### DIFF
--- a/mineru/doclib/core/fts.py
+++ b/mineru/doclib/core/fts.py
@@ -112,6 +112,8 @@ class FTSManager:
         tokens = _sanitize_query_tokens(tokenize_for_query(query))
         if not tokens:
             return []
+        if not query.rstrip().endswith("*"):
+            tokens[-1] += "*"
         fts_query = " ".join(tokens)
         try:
             return cast(

--- a/tests/unittest/test_doclib_cache_semantics.py
+++ b/tests/unittest/test_doclib_cache_semantics.py
@@ -2293,6 +2293,48 @@ def test_content_search_does_not_match_filename_but_find_does(tmp_path: Path) ->
     asyncio.run(_run())
 
 
+def test_filename_search_applies_prefix_only_to_final_query_token(tmp_path: Path) -> None:
+    async def _run() -> None:
+        db = DatabaseManager(str(tmp_path / "doclib.db"))
+        await db.initialize()
+        fts = FTSManager(db)
+        filenames = (
+            (1, "bench1.pdf"),
+            (2, "bench5.pdf"),
+            (3, "annual report2026.pdf"),
+            (4, "项目报告2026.pdf"),
+            (5, "annualized report2026.pdf"),
+        )
+        for file_id, filename in filenames:
+            await fts.upsert_filename(file_id, filename, "pdf")
+        await fts.replace(
+            sha256="f" * 64,
+            tier="standard",
+            text="benchmark content",
+            title="",
+            author="",
+        )
+
+        try:
+            implicit_prefix = await fts.search_filenames("bench")
+            explicit_prefix = await fts.search_filenames("bench*  ")
+            exact = await fts.search_filenames("bench1")
+            multi_token = await fts.search_filenames("annual rep")
+            cjk = await fts.search_filenames("项目报告")
+            content_prefix = await fts.search("bench")
+
+            assert {row["file_id"] for row in implicit_prefix} == {1, 2}
+            assert {row["file_id"] for row in explicit_prefix} == {1, 2}
+            assert [row["file_id"] for row in exact] == [1]
+            assert [row["file_id"] for row in multi_token] == [3]
+            assert [row["file_id"] for row in cjk] == [4]
+            assert content_prefix == []
+        finally:
+            await db.close()
+
+    asyncio.run(_run())
+
+
 def test_search_returns_all_files_in_reverse_insertion_order(tmp_path: Path) -> None:
     async def _run() -> None:
         db = DatabaseManager(str(tmp_path / "doclib.db"))


### PR DESCRIPTION
## Motivation

`mineru find bench` currently misses filenames such as `bench1.pdf`, even though the explicit wildcard form `bench*` works. This makes the default filename search behavior surprising and is the issue reported in #5281.

## Modification

- Apply FTS5 prefix matching to the final sanitized token in filename searches when the query does not already end in `*`.
- Preserve explicit wildcard queries and keep content full-text search behavior unchanged.
- Add SQLite-backed regression coverage for implicit and explicit prefixes, exact tokens, multi-token queries, CJK filenames, and filename/content search isolation.

## BC-breaking (Optional)

No. Filename lookup becomes more permissive for the final query token; public Python APIs, content search, indexing, and storage are unchanged.

## Testing

- `.venv/bin/python -m pytest -q -o addopts='' tests/unittest/test_doclib_cache_semantics.py tests/unittest/test_cli_next_command_design.py` (307 passed)
- `uvx ruff check mineru/doclib/core/fts.py`
- `uvx ruff check --ignore ANN001,E501 tests/unittest/test_doclib_cache_semantics.py`
- Direct tokenization smoke test for implicit prefix, explicit wildcard, multi-token, and CJK queries

Model/GPU parsing E2E tests were not run because this change is isolated to SQLite FTS filename query construction.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] Documentation impact was reviewed; no documentation change is needed for this targeted bug fix.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. (No downstream API or storage change.)
- [x] CLA has been signed and all committers have signed the CLA in this PR.

Fixes #5281
