### PR TITLE
fix(pipeline): default missing feature configs

### DIFF
--- a/mineru/backend/pipeline/model_init.py
+++ b/mineru/backend/pipeline/model_init.py
@@ -230,9 +230,9 @@ def atom_model_init(model_name: str, **kwargs):
 
 class MineruPipelineModel:
     def __init__(self, **kwargs):
-        self.formula_config = kwargs.get('formula_config')
+        self.formula_config = kwargs.get('formula_config') or {}
         self.apply_formula = self.formula_config.get('enable', True)
-        self.table_config = kwargs.get('table_config')
+        self.table_config = kwargs.get('table_config') or {}
         self.apply_table = self.table_config.get('enable', True)
         self.lang = kwargs.get('lang', None)
         self.device = kwargs.get('device', 'cpu')

--- a/tests/unittest/test_pipeline_model_config.py
+++ b/tests/unittest/test_pipeline_model_config.py
@@ -1,0 +1,53 @@
+import pytest
+
+from mineru.backend.pipeline import model_init
+
+
+def _fake_get_atom_model(
+    _self: object,
+    atom_model_name: str,
+    **_kwargs: object,
+) -> object:
+    return object()
+
+
+def _fake_model_path(*_args: object, **_kwargs: object) -> str:
+    return "/tmp/mineru-models"
+
+
+@pytest.mark.parametrize(
+    ("config", "formula_enabled", "table_enabled"),
+    [
+        ({}, True, True),
+        ({"formula_config": None, "table_config": None}, True, True),
+        (
+            {
+                "formula_config": {"enable": False},
+                "table_config": {"enable": False},
+            },
+            False,
+            False,
+        ),
+    ],
+)
+def test_pipeline_model_handles_optional_feature_configs(
+    monkeypatch: pytest.MonkeyPatch,
+    config: dict,
+    formula_enabled: bool,
+    table_enabled: bool,
+) -> None:
+    monkeypatch.setattr(
+        model_init.AtomModelSingleton,
+        "get_atom_model",
+        _fake_get_atom_model,
+    )
+    monkeypatch.setattr(
+        model_init,
+        "auto_download_and_get_model_root_path",
+        _fake_model_path,
+    )
+
+    model = model_init.MineruPipelineModel(**config)
+
+    assert model.apply_formula is formula_enabled
+    assert model.apply_table is table_enabled


### PR DESCRIPTION
## Motivation

Fixes #5317.

`MineruPipelineModel` assumes both `formula_config` and `table_config` are
dictionaries. Direct integrations that omit either optional config, or pass
it as `None`, fail before model initialization:

```text
AttributeError: 'NoneType' object has no attribute 'get'
```

The standard CLI supplies both dictionaries, but the model class accepts
keyword arguments directly and should preserve its documented default-enabled
behavior when those optional dictionaries are absent.

## Modification

- Normalize a missing or `None` `formula_config` to an empty dictionary.
- Normalize a missing or `None` `table_config` to an empty dictionary.
- Add regression coverage for omitted configs, explicit `None`, and explicit
  `{"enable": False}` values.
- Mock atom model creation in the tests, so no weights are downloaded and no
  GPU is required.

## BC-breaking (Optional)

No. Missing configs now use the existing default of `enable=True`. Explicit
`enable=False` values remain unchanged.

## Verification

The same regression test was run against the original and patched code.

Before:

```text
2 failed, 1 passed
AttributeError: 'NoneType' object has no attribute 'get'
```

After:

```text
3 passed
```

Commands:

```bash
PYTHONPATH=. uv run --python 3.12 --with pytest --with torch \
  --with torchvision --with loguru --with numpy --with opencv-python \
  --with transformers --with modelscope --with pypdfium2 --with pypdf \
  --with pdftext --with pillow --with shapely --with pyclipper \
  --with onnxruntime --with fast-langdetect --with six \
  --with beautifulsoup4 --no-project pytest -q -o addopts='' \
  tests/unittest/test_pipeline_model_config.py

uvx ruff check --ignore ANN mineru/backend/pipeline/model_init.py
uvx ruff check tests/unittest/test_pipeline_model_config.py
```

No model or GPU end-to-end run is needed for this constructor-level change;
the regression test replaces all atom model factories and exercises the
configuration boundary directly.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests.
- [x] Documentation impact was reviewed; no public API documentation change is needed.

**After PR**:

- [x] No downstream API or model behavior changes for explicit configurations.
- [x] CLA has already been signed by this contributor.
