### PR TITLE
fix(doclib): invalidate stale tier health on switch

### DIFF
--- a/mineru/doclib/background/parse_server_health.py
+++ b/mineru/doclib/background/parse_server_health.py
@@ -72,6 +72,17 @@ class ParseServerHealth:
     managed_proc: subprocess.Popen | None = None
     managed_control: ManagedProcessControl | None = None
 
+    def begin_managed_tier_transition(self, tier: DeploymentTier) -> None:
+        self.managed_tier = tier
+        self.local_starting = True
+        self.local = ProbeState(
+            url=self.managed_url,
+            probe=ProbeResult(
+                error_code="parse_server_unavailable",
+                error_msg=f"Managed parse-server is restarting for tier '{tier}'.",
+            ),
+        )
+
 
 _parse_server_health = ParseServerHealth()
 
@@ -449,12 +460,14 @@ class ParseServerHealthCheck:
         if count_restart:
             health.restart_count += 1
         managed_tier = await get_managed_parse_server_tier(self.config_svc)
+        startup_in_progress = health.local_starting
+        health.begin_managed_tier_transition(managed_tier)
         stop_managed_parse_server(
             health.managed_proc,
             control=health.managed_control,
             timeout_sec=self.stop_timeout_sec,
             reason=reason,
-            startup_in_progress=health.local_starting,
+            startup_in_progress=startup_in_progress,
         )
         health.managed_proc = None
         health.managed_control = None

--- a/mineru/doclib/server.py
+++ b/mineru/doclib/server.py
@@ -905,8 +905,16 @@ class DoclibServer(AsyncDoclibInterface):
     async def set_config(self, key: str, request: ConfigSetRequest) -> ConfigSetResponse:
         await self._validate_config_set(key, request.value)
         await self.state.config_svc.set(key, request.value)
+        if key == "parse_server.local.managed_tier":
+            self._begin_managed_tier_transition_if_needed(cast(DeploymentTier, request.value))
         value, source = await self._effective_config_value(key)
         return ConfigSetResponse(key=key, value=_mask_config_value(key, value or ""), source=source)
+
+    @staticmethod
+    def _begin_managed_tier_transition_if_needed(tier: DeploymentTier) -> None:
+        health = get_health()
+        if health.local_mode == "managed" and health.running_managed_tier != tier:
+            health.begin_managed_tier_transition(tier)
 
     async def _effective_config_value(self, key: str) -> tuple[str | None, ConfigSource]:
         if key == REMOTE_API_KEY_CONFIG:
@@ -931,6 +939,8 @@ class DoclibServer(AsyncDoclibInterface):
     async def unset_config(self, key: str) -> ConfigUnsetResponse:
         removed = await self.state.config_svc.unset(key)
         value, source = await self._effective_config_value(key)
+        if key == "parse_server.local.managed_tier" and value:
+            self._begin_managed_tier_transition_if_needed(cast(DeploymentTier, value))
         return ConfigUnsetResponse(key=key, value=_mask_config_value(key, value or ""), source=source, removed=removed)
 
     @route("POST", "/watches", tags=("watches",))

--- a/tests/unittest/test_doclib_cache_semantics.py
+++ b/tests/unittest/test_doclib_cache_semantics.py
@@ -61,7 +61,14 @@ from mineru.doclib.services.parse_svc import (
 )
 from mineru.doclib.services.scan_svc import ScanService
 from mineru.doclib.services.search_svc import SearchService
-from mineru.doclib.types import DocContentExportRequest, FileInfo, InvalidateRequest, ParseResponse, WatchRequest
+from mineru.doclib.types import (
+    ConfigSetRequest,
+    DocContentExportRequest,
+    FileInfo,
+    InvalidateRequest,
+    ParseResponse,
+    WatchRequest,
+)
 from mineru.errors import InvalidRequestError, MineruError, NotFoundError
 from mineru.filetypes import file_type_for_extension
 from mineru.parser import backend_for_tier, resolve_tier_and_backend
