### PR TITLE
docs: fix broken example image paths in output_files docs

### DIFF
--- a/docs/en/reference/output_files.md
+++ b/docs/en/reference/output_files.md
@@ -30,7 +30,7 @@ The following sections provide detailed descriptions of each file's purpose and 
 - Verify if reading order is reasonable
 - Debug layout-related issues
 
-![layout page example](../images/layout_example.png)
+![layout page example](../../images/layout_example.png)
 
 ### Text Spans File (span.pdf)
 
@@ -50,7 +50,7 @@ The following sections provide detailed descriptions of each file's purpose and 
 - Check inline formula recognition
 - Verify text segmentation accuracy
 
-![span page example](../images/spans_example.png)
+![span page example](../../images/spans_example.png)
 
 ## Structured Data Files
 

--- a/docs/zh/reference/output_files.md
+++ b/docs/zh/reference/output_files.md
@@ -30,7 +30,7 @@
 - 确认阅读顺序是否合理
 - 调试布局相关问题
 
-![layout 页面示例](../images/layout_example.png)
+![layout 页面示例](../../images/layout_example.png)
 
 ### 文本片段文件 (span.pdf)
 
@@ -50,7 +50,7 @@
 - 检查行内公式识别情况
 - 验证文本分割准确性
 
-![span 页面示例](../images/spans_example.png)
+![span 页面示例](../../images/spans_example.png)
 
 ## 结构化数据文件
 


### PR DESCRIPTION
The layout/span example images in `docs/en/reference/output_files.md` and `docs/zh/reference/output_files.md` are referenced as `../images/layout_example.png` and `../images/spans_example.png`, which resolve to `docs/en/images/` and `docs/zh/images/` - directories that do not exist. The images live in the shared `docs/images/` directory, so the correct relative path is `../../images/...`. The rendered docs currently show broken images.