### PR TITLE
docs(cli): document public HTTP client security boundary

### DIFF
--- a/docs/en/usage/cli_tools.md
+++ b/docs/en/usage/cli_tools.md
@@ -39,12 +39,14 @@ mineru-api --help
 Usage: mineru-api [OPTIONS]
 
 Options:
-  --host TEXT     Server host (default: 127.0.0.1)
-  --port INTEGER  Server port (default: 8000)
-  --reload        Enable auto-reload (development mode)
-  --enable-vlm-preload BOOLEAN
-                  Preload the local VLM model during mineru-api startup.
-  --help          Show this message and exit.
+  --host TEXT                   Server host (default: 127.0.0.1)
+  --port INTEGER                Server port (default: 8000)
+  --reload                      Enable auto-reload (development mode)
+  --allow-public-http-client    Allow *-http-client backends and server_url even
+                                when binding the API to 0.0.0.0 or ::.
+  --enable-vlm-preload BOOLEAN  Preload the local VLM model during mineru-api
+                                startup.
+  --help                        Show this message and exit.
 ```
 ```bash
 mineru-gradio --help
@@ -81,18 +83,31 @@ mineru-router --help
 Usage: mineru-router [OPTIONS]
 
 Options:
-  --host TEXT             Server host (default: 127.0.0.1)
-  --port INTEGER          Server port (default: 8002)
-  --reload                Enable auto-reload (development mode)
-  --upstream-url TEXT     Existing MinerU FastAPI base URL; repeat to add more
-  --local-gpus TEXT       Local GPU workers to launch: auto, none, or CSV such
-                          as 0,1,2
-  --worker-host TEXT      Host for router-managed workers (default: 127.0.0.1)
-  --enable-vlm-preload BOOLEAN
-                          Preload the local VLM model in router-managed
-                          mineru-api workers.
-  --help                  Show this message and exit.
+  --host TEXT                   Server host (default: 127.0.0.1)
+  --port INTEGER                Server port (default: 8002)
+  --reload                      Enable auto-reload (development mode)
+  --allow-public-http-client    Allow *-http-client backends and server_url even
+                                when binding the router to 0.0.0.0 or ::.
+  --upstream-url TEXT           Existing MinerU FastAPI base URL. Repeat to add
+                                multiple upstream servers.
+  --local-gpus TEXT             Local GPU workers to launch: auto, none, or CSV
+                                such as 0,1,2.
+  --worker-host TEXT            Host for router-managed mineru-api workers
+                                (default: 127.0.0.1).
+  --enable-vlm-preload BOOLEAN  Preload the local VLM model in router-managed
+                                mineru-api workers.
+  --help                        Show this message and exit.
 ```
+
+> [!WARNING]
+> When `mineru-api` or `mineru-router` listens on `0.0.0.0` or `::`, requests
+> that select a `*-http-client` backend or supply `server_url` are rejected by
+> default. These inputs let callers choose remote inference endpoints.
+> `--allow-public-http-client` explicitly removes that safeguard, so an
+> untrusted caller could use the service for SSRF or internal network probing.
+> Enable it only when callers are trusted and outbound network access is
+> appropriately restricted. Loopback bindings such as `127.0.0.1` are not
+> affected by this public-bind safeguard.
 
 ## Environment Variables Description
 

--- a/docs/zh/usage/cli_tools.md
+++ b/docs/zh/usage/cli_tools.md
@@ -37,12 +37,13 @@ mineru-api --help
 Usage: mineru-api [OPTIONS]
 
 Options:
-  --host TEXT     服务器主机地址（默认：127.0.0.1）
-  --port INTEGER  服务器端口（默认：8000）
-  --reload        启用自动重载（开发模式）
-  --enable-vlm-preload BOOLEAN
-                  在 mineru-api 启动阶段预加载本地 VLM 模型
-  --help          显示此帮助信息并退出
+  --host TEXT                   服务器主机地址（默认：127.0.0.1）
+  --port INTEGER                服务器端口（默认：8000）
+  --reload                      启用自动重载（开发模式）
+  --allow-public-http-client    即使 API 绑定到 0.0.0.0 或 ::，仍允许使用
+                                *-http-client 后端和 server_url
+  --enable-vlm-preload BOOLEAN  在 mineru-api 启动阶段预加载本地 VLM 模型
+  --help                        显示此帮助信息并退出
 ```
 ```bash
 mineru-gradio --help
@@ -74,17 +75,25 @@ mineru-router --help
 Usage: mineru-router [OPTIONS]
 
 Options:
-  --host TEXT             路由服务主机地址（默认：127.0.0.1）
-  --port INTEGER          路由服务端口（默认：8002）
-  --reload                启用自动重载（开发模式）
-  --upstream-url TEXT     现有 MinerU FastAPI 服务地址；可重复传入多个
-  --local-gpus TEXT       本地 GPU worker 配置：auto、none 或 0,1,2 形式
-  --worker-host TEXT      路由托管 worker 的监听地址（默认：127.0.0.1）
-  --enable-vlm-preload BOOLEAN
-                          在 router 托管的本地 mineru-api worker 中预加载本地
-                          VLM 模型
-  --help                  显示此帮助信息并退出
+  --host TEXT                   路由服务主机地址（默认：127.0.0.1）
+  --port INTEGER                路由服务端口（默认：8002）
+  --reload                      启用自动重载（开发模式）
+  --allow-public-http-client    即使 router 绑定到 0.0.0.0 或 ::，仍允许使用
+                                *-http-client 后端和 server_url
+  --upstream-url TEXT           现有 MinerU FastAPI 服务地址；可重复传入多个
+  --local-gpus TEXT             本地 GPU worker 配置：auto、none 或 0,1,2 形式
+  --worker-host TEXT            路由托管 worker 的监听地址（默认：127.0.0.1）
+  --enable-vlm-preload BOOLEAN  在 router 托管的本地 mineru-api worker 中预加载
+                                本地 VLM 模型
+  --help                        显示此帮助信息并退出
 ```
