### PR TITLE
fix: normalize common unit misrecognitions in table OCR rec (cmH2O, bpm)

### DIFF
--- a/mineru/backend/pipeline/batch_analyze.py
+++ b/mineru/backend/pipeline/batch_analyze.py
@@ -46,6 +46,9 @@ TABLE_OCR_REC_SINGLE_CHAR_REPLACEMENTS = {
 TABLE_OCR_REC_REGEX_REPLACEMENTS = (
     # 仅规范化完整的“单个数字 + 號”，避免影响“10號”“第6號”等普通文本。
     (re.compile(r"^([0-9])號$"), r"\1"),
+    # 表格 OCR 常见单位误识别：数字/字母混淆、单位内部多余空格
+    (re.compile(r"cmH20"), "cmH2O"),
+    (re.compile(r"bp m"), "bpm"),
 )
 
 
@@ -310,9 +313,8 @@ class BatchAnalyze:
         if text in TABLE_OCR_REC_SINGLE_CHAR_REPLACEMENTS:
             return TABLE_OCR_REC_SINGLE_CHAR_REPLACEMENTS[text]
         for pattern, replacement in TABLE_OCR_REC_REGEX_REPLACEMENTS:
-            match = pattern.fullmatch(text)
-            if match:
-                return match.expand(replacement)
+            if pattern.search(text):
+                return pattern.sub(replacement, text)
         return text
 
     @classmethod

--- a/tests/unittest/test_table_ocr_rec_normalization.py
+++ b/tests/unittest/test_table_ocr_rec_normalization.py
@@ -2,7 +2,7 @@
 from mineru.backend.pipeline.batch_analyze import BatchAnalyze
 
 
-def test_normalize_table_ocr_rec_unit_corrections():
+def test_normalize_table_ocr_rec_unit_corrections() -> None:
     normalize = BatchAnalyze._normalize_table_ocr_rec_text
     # 数字/字母混淆：cmH2O 被识别为 cmH20
     assert normalize("4~30cmH20") == "4~30cmH2O"
@@ -10,13 +10,13 @@ def test_normalize_table_ocr_rec_unit_corrections():
     assert normalize("30 ~ 300 bp m") == "30 ~ 300 bpm"
 
 
-def test_normalize_table_ocr_rec_keeps_legacy_rules():
+def test_normalize_table_ocr_rec_keeps_legacy_rules() -> None:
     normalize = BatchAnalyze._normalize_table_ocr_rec_text
     assert normalize("香") == "否"
     assert normalize("3號") == "3"
 
 
-def test_normalize_table_ocr_rec_untouched_text():
+def test_normalize_table_ocr_rec_untouched_text() -> None:
     normalize = BatchAnalyze._normalize_table_ocr_rec_text
     assert normalize("10號") == "10號"
     assert normalize("30 ~ 300 bpm") == "30 ~ 300 bpm"

--- a/tests/unittest/test_table_ocr_rec_normalization.py
+++ b/tests/unittest/test_table_ocr_rec_normalization.py
@@ -1,0 +1,23 @@
+# Copyright (c) Opendatalab. All rights reserved.
+from mineru.backend.pipeline.batch_analyze import BatchAnalyze
+
+
+def test_normalize_table_ocr_rec_unit_corrections():
+    normalize = BatchAnalyze._normalize_table_ocr_rec_text
+    # 数字/字母混淆：cmH2O 被识别为 cmH20
+    assert normalize("4~30cmH20") == "4~30cmH2O"
+    # 单位内部多余空格：bpm 被识别为 bp m
+    assert normalize("30 ~ 300 bp m") == "30 ~ 300 bpm"
+
+
+def test_normalize_table_ocr_rec_keeps_legacy_rules():
+    normalize = BatchAnalyze._normalize_table_ocr_rec_text
+    assert normalize("香") == "否"
+    assert normalize("3號") == "3"
+
+
+def test_normalize_table_ocr_rec_untouched_text():
+    normalize = BatchAnalyze._normalize_table_ocr_rec_text
+    assert normalize("10號") == "10號"
+    assert normalize("30 ~ 300 bpm") == "30 ~ 300 bpm"
+    assert normalize("cmH2O") == "cmH2O"


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.

### Summary

Fixes #5407.

Table OCR rec corrupts unit strings in tables of text-layer PDFs. This PR extends the existing `TABLE_OCR_REC_REGEX_REPLACEMENTS` normalization (already used for `香 → 否` and `3號 → 3`) with two common unit misrecognitions, and switches the matching from `fullmatch` to `search + sub` so rules can apply to composite cell text (e.g. `4~30cmH20`) while keeping the anchored legacy rules unchanged.

### Changes

- `mineru/backend/pipeline/batch_analyze.py`
  - Add `cmH20 → cmH2O` and `bp m → bpm` to `TABLE_OCR_REC_REGEX_REPLACEMENTS`.
  - Normalize with `pattern.search`/`pattern.sub` instead of `fullmatch`/`expand`.
- `tests/unittest/test_table_ocr_rec_normalization.py` (new)
  - Covers the two new corrections, regression of legacy rules, and untouched normal text.

### Verification

- MinerU 3.4.5, Windows, Python 3.12, `-b pipeline -m auto`, device: CPU.
- Before the fix, raw rec outputs were `4~30cmH20` and `30 ~ 300 bp m`; after the fix the parsed Markdown contains `4~30cmH2O` and `30 ~ 300 bpm`.
- Diff of before/after parsing shows changes only in the affected table cells.

Closes #5407