### PR TITLE
fix(markdown): move punctuation outside inline math

### DIFF
--- a/mineru/backend/pipeline/pipeline_middle_json_mkcontent.py
+++ b/mineru/backend/pipeline/pipeline_middle_json_mkcontent.py
@@ -217,6 +217,7 @@ display_left_delimiter = delimiters['display']['left']
 display_right_delimiter = delimiters['display']['right']
 inline_left_delimiter = delimiters['inline']['left']
 inline_right_delimiter = delimiters['inline']['right']
+INLINE_EQUATION_TRAILING_PUNCTUATION = ',.，。'
 
 CJK_LANGS = {'zh', 'ja', 'ko'}
 
@@ -362,6 +363,19 @@ def _normalize_text_content(content):
     return full_to_half_exclude_marks(content or '')
 
 
+def _render_inline_equation(content: str) -> str:
+    # OCR may attach sentence punctuation to the formula span. Keep that
+    # punctuation outside the Markdown math delimiters.
+    equation = content.rstrip(INLINE_EQUATION_TRAILING_PUNCTUATION)
+    trailing_punctuation = content[len(equation):]
+    if not equation.strip():
+        return f"{inline_left_delimiter}{content}{inline_right_delimiter}"
+    return (
+        f"{inline_left_delimiter}{equation}{inline_right_delimiter}"
+        f"{trailing_punctuation}"
+    )
+
+
 def _render_span(span, escape_markdown=True):
     # 将单个 span 渲染成 markdown 片段。
     # 这里只负责“渲染成什么文本”，不决定后面是否补空格。
@@ -374,7 +388,7 @@ def _render_span(span, escape_markdown=True):
             content = escape_special_markdown_char(content)
     elif span_type == ContentType.INLINE_EQUATION:
         if span.get('content', ''):
-            content = f"{inline_left_delimiter}{span['content']}{inline_right_delimiter}"
+            content = _render_inline_equation(span['content'])
     elif span_type == ContentType.INTERLINE_EQUATION:
         if span.get('content', ''):
             content = f"\n{display_left_delimiter}\n{span['content']}\n{display_right_delimiter}\n"

--- a/tests/unittest/test_inline_equation_punctuation.py
+++ b/tests/unittest/test_inline_equation_punctuation.py
@@ -1,0 +1,40 @@
+import pytest
+
+from mineru.backend.pipeline.pipeline_middle_json_mkcontent import _render_span
+from mineru.utils.enum_class import ContentType
+
+
+def _inline_equation(content: str) -> tuple[str, str] | None:
+    return _render_span({
+        'type': ContentType.INLINE_EQUATION,
+        'content': content,
+    })
+
+
+@pytest.mark.parametrize(
+    ('content', 'expected'),
+    [
+        (r'P(G\mid ¬U),', r'$P(G\mid ¬U)$,'),
+        ('f(x).', '$f(x)$.'),
+        ('f(x)，', '$f(x)$，'),
+        ('f(x)。', '$f(x)$。'),
+    ],
+)
+def test_render_inline_equation_moves_sentence_punctuation_outside_math(
+    content: str,
+    expected: str,
+) -> None:
+    assert _inline_equation(content) == (ContentType.INLINE_EQUATION, expected)
+
+
+def test_render_inline_equation_keeps_internal_punctuation() -> None:
+    assert _inline_equation('f(x,y)') == (
+        ContentType.INLINE_EQUATION,
+        '$f(x,y)$',
+    )
+    assert _inline_equation('n!') == (ContentType.INLINE_EQUATION, '$n!$')
+
+
+def test_render_inline_equation_does_not_create_empty_math() -> None:
+    assert _inline_equation(',') == (ContentType.INLINE_EQUATION, '$,$')
+    assert _inline_equation('') is None


### PR DESCRIPTION
## Motivation

Fixes #5355.

The pipeline Markdown renderer currently wraps the complete inline-equation
span in math delimiters. When OCR attaches sentence punctuation to the span,
`P(G\mid ¬U),` is rendered as `$P(G\mid ¬U),$` instead of
`$P(G\mid ¬U)$,`.

## Modification

- Move trailing ASCII and CJK commas and periods outside the inline math
  delimiters.
- Keep punctuation inside a formula unchanged when it is not trailing.
- Preserve other trailing math syntax such as the factorial operator in `n!`.
- Preserve punctuation-only spans instead of producing an empty math
  expression.
- Add focused regression tests for commas, periods, CJK punctuation,
  internal commas, factorials, and empty content.

## BC-breaking (Optional)

No. The middle JSON and public APIs are unchanged. Only generated Markdown
for inline-equation spans ending in sentence punctuation changes.

## Verification

Before this change:

```text
'P(G\\mid ¬U),' => ('inline_equation', '$P(G\\mid ¬U),$')
```

After this change:

```text
'P(G\\mid ¬U),' => ('inline_equation', '$P(G\\mid ¬U)$,')
'x,y' => ('inline_equation', '$x,y$')
',' => ('inline_equation', '$,$')
```

Commands:

```bash
PYTHONPATH=. uv run --python 3.12 --with pytest --with loguru \
  --with fast-langdetect --no-project pytest -q -o addopts='' \
  tests/unittest/test_inline_equation_punctuation.py
# 6 passed

uvx ruff check --ignore ANN \
  mineru/backend/pipeline/pipeline_middle_json_mkcontent.py
uvx ruff check tests/unittest/test_inline_equation_punctuation.py
# All checks passed

PYTHONPATH=. uv run --python 3.12 --with loguru \
  --with fast-langdetect --no-project python -m py_compile \
  mineru/backend/pipeline/pipeline_middle_json_mkcontent.py \
  tests/unittest/test_inline_equation_punctuation.py
```

Model/GPU end-to-end parsing was not run because this change is isolated to
the pure Markdown rendering step and is covered directly at that boundary.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests.
- [x] Documentation impact was reviewed; no user-facing documentation change is needed.

**After PR**:

- [x] No downstream API or serialized middle JSON change is introduced.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
