### PR TITLE
fix(doclib): support long Windows sidecar paths

### DIFF
--- a/mineru/doclib/services/parse_svc.py
+++ b/mineru/doclib/services/parse_svc.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import ntpath
 import os
 import time
 from collections.abc import Sequence
@@ -27,6 +28,7 @@ from ...filetypes import (
 from ...parser.api_client import _APITransportError, _V1APIError
 from ...parser.base import ParseResult
 from ...types import QUALITY_TIERS, TIER_ORDER, PageInfo, Tier, select_default_quality_tier, select_parsing_rule_tier
+from ...utils.check_sys_env import is_windows_environment
 from ..core.db import DatabaseManager
 from ..core.file_io import FileStat, MetadataExtractionError, compute_sha256, extract_metadata, get_file_stat
 from ..core.fts import FTSManager
@@ -1484,6 +1486,20 @@ def parse_image_sidecar_dir(data_dir: str, sha256: str, tier: Tier) -> str:
     return os.path.join(os.path.expanduser(data_dir), "parsed", sha256[:2], sha256, tier, "images")
 
 
+def _windows_extended_path(path: str | os.PathLike[str]) -> str:
+    """Return a Windows extended-length path for internal cache I/O."""
+    raw_path = os.fspath(path)
+    if not is_windows_environment():
+        return raw_path
+
+    absolute_path = ntpath.abspath(raw_path)
+    if absolute_path.startswith("\\\\?\\"):
+        return absolute_path
+    if absolute_path.startswith("\\\\"):
+        return f"\\\\?\\UNC\\{absolute_path[2:]}"
+    return f"\\\\?\\{absolute_path}"
+
+
 def resolve_image_sidecar_path(image_dir: str, image_path: str) -> Path | None:
     """把 public image_path 安全映射到 doclib 缓存图片目录，拒绝绝对路径和上跳路径。"""
     if not image_path:
@@ -1491,7 +1507,8 @@ def resolve_image_sidecar_path(image_dir: str, image_path: str) -> Path | None:
     raw_path = PurePosixPath(image_path)
     if raw_path.is_absolute() or any(part in {"", ".", ".."} for part in raw_path.parts):
         return None
-    return Path(image_dir).joinpath(*raw_path.parts)
+    sidecar_path = Path(image_dir).joinpath(*raw_path.parts)
+    return Path(_windows_extended_path(sidecar_path))
 
 
 def _write_cached_image_sidecars(image_dir: str, images: dict[str, bytes]) -> None:

--- a/tests/unittest/test_doclib_cache_semantics.py
+++ b/tests/unittest/test_doclib_cache_semantics.py
@@ -53,6 +53,7 @@ from mineru.doclib.services.parse_svc import (
     _local_parse_server_url,
     _resolve_default_tier,
     _resolve_parsing_rule_default_tier,
+    _windows_extended_path,
     expand_page_range,
     filter_pages_by_user_range,
     load_pages_from_done_batches,
@@ -4510,6 +4511,30 @@ def test_progressive_markdown_uses_sidecar_availability_for_bboxless_blocks(
 
     assert f"![Image block]({expected_target})" in response.content
     assert "figures/rendered.jpg" not in response.content
+
+
+def test_windows_extended_path_supports_long_sidecar_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "mineru.doclib.services.parse_svc.is_windows_environment",
+        lambda: True,
+    )
+
+    drive_path = "C:\\mineru\\" + ("nested\\" * 30) + "image.jpg"
+    unc_path = "\\\\server\\share\\" + ("nested\\" * 30) + "image.jpg"
+
+    assert _windows_extended_path(drive_path) == f"\\\\?\\{drive_path}"
+    assert _windows_extended_path(unc_path) == f"\\\\?\\UNC\\{unc_path[2:]}"
+    assert _windows_extended_path(f"\\\\?\\{drive_path}") == f"\\\\?\\{drive_path}"
+
+
+def test_windows_extended_path_is_noop_on_other_platforms(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "mineru.doclib.services.parse_svc.is_windows_environment",
+        lambda: False,
+    )
+    path = "/tmp/mineru/images/image.jpg"
+
+    assert _windows_extended_path(path) == path
 
 
 def test_doclib_office_image_asset_reads_cached_sidecar(tmp_path: Path) -> None:


### PR DESCRIPTION
## Motivation

Fixes #5321.

On Windows, DOCX/XLSX Flash parsing fails when an embedded-image sidecar path
reaches the `MAX_PATH` boundary. The issue report provides repeated 259/260
character A/B results: 259-character paths succeed, while otherwise identical
260-character paths fail before the JPG is written.

Doclib currently maps sidecar paths with a regular `Path` and then uses that
path for both writes and reads. No Windows extended-length prefix is applied.

## Modification

- Convert internal Windows sidecar paths to the `\\?\` extended-length form.
- Convert UNC paths to the required `\\?\UNC\` form.
- Keep already-prefixed paths unchanged.
- Keep non-Windows paths unchanged.
- Apply the conversion in the shared sidecar path resolver so cache writes,
  existence checks, and reads use the same path representation.

Public `image_path` values, cache directory layout, and hashed filenames are
unchanged.

## BC-breaking (Optional)

No. This only changes the filesystem representation used for internal cache
I/O on Windows.

## Verification

Focused path and sidecar tests:

```text
8 passed
```

Full Doclib cache semantics:

```text
195 passed
```

Commands:

```bash
PYTHONPATH=. uv run --python 3.12 --with 'mineru[basic]@.' \
  --with pytest --no-project pytest -q -o addopts='' \
  tests/unittest/test_doclib_cache_semantics.py

uvx ruff check mineru/doclib/services/parse_svc.py
uvx ruff check --ignore ANN,E501 \
  tests/unittest/test_doclib_cache_semantics.py
```

The unit tests cover drive paths, UNC paths, already-prefixed paths, and the
non-Windows no-op behavior. A Windows machine was not available locally; the
real Windows boundary evidence comes from the issue's repeated 259/260
character reproduction.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests.
- [x] Documentation impact was reviewed; no public path format changes.

**After PR**:

- [x] Existing Doclib sidecar read/write behavior passes on the local platform.
- [x] CLA has already been signed by this contributor.
