### PR TITLE
fix(markdown): exclude dot leaders from formula tags

### DIFF
--- a/mineru/backend/utils/formula_number.py
+++ b/mineru/backend/utils/formula_number.py
@@ -1,4 +1,5 @@
 # Copyright (c) Opendatalab. All rights reserved.
+import re
 from collections.abc import Callable, Iterable, Sequence
 from typing import Any
 
@@ -36,8 +37,11 @@ def extract_formula_number_text(block: Block) -> str:
 
 
 def normalize_formula_tag_content(tag_content: str) -> str:
-    """归一化公式编号文本，去掉外层括号并转换全角字符。"""
+    """归一化公式编号文本，去掉引导符和外层括号并转换全角字符。"""
     tag_content = full_to_half(tag_content.strip())
+    trailing_tag = re.search(r"\(([^()]*)\)\s*$", tag_content)
+    if trailing_tag:
+        return trailing_tag.group(1).strip()
     if tag_content.startswith("("):
         tag_content = tag_content[1:].strip()
     if tag_content.endswith(")"):

--- a/tests/unittest/test_formula_number.py
+++ b/tests/unittest/test_formula_number.py
@@ -1,0 +1,24 @@
+import pytest
+
+from mineru.backend.utils.formula_number import (
+    build_tagged_formula_content,
+    normalize_formula_tag_content,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw_tag", "expected"),
+    [
+        ("(3)", "3"),
+        ("（３）", "3"),
+        ("......(3)", "3"),
+        ("......（３）", "3"),
+        ("A.3", "A.3"),
+    ],
+)
+def test_normalize_formula_tag_content(raw_tag: str, expected: str) -> None:
+    assert normalize_formula_tag_content(raw_tag) == expected
+
+
+def test_build_tagged_formula_content_drops_dot_leader() -> None:
+    assert build_tagged_formula_content("E=x", {"content": "......(3)"}) == (r"E=x\tag{3}")


### PR DESCRIPTION
## Motivation

Fixes #5289.

Formula-number layout blocks can include the dotted leader between a display
formula and its printed number. For example, the issue's minimal PDF produces
a number block ending in `......(3)`.

The existing normalization removes the first opening parenthesis and the last
closing parenthesis independently, turning that value into `......(3`. The
generated `\tag{......(3}` then renders the extra opening parenthesis and
leader shown in the issue.

## Modification

- Extract the final complete parenthesized number from a formula-number block.
- Preserve the existing behavior for bare tags such as `A.3`.
- Keep full-width digit and parenthesis normalization.
- Add focused regression coverage for ASCII and full-width leaders, ordinary
  parenthesized numbers, bare tags, and final `\tag{}` generation.

## BC-breaking (Optional)

No. This only removes non-number leader text from generated formula tags.

## Verification

The same focused regression test was run before and after the change.

Before:

```text
2 failed, 3 passed
'......(3)' normalized to '......(3'
```

After:

```text
6 passed
'......(3)' produces 'E=x\tag{3}'
```

Commands:

```bash
PYTHONPATH=. uv run --python 3.12 --with pytest --with loguru \
  --no-project pytest -q -o addopts='' \
  tests/unittest/test_formula_number.py

uvx ruff check \
  mineru/backend/utils/formula_number.py \
  tests/unittest/test_formula_number.py

PYTHONPATH=. uv run --python 3.12 --with loguru --no-project \
  python -m py_compile \
  mineru/backend/utils/formula_number.py \
  tests/unittest/test_formula_number.py
```

Model/GPU end-to-end parsing was not run because this change is isolated to
the deterministic formula-number normalization boundary exercised by the
regression tests.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix potential lint issues.
- [x] The bug is fully covered by focused unit tests.
- [x] The modification is covered by complete tests at the changed boundary.
- [x] Documentation impact was reviewed; no public interface changes.

**After PR**:

- [x] No downstream API or serialized middle-JSON change is introduced.
- [x] CLA has already been signed by this contributor.