@@ -891,6 +898,86 @@ def test_managed_parse_server_tier_change_detection_triggers_restart(monkeypatch
     assert calls == [("tier-change", "tier change standard->basic", False)]
 
 
+def test_config_changes_invalidate_stale_managed_tier_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _ConfigSvc:
+        value = "standard"
+        source = "default"
+
+        async def get(self, key: str) -> str:
+            assert key == "parse_server.local.managed_tier"
+            return self.value
+
+        async def set(self, key: str, value: str) -> None:
+            assert key == "parse_server.local.managed_tier"
+            self.value = value
+            self.source = "override"
+
+        async def unset(self, key: str) -> bool:
+            assert key == "parse_server.local.managed_tier"
+            self.value = "standard"
+            self.source = "default"
+            return True
+
+        async def get_source(self, key: str) -> str:
+            assert key == "parse_server.local.managed_tier"
+            return self.source
+
+    health = ParseServerHealth(
+        local=ProbeState(
+            url="http://127.0.0.1:16580",
+            probe=ProbeResult(healthy=True, tiers=["standard"]),
+        ),
+        local_mode="managed",
+        managed_url="http://127.0.0.1:16580",
+        managed_tier="standard",
+        running_managed_tier="standard",
+    )
+    monkeypatch.setattr(
+        "mineru.doclib.background.parse_server_health._parse_server_health",
+        health,
+    )
+    monkeypatch.setattr(
+        "mineru.doclib.server._ensure_managed_parse_server_tier_available",
+        lambda tier, param: None,
+    )
+    config_svc = _ConfigSvc()
+    server = DoclibServer(SimpleNamespace(config_svc=config_svc))
+
+    response = asyncio.run(
+        server.set_config(
+            "parse_server.local.managed_tier",
+            ConfigSetRequest(value="basic"),
+        )
+    )
+
+    assert response.value == "basic"
+    assert health.managed_tier == "basic"
+    assert health.local_starting is True
+    assert health.local.probe.healthy is False
+    assert health.local.probe.tiers == []
+    assert health.local.probe.error_code == "parse_server_unavailable"
+
+    health.running_managed_tier = "basic"
+    health.managed_tier = "basic"
+    health.local_starting = False
+    health.local = ProbeState(
+        url="http://127.0.0.1:16580",
+        probe=ProbeResult(healthy=True, tiers=["basic"]),
+    )
+
+    unset_response = asyncio.run(
+        server.unset_config("parse_server.local.managed_tier")
+    )
+
+    assert unset_response.value == "standard"
+    assert unset_response.source == "default"
+    assert health.managed_tier == "standard"
+    assert health.local_starting is True
+    assert health.local.probe.healthy is False
+    assert health.local.probe.tiers == []
+    assert health.local.probe.error_code == "parse_server_unavailable"
+
+
 def test_managed_parse_server_tier_change_restart_uses_desired_tier(monkeypatch: pytest.MonkeyPatch) -> None:
     events: list[str] = []
     old_proc = object()
@@ -947,6 +1034,9 @@ def test_managed_parse_server_tier_change_restart_uses_desired_tier(monkeypatch:
     assert health.managed_proc.pid == 24680
     assert health.running_managed_tier == "basic"
     assert health.restart_count == 2
+    assert health.local_starting is True
+    assert health.local.probe.healthy is False
+    assert health.local.probe.tiers == []
 
 
 def test_get_file_stat_returns_typed_file_stat(tmp_path: Path) -> None:


### PR DESCRIPTION
## Motivation

Fixes #5272.

The `next` branch already detects managed parse-server tier changes and
restarts the child in the background. However, updating
`parse_server.local.managed_tier` returns before that health-check cycle.
During this window, the old parse-server probe remains healthy and still
advertises its previous tier, so an immediate parse can be routed to the
stale process and fail with `tier_mismatch`.

The tier names on `next` are now `basic` and `standard`, but the race is the
same one reported for the previous `medium`/`high` names.

## Modification

- Add a managed-tier transition state that immediately marks the local
  parse-server as starting and unavailable.
- Clear the stale supported-tier probe as soon as a new managed tier is
  persisted.
- Apply the same transition when unsetting the override returns to the
  default managed tier.
- Reapply that transition state when the background health checker begins
  the actual restart, covering the probe-before-restart race.
- Preserve the old process's original startup state when calculating its
  graceful shutdown budget.
- Add API-level regression coverage for setting and unsetting the managed
  tier while the old tier is still reported healthy.

## BC-breaking (Optional)

No. During a managed tier transition, callers now receive the existing
"parse-server is not ready" behavior instead of being routed to a known-stale
process. Normal operation and same-tier updates are unchanged.

## Verification

The same focused test selection was run against the original and patched
code.

Before:

```text
1 failed, 2 passed
health.managed_tier remained "standard" after setting "basic"
```

After:

```text
3 passed
```

Expanded regression:

```text
225 passed
```

Commands:

```bash
PYTHONPATH=. uv run --python 3.12 --with 'mineru[basic]@.' \
  --with pytest --no-project pytest -q -o addopts='' \
  tests/unittest/test_doclib_cache_semantics.py \
  tests/unittest/test_doclib_app_startup.py

uvx ruff check \
  mineru/doclib/background/parse_server_health.py \
  mineru/doclib/server.py
uvx ruff check --ignore ANN,E501 \
  tests/unittest/test_doclib_cache_semantics.py
```

A real model restart was not required for this state/routing fix. The tests
exercise the config API, shared health state, restart path, and surrounding
Doclib lifecycle with the managed child mocked.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests.
- [x] Documentation impact was reviewed; no configuration syntax changes.

**After PR**:

- [x] The surrounding Doclib config and lifecycle tests pass.
- [x] CLA has already been signed by this contributor.
