### PR TITLE
security: parse untrusted OOXML with defusedxml (entity-expansion DoS)

### DIFF
--- a/mineru/model/docx/tools/office_xml.py
+++ b/mineru/model/docx/tools/office_xml.py
@@ -1,6 +1,7 @@
 # Copyright (c) Opendatalab. All rights reserved.
 import xml.dom.minidom
 
+from defusedxml.minidom import parseString as _defused_parseString
 from mammoth.docx.xmlparser import XmlText, XmlElement
 from mammoth.docx.office_xml import _collapse_alternate_content, _namespaces
 
@@ -11,7 +12,7 @@ def parse_xml_str(xml_str, namespace_mapping=None):
     else:
         namespace_prefixes = dict((uri, prefix) for prefix, uri in namespace_mapping)
 
-    document = xml.dom.minidom.parseString(xml_str)
+    document = _defused_parseString(xml_str)
 
     def convert_node(node):
         if node.nodeType == xml.dom.Node.ELEMENT_NODE:

--- a/mineru/model/xlsx/package_normalizer.py
+++ b/mineru/model/xlsx/package_normalizer.py
@@ -4,6 +4,9 @@ import re
 from zipfile import BadZipFile, ZIP_DEFLATED, ZipFile, ZipInfo
 import xml.etree.ElementTree as ET
 
+from defusedxml.ElementTree import fromstring as _defused_fromstring
+from defusedxml.common import DefusedXmlException
+
 SPREADSHEETML_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
 SHARED_STRINGS_PATH = "xl/sharedStrings.xml"
 STYLES_PATH = "xl/styles.xml"
@@ -71,8 +74,8 @@ def _normalize_xlsx_member(member_name: str, member_data: bytes) -> bytes:
 def _normalize_shared_strings_xml(xml_bytes: bytes) -> bytes:
     """规范化共享字符串 XML 中 openpyxl 无法接受的富文本属性。"""
     try:
-        root = ET.fromstring(xml_bytes)
-    except ET.ParseError:
+        root = _defused_fromstring(xml_bytes)
+    except (ET.ParseError, DefusedXmlException):
         return xml_bytes
 
     changed = False
@@ -89,8 +92,8 @@ def _normalize_shared_strings_xml(xml_bytes: bytes) -> bytes:
 def _normalize_styles_xml(xml_bytes: bytes) -> bytes:
     """规范化 styles.xml 中 openpyxl 无法接受的空 fill 节点。"""
     try:
-        root = ET.fromstring(xml_bytes)
-    except ET.ParseError:
+        root = _defused_fromstring(xml_bytes)
+    except (ET.ParseError, DefusedXmlException):
         return xml_bytes
 
     changed = False
@@ -109,8 +112,8 @@ def _normalize_styles_xml(xml_bytes: bytes) -> bytes:
 def _normalize_worksheet_xml(xml_bytes: bytes) -> bytes:
     """规范化 worksheet XML 中会阻断 openpyxl 加载的行范围筛选器。"""
     try:
-        root = ET.fromstring(xml_bytes)
-    except ET.ParseError:
+        root = _defused_fromstring(xml_bytes)
+    except (ET.ParseError, DefusedXmlException):
         return xml_bytes
 
     changed = False

--- a/mineru/model/xlsx/xlsx_converter.py
+++ b/mineru/model/xlsx/xlsx_converter.py
@@ -5,6 +5,7 @@ import posixpath
 import zipfile
 import re
 import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import parse as _defused_parse
 from io import BytesIO
 from urllib.parse import urlparse
 from typing import BinaryIO, Annotated, cast
@@ -397,7 +398,7 @@ class XlsxConverter:
 
         try:
             with self.zf.open(path) as f:
-                tree = ET.parse(f)
+                tree = _defused_parse(f)
                 root = tree.getroot()
 
             # Namespaces
@@ -1387,7 +1388,7 @@ class XlsxConverter:
 
         try:
             with self.zf.open(cellimages_path) as f:
