### PR TITLE
fix(parser): preserve hyperlinks in document outputs

### DIFF
--- a/mineru/backend/pipeline/pipeline_middle_json_mkcontent.py
+++ b/mineru/backend/pipeline/pipeline_middle_json_mkcontent.py
@@ -12,6 +12,8 @@ from mineru.utils.language import detect_lang
 from mineru.backend.utils.markdown_utils import (
     escape_conservative_markdown_text,
     escape_text_block_markdown_prefix,
+    render_markdown_hyperlink,
+    render_page_anchor,
 )
 
 
@@ -372,6 +374,10 @@ def _render_span(span, escape_markdown=True):
         content = _normalize_text_content(span.get('content', ''))
         if escape_markdown:
             content = escape_special_markdown_char(content)
+    elif span_type == ContentType.HYPERLINK:
+        content = _normalize_text_content(span.get('content', ''))
+        if escape_markdown:
+            content = render_markdown_hyperlink(content, span.get('url', ''))
     elif span_type == ContentType.INLINE_EQUATION:
         if span.get('content', ''):
             content = f"{inline_left_delimiter}{span['content']}{inline_right_delimiter}"
@@ -404,7 +410,7 @@ def _join_rendered_span(para_block, block_lang, line, line_idx, span_idx, span_t
             return content, ''
         return content, ' '
 
-    if span_type not in [ContentType.TEXT, ContentType.INLINE_EQUATION]:
+    if span_type not in [ContentType.TEXT, ContentType.HYPERLINK, ContentType.INLINE_EQUATION]:
         return content, ''
 
     if (
@@ -588,6 +594,16 @@ def merge_para_with_text_v2(para_block):
                     para_content.append({
                         'type': output_type,
                         'content': rendered_content,
+                    })
+            elif span_type == ContentType.HYPERLINK:
+                content = _normalize_text_content(span.get('content', ''))
+                if content.strip():
+                    if span_idx < len(line.get('spans', [])) - 1:
+                        content += ' '
+                    para_content.append({
+                        'type': ContentTypeV2.SPAN_TEXT,
+                        'content': render_markdown_hyperlink(content, span.get('url', '')),
+                        'url': span.get('url', ''),
                     })
             elif span_type == ContentType.INLINE_EQUATION:
                 content = span.get('content', '').strip()
@@ -977,8 +993,13 @@ def union_make(pdf_info_dict: list,
         page_size = page_info.get('page_size')
         if make_mode in [MakeMode.MM_MD, MakeMode.NLP_MD]:
             if not paras_of_layout:
+                if page_info.get('page_anchor'):
+                    output_content.append(render_page_anchor(page_info['page_anchor']))
                 continue
             page_markdown = make_blocks_to_markdown(paras_of_layout, make_mode, img_buket_path)
+            page_anchor = page_info.get('page_anchor')
+            if page_anchor:
+                page_markdown.insert(0, render_page_anchor(page_anchor))
             output_content.extend(page_markdown)
         elif make_mode == MakeMode.CONTENT_LIST:
             para_blocks = merge_adjacent_ref_text_blocks_for_content(

--- a/mineru/backend/utils/markdown_utils.py
+++ b/mineru/backend/utils/markdown_utils.py
@@ -48,6 +48,20 @@ def escape_text_block_markdown_prefix(content: str) -> str:
     return f"{content[:marker_start]}\\{content[marker_start:]}"
 
 
+def render_markdown_hyperlink(content: str, target: str) -> str:
+    """Render a link using Markdown's angle-bracket destination form."""
+    label = escape_conservative_markdown_text(str(content or ""))
+    label = label.replace("[", r"\[").replace("]", r"\]")
+    href = str(target or "").replace("\r", "").replace("\n", "")
+    href = href.replace("<", "%3C").replace(">", "%3E")
+    return f"[{label}](<{href}>)"
+
+
+def render_page_anchor(anchor: str) -> str:
+    """Render a stable HTML anchor that works in generated Markdown."""
+    return f'<a id="{escape(str(anchor), quote=True)}"></a>'
+
+
 def render_algorithm_html_from_lines(
     lines: list[dict],
     inline_left_delimiter: str,

--- a/mineru/backend/vlm/vlm_middle_json_mkcontent.py
+++ b/mineru/backend/vlm/vlm_middle_json_mkcontent.py
@@ -13,6 +13,8 @@ from mineru.backend.utils.markdown_utils import (
     escape_conservative_markdown_text,
     escape_text_block_markdown_prefix,
     render_algorithm_html_from_lines,
+    render_markdown_hyperlink,
+    render_page_anchor,
 )
 
 latex_delimiters_config = get_latex_delimiter_config()
@@ -76,7 +78,7 @@ def _has_following_joinable_span(para_block, line_idx, span_idx):
         start_span_idx = span_idx + 1 if next_line_idx == line_idx else 0
         for next_span in next_line.get('spans', [])[start_span_idx:]:
             next_span_type = next_span.get('type')
-            if next_span_type == ContentType.TEXT:
+            if next_span_type in [ContentType.TEXT, ContentType.HYPERLINK]:
                 if _normalize_text_content(next_span.get('content')).strip():
                     return True
             elif next_span_type == ContentType.INLINE_EQUATION:
@@ -296,6 +298,11 @@ def merge_para_with_text(
                 content = span['content']
                 if escape_markdown_text:
                     content = escape_conservative_markdown_text(content)
+            elif span_type == ContentType.HYPERLINK:
+                content = render_markdown_hyperlink(
+                    _normalize_text_content(span.get('content', '')),
+                    span.get('url', ''),
+                )
             elif span_type == ContentType.INLINE_EQUATION:
                 content = f"{inline_left_delimiter}{span['content']}{inline_right_delimiter}"
             elif span_type == ContentType.INTERLINE_EQUATION:
@@ -330,7 +337,7 @@ def merge_para_with_text(
                         para_text += content
                 else:
                     # 西方文本语境下 每行的最后一个span判断是否要去除连字符
-                    if span_type in [ContentType.TEXT, ContentType.INLINE_EQUATION]:
+                    if span_type in [ContentType.TEXT, ContentType.HYPERLINK, ContentType.INLINE_EQUATION]:
                         # 如果span是line的最后一个且末尾带有-连字符，那么末尾不应该加空格,同时应该把-删除
                         if (
                                 is_last_span
@@ -818,11 +825,19 @@ def merge_para_with_text_v2(para_block):
         for j, span in enumerate(line['spans']):
             span_type = span['type']
             if span.get("content", '').strip():
+                is_hyperlink = span_type == ContentType.HYPERLINK
                 if span_type == ContentType.TEXT:
                     if para_type == BlockType.PHONETIC:
                         span_type = ContentTypeV2.SPAN_PHONETIC
                     else:
                         span_type = ContentTypeV2.SPAN_TEXT
+                elif is_hyperlink:
+                    span_type = ContentTypeV2.SPAN_TEXT
+                    span = dict(span)
+                    span['content'] = render_markdown_hyperlink(
+                        _normalize_text_content(span.get('content', '')),
+                        span.get('url', ''),
+                    )
                 if span_type == ContentType.INLINE_EQUATION:
                     span_type = ContentTypeV2.SPAN_EQUATION_INLINE
                 if span_type in [
@@ -865,7 +880,12 @@ def merge_para_with_text_v2(para_block):
                             else:
                                 span_content = span['content']
 
-                    if para_content and para_content[-1]['type'] == span_type:
+                    if (
+                        para_content
+                        and para_content[-1]['type'] == span_type
+                        and not para_content[-1].get('url')
+                        and not is_hyperlink
+                    ):
                         # 合并相同类型的span
                         para_content[-1]['content'] += span_content
                     else:
@@ -873,6 +893,8 @@ def merge_para_with_text_v2(para_block):
                             'type': span_type,
                             'content': span_content,
                         }
+                        if is_hyperlink:
+                            span_content['url'] = span.get('url', '')
                         para_content.append(span_content)
 
                 elif span_type in [
@@ -905,8 +927,13 @@ def union_make(pdf_info_dict: list,
         page_size = page_info.get('page_size')
         if make_mode in [MakeMode.MM_MD, MakeMode.NLP_MD]:
             if not paras_of_layout:
+                if page_info.get('page_anchor'):
+                    output_content.append(render_page_anchor(page_info['page_anchor']))
                 continue
             page_markdown = mk_blocks_to_markdown(paras_of_layout, make_mode, formula_enable, table_enable, img_buket_path)
+            page_anchor = page_info.get('page_anchor')
+            if page_anchor:
+                page_markdown.insert(0, render_page_anchor(page_anchor))
             output_content.extend(page_markdown)
         elif make_mode == MakeMode.CONTENT_LIST:
             para_blocks = (paras_of_layout or []) + (paras_of_discarded or [])

--- a/mineru/cli/common.py
+++ b/mineru/cli/common.py
@@ -284,6 +284,12 @@ def _process_output(
         make_func = office_union_make
     else:
         raise Exception(f"Unknown process_mode: {process_mode}")
+    if process_mode in {"pipeline", "vlm"}:
+        # PDF link annotations are not part of model middle JSON; merge them
+        # before generating Markdown, content lists, and middle JSON outputs.
+        from mineru.utils.pdf_hyperlink import enrich_pdf_hyperlinks
+
+        enrich_pdf_hyperlinks(pdf_info, pdf_bytes)
     """处理输出文件"""
     if f_draw_layout_bbox:
         try:

--- a/mineru/model/docx/docx_converter.py
+++ b/mineru/model/docx/docx_converter.py
@@ -1,5 +1,6 @@
 # Copyright (c) Opendatalab. All rights reserved.
 import re
+from html import escape
 from io import BytesIO
 from pathlib import Path
 from typing import BinaryIO, Optional, Union, Any, Final, Iterator
@@ -47,6 +48,7 @@ class DocxConverter:
         "w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
         "wp": "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",
         "mc": "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",
         "v": "urn:schemas-microsoft-com:vml",
         "wps": "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",
         "w10": "urn:schemas-microsoft-com:office:word",
@@ -1244,6 +1246,185 @@ class DocxConverter:
             return None
         return f'<p>{"".join(items)}</p>'
 
+    def _resolve_xml_hyperlink_target(self, hyperlink) -> str:
+        relationship_id = hyperlink.get(
+            "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}id"
+        )
+        if relationship_id and self.docx_obj is not None:
+            try:
+                relationship = self.docx_obj.part.rels[relationship_id]
+                target = getattr(relationship, "target_ref", None)
+                if target:
+                    return str(target).strip()
+            except (KeyError, AttributeError):
+                pass
+
+        anchor = hyperlink.get(
+            "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}anchor"
+        )
+        return f"#{anchor.strip()}" if anchor and anchor.strip() else ""
+
+    @staticmethod
+    def _wrap_table_cell_text_with_link(soup, html_cell, label: str, target: str) -> bool:
+        for text_node in html_cell.find_all(string=True):
+            if text_node.find_parent("a") is not None:
+                continue
+            node_text = str(text_node)
+            match_start = node_text.find(label)
+            if match_start < 0:
+                continue
+
+            link = soup.new_tag("a", href=target)
+            link.string = label
+            replacements = []
+            if match_start:
+                replacements.append(node_text[:match_start])
+            replacements.append(link)
+            match_end = match_start + len(label)
+            if match_end < len(node_text):
+                replacements.append(node_text[match_end:])
+            text_node.replace_with(*replacements)
+            return True
+        return False
+
+    def _inject_table_hyperlinks(self, html: str, xml_table) -> str:
+        """Restore DOCX relationships when a table used isolated XML fallback."""
+        hyperlinks = xml_table.findall(
+            ".//w:hyperlink", namespaces=DocxConverter._BLIP_NAMESPACES
+        )
+        if not html or not hyperlinks:
+            return html
+
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(html, "html.parser")
+        html_table = soup.find("table")
+        if html_table is None:
+            return html
+
+        w_ns = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+        html_rows = html_table.find_all("tr")
+        xml_rows = xml_table.findall(f"{{{w_ns}}}tr")
+        if len(html_rows) != len(xml_rows):
+            return html
+
+        for html_row, xml_row in zip(html_rows, xml_rows):
+            html_cells = html_row.find_all(["td", "th"], recursive=False)
+            xml_cells = xml_row.findall(f"{{{w_ns}}}tc")
+            if len(html_cells) != len(xml_cells):
+                continue
+
+            for html_cell, xml_cell in zip(html_cells, xml_cells):
+                for hyperlink in xml_cell.findall(
+                    ".//w:hyperlink", namespaces=DocxConverter._BLIP_NAMESPACES
+                ):
+                    target = self._resolve_xml_hyperlink_target(hyperlink)
+                    if not target:
+                        continue
+                    label = "".join(
+                        node.text or ""
+                        for node in hyperlink.findall(
+                            ".//w:t", namespaces=DocxConverter._BLIP_NAMESPACES
+                        )
+                    )
+                    if not label:
+                        continue
+                    if html_cell.find("a", href=target) is not None:
+                        continue
+                    self._wrap_table_cell_text_with_link(
+                        soup, html_cell, label, target
+                    )
+
+        return str(html_table)
+
+    def _build_xml_paragraph_html(self, xml_paragraph) -> str:
+        """Build a minimal paragraph when Mammoth cannot parse a table."""
+        w_ns = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+        parts = []
+        for child in xml_paragraph:
+            child_name = self._local_name(child)
+            if child_name == "hyperlink":
+                label = "".join(
+                    node.text or "" for node in child.findall(f".//{{{w_ns}}}t")
+                )
+                target = self._resolve_xml_hyperlink_target(child)
+                escaped_label = escape(label, quote=False)
+                if escaped_label and target:
+                    parts.append(
+                        f'<a href="{escape(target, quote=True)}">{escaped_label}</a>'
+                    )
+                elif target:
+                    fallback_label = re.split(r"[\\/]", target.rstrip("\\/"))[-1]
+                    parts.append(
+                        f'<a href="{escape(target, quote=True)}">'
+                        f"{escape(fallback_label or target, quote=False)}</a>"
+                    )
+                elif escaped_label:
+                    parts.append(escaped_label)
+                continue
+
+            if child_name == "r":
+                for run_child in child.iter():
+                    run_child_name = self._local_name(run_child)
+                    if run_child_name == "t" and run_child.text:
+                        parts.append(escape(run_child.text, quote=False))
+                    elif run_child_name == "tab":
+                        parts.append("&emsp;")
+                    elif run_child_name in {"br", "cr"}:
+                        parts.append("<br>")
+                continue
+
+            if child_name in {"oMath", "oMathPara"}:
+                math_nodes = (
+                    [child]
+                    if child_name == "oMath"
+                    else child.findall(
+                        ".//m:oMath", namespaces=DocxConverter._BLIP_NAMESPACES
+                    )
+                )
+                for math_node in math_nodes:
+                    try:
+                        latex = str(oMath2Latex(math_node)).strip()
+                    except Exception as exc:
+                        logger.debug(f"Failed to convert table OMML equation: {exc}")
+                        continue
+                    if latex:
+                        parts.append(self.equation_bookends.format(EQ=latex))
+
+        return f'<p>{"".join(parts)}</p>' if parts else "<p></p>"
+
+    def _build_table_html_from_xml(self, xml_table) -> str:
+        """Fallback table renderer that does not require Mammoth relationships."""
+        w_ns = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+        val_attr = f"{{{w_ns}}}val"
+        html_parts = ["<table>"]
+        for xml_row in xml_table.findall(f"{{{w_ns}}}tr"):
+            html_parts.append("<tr>")
+            for xml_cell in xml_row.findall(f"{{{w_ns}}}tc"):
+                attrs = []
+                grid_span = xml_cell.find(f"{{{w_ns}}}tcPr/{{{w_ns}}}gridSpan")
+                if grid_span is not None:
+                    try:
+                        col_span = int(grid_span.get(val_attr, "1"))
+                    except (TypeError, ValueError):
+                        col_span = 1
+                    if col_span > 1:
+                        attrs.append(f'colspan="{col_span}"')
+
+                cell_parts = []
+                for child in xml_cell:
+                    child_name = self._local_name(child)
+                    if child_name == "p":
+                        cell_parts.append(self._build_xml_paragraph_html(child))
+                    elif child_name == "tbl":
+                        cell_parts.append(self._build_table_html_from_xml(child))
+
+                attr_text = f" {' '.join(attrs)}" if attrs else ""
+                html_parts.append(f"<td{attr_text}>{''.join(cell_parts)}</td>")
+            html_parts.append("</tr>")
+        html_parts.append("</table>")
+        return "".join(html_parts)
+
     def _handle_tables(self, element: BaseOxmlElement):
         """
         处理表格。
@@ -1262,6 +1443,7 @@ class DocxConverter:
             self._mammoth_table_idx += 1
             if html is not None:
                 html = self._normalize_table_colspans(html)
+                html = self._inject_table_hyperlinks(html, element)
                 table_block = {
                     "type": BlockType.TABLE,
                     "content": html,
@@ -1270,11 +1452,16 @@ class DocxConverter:
                 return
 
         # 回退：孤立 XML 解析模式（原始方案，不含文档上下文）
-        table = read_str(element.xml)
-        body_reader = body_xml.reader()
-        t = body_reader.read_all([table])
-        res = convert_document_element_to_html(t.value[0])
-        html = self._normalize_table_colspans(res.value)
+        try:
+            table = read_str(element.xml)
+            body_reader = body_xml.reader()
+            t = body_reader.read_all([table])
+            res = convert_document_element_to_html(t.value[0])
+            html = self._normalize_table_colspans(res.value)
+        except Exception as exc:
+            logger.debug(f"Falling back to native DOCX table rendering: {exc}")
+            html = self._build_table_html_from_xml(element)
+        html = self._inject_table_hyperlinks(html, element)
         table_block = {
             "type": BlockType.TABLE,
             "content": html,

--- a/mineru/model/pptx/pptx_converter.py
+++ b/mineru/model/pptx/pptx_converter.py
@@ -2,6 +2,7 @@
 import base64
 from collections import Counter
 from dataclasses import dataclass
+from html import escape
 from io import BytesIO
 from typing import Any, Final, BinaryIO, Optional
 
@@ -594,6 +595,51 @@ class PptxConverter:
         except Exception:
             return False
 
+    def _build_table_cell_html(self, cell, shape) -> str:
+        """Render table-cell text while preserving run-level hyperlinks."""
+        paragraph_parts = []
+        for paragraph in cell.text_frame.paragraphs:
+            run_map = {}
+            for run in paragraph.runs:
+                try:
+                    run_map[id(run._r)] = run
+                except Exception:
+                    continue
+
+            inline_parts = []
+            for node in paragraph._element.content_children:
+                if isinstance(node, CT_TextLineBreak):
+                    inline_parts.append("<br>")
+                    continue
+
+                if self._is_math_content_node(node):
+                    latex = self._convert_math_node_to_latex(node)
+                    if latex:
+                        inline_parts.append(self.equation_bookends.format(EQ=latex))
+                    continue
+
+                node_text = getattr(node, "text", None)
+                if not node_text:
+                    continue
+
+                rendered_text = escape(str(node_text), quote=False)
+                run = run_map.get(id(node))
+                hyperlink = (
+                    self._resolve_hyperlink_from_run(run, shape)
+                    if run is not None
+                    else None
+                )
+                if hyperlink:
+                    rendered_text = (
+                        f'<a href="{escape(str(hyperlink), quote=True)}">'
+                        f"{rendered_text}</a>"
+                    )
+                inline_parts.append(rendered_text)
+
+            paragraph_parts.append("".join(inline_parts))
+
+        return "<br>".join(paragraph_parts).strip()
+
     def _handle_tables(self, shape):
         """将PowerPoint表格转换为HTML格式。
 
@@ -663,14 +709,8 @@ class PptxConverter:
                 attr_str = " " + " ".join(attrs) if attrs else ""
 
                 # 获取单元格文本内容
-                cell_text = cell.text.strip() if cell.text else ""
+                cell_text = self._build_table_cell_html(cell, shape)
                 # 转义HTML特殊字符，防止XSS
-                cell_text = (
-                    cell_text.replace("&", "&amp;")
-                    .replace("<", "&lt;")
-                    .replace(">", "&gt;")
-                )
-
                 html_parts.append(f"    <{tag}{attr_str}>{cell_text}</{tag}>")
 
             html_parts.append("  </tr>")

--- a/mineru/utils/pdf_hyperlink.py
+++ b/mineru/utils/pdf_hyperlink.py
@@ -1,0 +1,293 @@
+# Copyright (c) Opendatalab. All rights reserved.
+"""Preserve PDF link annotations in MinerU's middle JSON representation."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from io import BytesIO
+from typing import Any
+
+from pypdf import PdfReader
+
+from mineru.utils.enum_class import BlockType, ContentType
+
+
+_PDF_LINK_TYPE = "/Link"
+_URI_ACTION = "/URI"
+_GOTO_ACTION = "/GoTo"
+_PAGE_ANCHOR_PREFIX = "page-"
+
+
+def _as_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        for encoding in ("utf-8", "utf-16", "latin-1"):
+            try:
+                return value.decode(encoding).strip()
+            except UnicodeDecodeError:
+                continue
+        return value.decode("utf-8", errors="replace").strip()
+    return str(value).strip()
+
+
+def _iter_spans(blocks: list[dict] | None) -> Iterator[dict]:
+    for block in blocks or []:
+        for line in block.get("lines", []):
+            line_bbox = line.get("bbox")
+            for span in line.get("spans", []):
+                if line_bbox and not span.get("bbox"):
+                    span["bbox"] = line_bbox
+                yield span
+        yield from _iter_spans(block.get("blocks"))
+
+
+def _page_reference_key(reference: Any) -> tuple[int, int] | None:
+    reference = getattr(reference, "indirect_reference", reference)
+    idnum = getattr(reference, "idnum", None)
+    generation = getattr(reference, "generation", 0)
+    if idnum is None:
+        return None
+    return int(idnum), int(generation)
+
+
+def _build_page_reference_map(reader: PdfReader) -> dict[tuple[int, int], int]:
+    result = {}
+    for index, page in enumerate(reader.pages):
+        key = _page_reference_key(page)
+        if key is not None:
+            result[key] = index
+    return result
+
+
+def _destination_page_index(
+    destination: Any,
+    reader: PdfReader,
+    page_reference_map: dict[tuple[int, int], int],
+) -> int | None:
+    if destination is None:
+        return None
+
+    try:
+        named_destination = reader.named_destinations.get(_as_text(destination))
+    except Exception:
+        named_destination = None
+    if named_destination is not None:
+        try:
+            return reader.get_destination_page_number(named_destination)
+        except Exception:
+            pass
+
+    if isinstance(destination, (list, tuple)) and destination:
+        page_reference = destination[0]
+        if isinstance(page_reference, int):
+            return page_reference if 0 <= page_reference < len(reader.pages) else None
+        return page_reference_map.get(_page_reference_key(page_reference))
+
+    if isinstance(destination, int):
+        return destination if 0 <= destination < len(reader.pages) else None
+
+    return page_reference_map.get(_page_reference_key(destination))
+
+
+def _resolve_link_target(
+    annotation: Any,
+    reader: PdfReader,
+    page_reference_map: dict[tuple[int, int], int],
+) -> tuple[str, int | None]:
+    action = annotation.get("/A")
+    if action is not None:
+        action_type = _as_text(action.get("/S"))
+        if action_type == _URI_ACTION:
+            return _as_text(action.get("/URI")), None
+        if action_type == _GOTO_ACTION:
+            destination = action.get("/D")
+            target_page = _destination_page_index(
+                destination,
+                reader,
+                page_reference_map,
+            )
+            return (
+                f"#{_PAGE_ANCHOR_PREFIX}{target_page + 1}"
+                if target_page is not None
+                else _as_text(destination),
+                target_page,
+            )
+
+    destination = annotation.get("/Dest")
+    target_page = _destination_page_index(
+        destination,
+        reader,
+        page_reference_map,
+    )
+    return (
+        f"#{_PAGE_ANCHOR_PREFIX}{target_page + 1}"
+        if target_page is not None
+        else _as_text(destination),
+        target_page,
+    )
+
+
+def _annotation_bbox(
+    page: Any,
+    rect: Any,
+    output_size: list[float] | tuple[float, float] | None,
+) -> list[float] | None:
+    if not rect or len(rect) < 4:
+        return None
+    try:
+        x0, y0, x1, y1 = (float(rect[index]) for index in range(4))
+        crop_box = page.cropbox
+        crop_left = float(crop_box.left)
+        crop_bottom = float(crop_box.bottom)
+        crop_width = float(crop_box.width)
+        crop_height = float(crop_box.height)
+        x0 -= crop_left
+        x1 -= crop_left
+        y0 -= crop_bottom
+        y1 -= crop_bottom
+        x0, x1 = sorted((x0, x1))
+        y0, y1 = sorted((y0, y1))
+
+        top_y0 = crop_height - y1
+        top_y1 = crop_height - y0
+        rotation = int(page.get("/Rotate", 0) or 0) % 360
+        if rotation == 90:
+            left, top, right, bottom = (
+                crop_height - top_y1,
+                x0,
+                crop_height - top_y0,
+                x1,
+            )
+            display_width, display_height = crop_height, crop_width
+        elif rotation == 180:
+            left, top, right, bottom = (
+                crop_width - x1,
+                crop_height - top_y1,
+                crop_width - x0,
+                crop_height - top_y0,
+            )
+            display_width, display_height = crop_width, crop_height
+        elif rotation == 270:
+            left, top, right, bottom = (
+                top_y0,
+                crop_width - x1,
+                top_y1,
+                crop_width - x0,
+            )
+            display_width, display_height = crop_height, crop_width
+        else:
+            left, top, right, bottom = x0, top_y0, x1, top_y1
+            display_width, display_height = crop_width, crop_height
+
+        if output_size and len(output_size) >= 2:
+            scale_x = float(output_size[0]) / max(display_width, 1.0)
+            scale_y = float(output_size[1]) / max(display_height, 1.0)
+            left, right = left * scale_x, right * scale_x
+            top, bottom = top * scale_y, bottom * scale_y
+        return [left, top, right, bottom]
+    except (TypeError, ValueError, AttributeError):
+        return None
+
+
+def _bbox_intersects(left: list[float], right: list[float]) -> bool:
+    if len(left) < 4 or len(right) < 4:
+        return False
+    intersection_width = min(left[2], right[2]) - max(left[0], right[0])
+    intersection_height = min(left[3], right[3]) - max(left[1], right[1])
+    if intersection_width <= 0 or intersection_height <= 0:
+        return False
+    intersection_area = intersection_width * intersection_height
+    right_area = max(right[2] - right[0], 1) * max(right[3] - right[1], 1)
+    return intersection_area / right_area >= 0.15
+
+
+def _fallback_link_label(target: str) -> str:
+    if target.startswith("#"):
+        return target[1:]
+    return target.rsplit("/", 1)[-1].rsplit("\\", 1)[-1] or target
+
+
+def enrich_pdf_hyperlinks(pdf_info: list[dict], pdf_bytes: bytes) -> None:
+    """Attach PDF annotations to overlapping text spans and page anchors."""
+    if not pdf_info or not pdf_bytes:
+        return
+
+    try:
+        reader = PdfReader(BytesIO(pdf_bytes))
+    except Exception:
+        return
+
+    page_reference_map = _build_page_reference_map(reader)
+    for page_index, page_info in enumerate(pdf_info):
+        if page_index >= len(reader.pages):
+            break
+        annotations = reader.pages[page_index].get("/Annots") or []
+        if not annotations:
+            continue
+
+        output_size = page_info.get("page_size")
+        spans = list(_iter_spans(page_info.get("para_blocks")))
+        spans.extend(_iter_spans(page_info.get("discarded_blocks")))
+        page_links = []
+        for annotation_ref in annotations:
+            annotation = annotation_ref.get_object()
+            if _as_text(annotation.get("/Subtype")) != _PDF_LINK_TYPE:
+                continue
+            target, target_page = _resolve_link_target(
+                annotation,
+                reader,
+                page_reference_map,
+            )
+            if not target or target.lower().startswith(("javascript:", "data:", "vbscript:")):
+                continue
+            bbox = _annotation_bbox(page=reader.pages[page_index], rect=annotation.get("/Rect"), output_size=output_size)
+            if bbox is None:
+                continue
+
+            if target_page is not None and target_page < len(pdf_info):
+                pdf_info[target_page]["page_anchor"] = f"{_PAGE_ANCHOR_PREFIX}{target_page + 1}"
+
+            matched = False
+            for span in spans:
+                span_bbox = span.get("bbox")
+                if not span_bbox or not _bbox_intersects(bbox, span_bbox):
+                    continue
+                if span.get("type") == ContentType.HYPERLINK and span.get("url") == target:
+                    matched = True
+                    continue
+                if span.get("type") != ContentType.TEXT or not str(span.get("content", "")).strip():
+                    continue
+                span["type"] = ContentType.HYPERLINK
+                span["url"] = target
+                matched = True
+
+            if not matched:
+                page_links.append((bbox, target))
+
+        if page_links:
+            blocks = page_info.setdefault("para_blocks", [])
+            next_index = max((block.get("index", -1) for block in blocks), default=-1) + 1
+            for bbox, target in page_links:
+                label = _fallback_link_label(target)
+                blocks.append(
+                    {
+                        "type": BlockType.TEXT,
+                        "index": next_index,
+                        "bbox": bbox,
+                        "lines": [
+                            {
+                                "bbox": bbox,
+                                "spans": [
+                                    {
+                                        "type": ContentType.HYPERLINK,
+                                        "content": label,
+                                        "url": target,
+                                        "bbox": bbox,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                )
+                next_index += 1

--- a/tests/unittest/test_hyperlink_preservation.py
+++ b/tests/unittest/test_hyperlink_preservation.py
@@ -1,0 +1,148 @@
+# Copyright (c) Opendatalab. All rights reserved.
+from io import BytesIO
+
+from docx import Document
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
+from docx.opc.constants import RELATIONSHIP_TYPE
+from pptx import Presentation
+from pptx.util import Inches
+from pypdf import PdfWriter
+from pypdf.annotations import Link
+
+from mineru.backend.pipeline.pipeline_middle_json_mkcontent import union_make
+from mineru.model.docx.docx_converter import DocxConverter
+from mineru.model.pptx.pptx_converter import PptxConverter
+from mineru.utils.enum_class import BlockType, ContentType, MakeMode
+from mineru.utils.pdf_hyperlink import enrich_pdf_hyperlinks
+
+
+def test_pptx_table_preserves_run_hyperlinks() -> None:
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    table = slide.shapes.add_table(
+        1, 1, Inches(1), Inches(1), Inches(4), Inches(1)
+    ).table
+    paragraph = table.cell(0, 0).text_frame.paragraphs[0]
+    run = paragraph.add_run()
+    run.text = "Example & docs"
+    run.hyperlink.address = "https://example.com/docs"
+
+    stream = BytesIO()
+    presentation.save(stream)
+    stream.seek(0)
+    converter = PptxConverter()
+    converter.convert(stream)
+
+    table_html = next(
+        block["content"]
+        for page in converter.pages
+        for block in page
+        if block["type"] == BlockType.TABLE
+    )
+    assert (
+        '<a href="https://example.com/docs">Example &amp; docs</a>'
+        in table_html
+    )
+
+
+def test_docx_native_table_fallback_preserves_hyperlinks() -> None:
+    document = Document()
+    table = document.add_table(rows=1, cols=1)
+    paragraph = table.cell(0, 0).paragraphs[0]
+    relationship_id = document.part.relate_to(
+        "https://example.com/issues",
+        RELATIONSHIP_TYPE.HYPERLINK,
+        is_external=True,
+    )
+    hyperlink = OxmlElement("w:hyperlink")
+    hyperlink.set(qn("r:id"), relationship_id)
+    run = OxmlElement("w:r")
+    text = OxmlElement("w:t")
+    text.text = "Issue tracker"
+    run.append(text)
+    hyperlink.append(run)
+    paragraph._p.append(hyperlink)
+
+    converter = DocxConverter()
+    converter.docx_obj = document
+    table_html = converter._build_table_html_from_xml(table._tbl)
+
+    assert (
+        '<a href="https://example.com/issues">Issue tracker</a>'
+        in table_html
+    )
+
+
+def test_pdf_annotations_are_rendered_as_markdown_links_and_anchors() -> None:
+    writer = PdfWriter()
+    writer.add_blank_page(width=200, height=200)
+    writer.add_blank_page(width=200, height=200)
+    writer.add_annotation(
+        page_number=0,
+        annotation=Link(
+            rect=(10, 150, 90, 170),
+            url="https://example.com/report",
+        ),
+    )
+    writer.add_annotation(
+        page_number=0,
+        annotation=Link(
+            rect=(100, 150, 190, 170),
+            target_page_index=1,
+        ),
+    )
+    stream = BytesIO()
+    writer.write(stream)
+
+    pdf_info = [
+        {
+            "page_idx": 0,
+            "page_size": [200, 200],
+            "para_blocks": [
+                {
+                    "type": BlockType.TEXT,
+                    "index": 0,
+                    "bbox": [10, 30, 190, 50],
+                    "lines": [
+                        {
+                            "bbox": [10, 30, 190, 50],
+                            "spans": [
+                                {
+                                    "type": ContentType.TEXT,
+                                    "content": "External",
+                                    "bbox": [10, 30, 90, 50],
+                                },
+                                {
+                                    "type": ContentType.TEXT,
+                                    "content": "Next page",
+                                    "bbox": [100, 30, 190, 50],
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "discarded_blocks": [],
+        },
+        {
+            "page_idx": 1,
+            "page_size": [200, 200],
+            "para_blocks": [],
+            "discarded_blocks": [],
+        },
+    ]
+
+    enrich_pdf_hyperlinks(pdf_info, stream.getvalue())
+    spans = pdf_info[0]["para_blocks"][0]["lines"][0]["spans"]
+
+    assert spans[0]["type"] == ContentType.HYPERLINK
+    assert spans[0]["url"] == "https://example.com/report"
+    assert spans[1]["type"] == ContentType.HYPERLINK
+    assert spans[1]["url"] == "#page-2"
+    assert pdf_info[1]["page_anchor"] == "page-2"
+
+    markdown = union_make(pdf_info, MakeMode.MM_MD)
+    assert "[External](<https://example.com/report>)" in markdown
+    assert "[Next page](<#page-2>)" in markdown
+    assert '<a id="page-2"></a>' in markdown


### PR DESCRIPTION
## Motivation

Hyperlinks were lost in several parsing paths: PPTX table cells were flattened with `cell.text`, DOCX table fallback conversion lost relationship context (and could drop an entire table containing OLE content), and PDF link annotations were never merged into middle JSON.

## Modification

- Preserve run-level hyperlinks while rendering PPTX table cells.
- Restore DOCX table hyperlink relationships and add a native XML fallback for tables Mammoth cannot convert in isolation.
- Read PDF URI and GoTo annotations, associate them with text spans, and emit internal page anchors.
- Render hyperlink spans in pipeline/VLM Markdown and content-list-v2 outputs.
- Add synthetic PPTX, DOCX, and PDF regression tests without external fixtures.

## BC-breaking

No. Existing plain-text output remains unchanged when documents contain no link annotations.

## Checklist

**Before PR**:

- [x] Bug fixes are fully covered by unit tests.
- [x] The modification is covered by unit tests.
- [x] `git diff --check` passes.

Test: `uv run --with pytest pytest -o addopts='' -q tests/unittest/test_hyperlink_preservation.py` (3 passed).