+
+> [!WARNING]
+> 当 `mineru-api` 或 `mineru-router` 监听 `0.0.0.0` 或 `::` 时，默认拒绝选择
+> `*-http-client` 后端或提供 `server_url` 的请求，因为这些输入允许调用方指定
+> 远程推理端点。`--allow-public-http-client` 会显式移除此保护，未受信任的调用方
+> 可能借此实施 SSRF 或探测内网。仅应在调用方可信且已合理限制出站网络访问时
+> 启用该参数。此公开绑定保护不影响 `127.0.0.1` 等回环地址。
 
 ## 环境变量说明
 


### PR DESCRIPTION
## Motivation

`mineru-api` and `mineru-router` expose `--allow-public-http-client`, but the
stable English and Chinese CLI help snapshots do not list it. The docs also do
not explain why public binds reject caller-selected HTTP inference endpoints by
default or what changes when the safeguard is explicitly disabled.

## Modification

- Sync the `mineru-api` and `mineru-router` help snapshots with the Click
  options, including `--allow-public-http-client`.
- Document the existing public-bind behavior for `0.0.0.0` and `::`.
- Explain the SSRF/internal-network-probing boundary and recommend trusted
  callers plus restricted outbound network access when enabling the option.
- Keep the English and Chinese CLI documentation aligned.

## BC-breaking (Optional)

No. This PR changes documentation only and describes behavior already enforced
by the CLI and request validation code.

## Use cases (Optional)

Operators exposing MinerU services can distinguish the safe default from the
explicit opt-in and apply appropriate caller trust and egress controls.

## Verification

- English `mineru-api` and `mineru-router` snapshots match Click output at an
  80-column terminal width.
- Bilingual assertions cover the default rejection, explicit opt-in,
  SSRF/internal-network-probing risk, egress guidance, and loopback exception.
- `git diff --check`
- `uvx --from mkdocs --with mkdocs-material --with mkdocs-static-i18n --with mkdocs-video --with markdown-gfm-admonition mkdocs build --site-dir /tmp/mineru-docs-pr-site`

The MkDocs build succeeds for both locales. Strict mode also parses both
changed pages but remains blocked by four pre-existing broken-link warnings in
unrelated changelog/plugin pages.

## Checklist

**Before PR**:

- [x] Documentation checks are used to catch formatting and snapshot drift.
- [x] This is a documentation-only change; no runtime behavior is modified.
- [x] The modification is covered by Click snapshot and bilingual boundary
      assertions.
- [x] The English and Chinese documentation has been updated together.

**After PR**:

- [x] No downstream behavior changes are introduced.
- [x] All committers use the existing signed CLA identity.