-                root = ET.parse(f).getroot()
+                root = _defused_parse(f).getroot()
 
             ns = {
                 "xdr": "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing",
@@ -1408,7 +1409,7 @@ class XlsxConverter:
                     cell_image_embed_to_name[embed_id] = image_name
 
             with self.zf.open(rels_path) as f:
-                rel_root = ET.parse(f).getroot()
+                rel_root = _defused_parse(f).getroot()
 
             rel_ns = {
                 "pr": "http://schemas.openxmlformats.org/package/2006/relationships"

--- a/mineru/utils/guess_suffix_or_lang.py
+++ b/mineru/utils/guess_suffix_or_lang.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from zipfile import BadZipFile, ZipFile
 from xml.etree import ElementTree
 
+from defusedxml.ElementTree import fromstring as _defused_fromstring
+
 from loguru import logger
 from magika import Magika
 
@@ -128,8 +130,8 @@ def _ooxml_content_type_overrides(root: ElementTree.Element) -> dict[str, str]:
 
 def _guess_ooxml_suffix_from_zip(package: ZipFile) -> str | None:
     """根据 OOXML 包内标准主文档关系和主内容类型判断 Office 子类型。"""
-    rels_root = ElementTree.fromstring(package.read(OOXML_ROOT_RELS))
-    content_types_root = ElementTree.fromstring(package.read(OOXML_CONTENT_TYPES))
+    rels_root = _defused_fromstring(package.read(OOXML_ROOT_RELS))
+    content_types_root = _defused_fromstring(package.read(OOXML_CONTENT_TYPES))
 
     overrides = _ooxml_content_type_overrides(content_types_root)
     for target in _ooxml_relationship_targets(rels_root):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "openai>=1.70.0,<3",
     "beautifulsoup4>=4.13.5,<5",
     "magika>=0.6.2,<1.1.0",
+    "defusedxml>=0.7.1",
     "mineru-vl-utils>=1.0.5,<2",
     "python-docx>=1.2.0,<2",
     'pypptx-with-oxml>=1.0.3,<2',


### PR DESCRIPTION
## Summary

MinerU parses untrusted Office Open XML (DOCX / XLSX / PPTX) and their ZIP relationship parts with Python's standard-library XML parsers in their default, DTD-expanding configuration. A document carrying a nested internal-entity DTD (a "billion laughs" construction) causes exponential in-memory expansion, exhausting CPU and memory and taking the worker down.

The parse happens during **type detection, before any file-type allow-check**, so any ZIP whose `_rels/.rels` member carries the DTD triggers it — the upload need not even be a supported type. A client that can submit a document to a MinerU deployment (most directly the bundled HTTP API server) can hang or crash the worker with a sub-kilobyte payload, unauthenticated.

This is resource-exhaustion only (CWE-776 / CWE-400): the stdlib parsers do not resolve *external* entities by default, so there is no XXE file-read / SSRF here — no code execution, no file disclosure.

## Fix

Route the untrusted-document XML parses through [`defusedxml`](https://pypi.org/project/defusedxml/), a drop-in that rejects DTD/entity expansion:

| File | Callsite |
|------|----------|
| `mineru/utils/guess_suffix_or_lang.py` | OOXML rels + content-types `fromstring` (runs on every upload, before the suffix allow-check) |
| `mineru/model/xlsx/package_normalizer.py` | shared-strings / styles / worksheet `fromstring` |
| `mineru/model/xlsx/xlsx_converter.py` | drawing / cellimage / rels `ET.parse` |
| `mineru/model/docx/tools/office_xml.py` | `minidom.parseString` |

`defusedxml` raises `DefusedXmlException` (a `ValueError` subclass) on such input. The `guess_suffix_or_lang` and `xlsx_converter` guards already catch `ValueError` / `Exception`, so a rejected part degrades exactly as a malformed one does today; `package_normalizer`'s `except ET.ParseError` guards are broadened to also catch `DefusedXmlException`. `defusedxml` is added to `dependencies`.

No behavior change for well-formed documents — `defusedxml`'s parse functions share the stdlib signatures and return the same trees.

## Reproduction

Withheld here per coordinated disclosure. The construction is a standard nested internal-entity DTD placed in the ZIP's `_rels/.rels` member; no external entities or network are involved. A working reproduction is available to maintainers on request.

## Disclosure

Reported privately via GitHub advisory **GHSA-6hc3-9j36-wrvf** (2026-06-26). Opening this patch publicly since it is a straightforward hardening change that does not itself reveal an exploit.

Credit: Aeon (https://github.com/aeonfun/aeon).
