### PR TITLE
fix(xlsx): preserve images anchored in merged cells

### DIFF
--- a/mineru/model/xlsx/xlsx_converter.py
+++ b/mineru/model/xlsx/xlsx_converter.py
@@ -112,6 +112,9 @@ class _MergedCellLookup:
             collections.defaultdict(list)
         )
         self._anchor_spans: dict[tuple[int, int], tuple[int, int]] = {}
+        self._merged_row_anchors: dict[
+            int, list[tuple[int, int, int, int]]
+        ] = collections.defaultdict(list)
 
         for merged in sheet.merged_cells.ranges:
             min_row = merged.min_row - 1
@@ -126,6 +129,9 @@ class _MergedCellLookup:
 
             for row in range(min_row, max_row + 1):
                 self._merged_row_intervals[row].append((min_col, max_col))
+                self._merged_row_anchors[row].append(
+                    (min_col, max_col, min_row, min_col)
+                )
                 hidden_start_col = min_col + 1 if row == min_row else min_col
                 if hidden_start_col <= max_col:
                     self._hidden_row_intervals[row].append(
@@ -136,6 +142,8 @@ class _MergedCellLookup:
             intervals.sort()
         for intervals in self._hidden_row_intervals.values():
             intervals.sort()
+        for anchors in self._merged_row_anchors.values():
+            anchors.sort()
 
     @staticmethod
     def _contains_interval(
@@ -162,6 +170,17 @@ class _MergedCellLookup:
     def get_anchor_span(self, row: int, col: int) -> tuple[int, int]:
         """返回合并区域左上角坐标对应的 rowspan/colspan，非合并锚点返回 1x1。"""
         return self._anchor_spans.get((row, col), (1, 1))
+
+    def get_anchor_position(self, row: int, col: int) -> tuple[int, int]:
+        """Return the top-left coordinate for a merged cell, or the input coordinate."""
+        for start_col, end_col, anchor_row, anchor_col in self._merged_row_anchors.get(
+            row, []
+        ):
+            if start_col <= col <= end_col:
+                return anchor_row, anchor_col
+            if start_col > col:
+                break
+        return row, col
 
 
 class XlsxConverter:
@@ -344,12 +363,16 @@ class XlsxConverter:
         if self.workbook is None:
             return images
 
+        merged_lookup = self._get_merged_cell_lookup(sheet)
         for item in getattr(sheet, "_images", []):  # type: ignore[attr-defined]
             try:
                 image: XlsImage = cast(XlsImage, item)
+                anchor = self._get_anchor_pos(item.anchor)
+                if anchor[0] is not None and anchor[1] is not None:
+                    anchor = merged_lookup.get_anchor_position(*anchor)
                 images.append(
                     {
-                        "anchor": self._get_anchor_pos(item.anchor),
+                        "anchor": anchor,
                         "base64": self._serialize_sheet_image(image),
                     }
                 )

--- a/tests/unittest/test_xlsx_converter.py
+++ b/tests/unittest/test_xlsx_converter.py
@@ -1,0 +1,39 @@
+# Copyright (c) Opendatalab. All rights reserved.
+from io import BytesIO
+
+from openpyxl import Workbook
+from openpyxl.drawing.image import Image as XlsImage
+from openpyxl.drawing.spreadsheet_drawing import AnchorMarker, OneCellAnchor
+from openpyxl.drawing.xdr import XDRPositiveSize2D
+from PIL import Image
+
+from mineru.model.xlsx.xlsx_converter import XlsxConverter
+
+
+def _image_stream(color: tuple[int, int, int]) -> BytesIO:
+    stream = BytesIO()
+    Image.new("RGB", (2, 2), color).save(stream, format="PNG")
+    stream.seek(0)
+    return stream
+
+
+def test_collect_sheet_images_preserves_images_inside_merged_cell() -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    worksheet.merge_cells("B1:D1")
+
+    for col, color in enumerate(((255, 0, 0), (0, 255, 0), (0, 0, 255)), start=1):
+        image = XlsImage(_image_stream(color))
+        image.anchor = OneCellAnchor(
+            _from=AnchorMarker(col=col, row=0),
+            ext=XDRPositiveSize2D(cx=10, cy=10),
+        )
+        worksheet.add_image(image)
+
+    converter = XlsxConverter()
+    converter.workbook = workbook
+
+    images = converter._collect_sheet_images(worksheet)
+
+    assert len(images) == 3
+    assert [image_info["anchor"] for image_info in images] == [(0, 1)] * 3


### PR DESCRIPTION
## Motivation

Images anchored to non-top-left cells inside an XLSX merged range were emitted under hidden merged-cell coordinates. As a result, only one image remained visible in the generated table output when several images belonged to the same merged cell.

## Modification

- Map image anchors inside merged ranges to the range's top-left cell.
- Keep all images assigned to that merged-cell anchor.
- Add a synthetic regression test with three images anchored across one merged range.

## BC-breaking

No.

## Checklist

**Before PR**:

- [x] Bug fixes are fully covered by unit tests.
- [x] The modification is covered by unit tests.
- [x] `git diff --check` passes.

Test: `uv run --with pytest pytest -o addopts='' -q tests/unittest/test_xlsx_converter.py` (1 passed).