### PR TITLE
fix(docx): preserve custom Word numbering labels

### DIFF
--- a/mineru/model/docx/docx_converter.py
+++ b/mineru/model/docx/docx_converter.py
@@ -2246,6 +2246,160 @@ class DocxConverter:
 
         return current_number
 
+    @staticmethod
+    def _format_roman_number(value: int) -> str:
+        """Format a positive integer as an uppercase Roman numeral."""
+        if value <= 0:
+            return str(value)
+
+        numerals = (
+            (1000, "M"),
+            (900, "CM"),
+            (500, "D"),
+            (400, "CD"),
+            (100, "C"),
+            (90, "XC"),
+            (50, "L"),
+            (40, "XL"),
+            (10, "X"),
+            (9, "IX"),
+            (5, "V"),
+            (4, "IV"),
+            (1, "I"),
+        )
+        remaining = value
+        parts = []
+        for number, symbol in numerals:
+            count, remaining = divmod(remaining, number)
+            parts.append(symbol * count)
+        return "".join(parts)
+
+    @staticmethod
+    def _format_letter_number(value: int) -> str:
+        """Format a positive integer using Word's A..Z, AA..ZZ sequence."""
+        if value <= 0:
+            return str(value)
+
+        parts = []
+        remaining = value
+        while remaining:
+            remaining, offset = divmod(remaining - 1, 26)
+            parts.append(chr(ord("A") + offset))
+        return "".join(reversed(parts))
+
+    @staticmethod
+    def _format_chinese_counting_number(value: int) -> str:
+        """Format the common Chinese counting forms used by Word numbering."""
+        if value < 0:
+            return str(value)
+        if value == 0:
+            return "零"
+
+        digits = "零一二三四五六七八九"
+        small_units = ("", "十", "百", "千")
+        large_units = ("", "万", "亿", "兆")
+
+        def format_group(group: int) -> str:
+            result = []
+            pending_zero = False
+            for position in range(3, -1, -1):
+                divisor = 10**position
+                digit = group // divisor
+                group %= divisor
+                if digit:
+                    if pending_zero and result:
+                        result.append("零")
+                    result.append(digits[digit])
+                    result.append(small_units[position])
+                    pending_zero = False
+                elif result and group:
+                    pending_zero = True
+            return "".join(result)
+
+        groups = []
+        remaining = value
+        while remaining:
+            groups.append(remaining % 10000)
+            remaining //= 10000
+
+        result = []
+        pending_zero = False
+        for group_index in range(len(groups) - 1, -1, -1):
+            group = groups[group_index]
+            if not group:
+                if result:
+                    pending_zero = True
+                continue
+            if result and (pending_zero or group < 1000):
+                result.append("零")
+            result.append(format_group(group))
+            result.append(large_units[group_index])
+            pending_zero = False
+
+        formatted = "".join(result)
+        if formatted.startswith("一十"):
+            formatted = formatted[1:]
+        return formatted
+
+    @classmethod
+    def _format_numbering_value(cls, value: int, num_fmt: str) -> str:
+        """Render a Word numbering counter using its w:numFmt value."""
+        if num_fmt == "decimalZero":
+            return f"{value:02d}"
+        if num_fmt == "upperRoman":
+            return cls._format_roman_number(value)
+        if num_fmt == "lowerRoman":
+            return cls._format_roman_number(value).lower()
+        if num_fmt == "upperLetter":
+            return cls._format_letter_number(value)
+        if num_fmt == "lowerLetter":
+            return cls._format_letter_number(value).lower()
+        if num_fmt in {"chineseCounting", "chineseCountingThousand"}:
+            return cls._format_chinese_counting_number(value)
+        return str(value)
+
+    def _get_numbering_level_format(self, numId: int, ilvl: int) -> Optional[str]:
+        lvl_element = self._get_numbering_level_definition(numId, ilvl)
+        if lvl_element is None:
+            return None
+        namespaces = {"w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main"}
+        num_fmt_element = lvl_element.find("w:numFmt", namespaces=namespaces)
+        if num_fmt_element is None:
+            return None
+        return num_fmt_element.get(self.XML_KEY)
+
+    def _get_numbering_level_text(self, numId: int, ilvl: int) -> Optional[str]:
+        lvl_element = self._get_numbering_level_definition(numId, ilvl)
+        if lvl_element is None:
+            return None
+        namespaces = {"w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main"}
+        lvl_text_element = lvl_element.find("w:lvlText", namespaces=namespaces)
+        if lvl_text_element is None:
+            return None
+        return lvl_text_element.get(self.XML_KEY)
+
+    def _render_numbering_label(self, numId: int, ilvl: int) -> Optional[str]:
+        """Resolve w:lvlText placeholders against the active list counters."""
+        lvl_text = self._get_numbering_level_text(numId, ilvl)
+        if not lvl_text or not re.search(r"%[1-9]", lvl_text):
+            return None
+
+        def replace_placeholder(match: re.Match) -> str:
+            referenced_ilvl = int(match.group(1)) - 1
+            counter = self.list_counters.get((numId, referenced_ilvl))
+            if counter is None:
+                counter = self._get_numbering_level_start(numId, referenced_ilvl)
+            num_fmt = self._get_numbering_level_format(numId, referenced_ilvl) or "decimal"
+            return self._format_numbering_value(counter, num_fmt)
+
+        return re.sub(r"%([1-9])", replace_placeholder, lvl_text)
+
+    def _uses_markdown_ordered_marker(self, numId: int, ilvl: int) -> bool:
+        """Return whether Markdown's N. marker preserves the Word label."""
+        return (
+            self._get_numbering_level_format(numId, ilvl) == "decimal"
+            and self._get_numbering_level_text(numId, ilvl) == f"%{ilvl + 1}."
+        )
     def _is_numbered_list(self, numId: int, ilvl: int) -> bool:
         """
         根据 numFmt 值检查列表是否为编号列表。
@@ -2279,6 +2433,8 @@ class DocxConverter:
                 "lowerLetter",
                 "upperLetter",
                 "decimalZero",
+                "chineseCounting",
+                "chineseCountingThousand",
             }
 
             return num_fmt in numbered_formats
@@ -2334,9 +2490,18 @@ class DocxConverter:
         if content_text == "":
             return None
 
-        # 确定列表属性
-        list_attribute = "ordered" if is_numbered else "unordered"
+        # Markdown can only express decimal N. markers. Render other
+        # w:lvlText templates into the item text so their labels are preserved.
         list_start = self._advance_list_counter(numid, ilevel) if is_numbered else None
+        numbering_label = self._render_numbering_label(numid, ilevel) if is_numbered else None
+        use_markdown_marker = is_numbered and (
+            numbering_label is None or self._uses_markdown_ordered_marker(numid, ilevel)
+        )
+        if numbering_label and not use_markdown_marker:
+            content_text = f"{numbering_label} {content_text}"
+        list_attribute = "ordered" if use_markdown_marker else "unordered"
+        if not use_markdown_marker:
+            list_start = None
 
         # 情况 1: 不存在上一个列表ID，或遇到了不同 numId 的新列表，创建新的顶层列表
         if self.pre_num_id == -1 or self.pre_num_id != numid:

--- a/tests/unittest/test_docx_numbering.py
+++ b/tests/unittest/test_docx_numbering.py
@@ -1,0 +1,163 @@
+from io import BytesIO
+from typing import Any
+
+import pytest
+from docx import Document
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
+
+from mineru.backend.office.office_magic_model import parse_list_block
+from mineru.model.docx.docx_converter import DocxConverter
+from mineru.render.office.output import _flatten_list_items
+from mineru.types import BlockType
+
+
+def _append_numbering_level(
+    abstract_num: Any,
+    *,
+    ilvl: int,
+    start: int,
+    num_fmt: str,
+    lvl_text: str,
+) -> None:
+    level = OxmlElement("w:lvl")
+    level.set(qn("w:ilvl"), str(ilvl))
+
+    start_element = OxmlElement("w:start")
+    start_element.set(qn("w:val"), str(start))
+    level.append(start_element)
+
+    format_element = OxmlElement("w:numFmt")
+    format_element.set(qn("w:val"), num_fmt)
+    level.append(format_element)
+
+    text_element = OxmlElement("w:lvlText")
+    text_element.set(qn("w:val"), lvl_text)
+    level.append(text_element)
+    abstract_num.append(level)
+
+
+def _build_numbered_docx(
+    levels: list[dict[str, int | str]], paragraphs: list[tuple[int, str]]
+) -> BytesIO:
+    document = Document()
+    numbering = document.part.numbering_part.element
+
+    abstract_num = OxmlElement("w:abstractNum")
+    abstract_num.set(qn("w:abstractNumId"), "42")
+    for level in levels:
+        _append_numbering_level(abstract_num, **level)
+    numbering.append(abstract_num)
+
+    num = OxmlElement("w:num")
+    num.set(qn("w:numId"), "42")
+    abstract_num_id = OxmlElement("w:abstractNumId")
+    abstract_num_id.set(qn("w:val"), "42")
+    num.append(abstract_num_id)
+    numbering.append(num)
+
+    for ilvl, text in paragraphs:
+        paragraph = document.add_paragraph(text)
+        num_pr = OxmlElement("w:numPr")
+        ilvl_element = OxmlElement("w:ilvl")
+        ilvl_element.set(qn("w:val"), str(ilvl))
+        num_id_element = OxmlElement("w:numId")
+        num_id_element.set(qn("w:val"), "42")
+        num_pr.extend((ilvl_element, num_id_element))
+        paragraph._p.get_or_add_pPr().append(num_pr)
+
+    stream = BytesIO()
+    document.save(stream)
+    stream.seek(0)
+    return stream
+
+
+def _collect_list_text(blocks: list[dict[str, Any]]) -> list[str]:
+    result = []
+    for block in blocks:
+        if block.get("type") == BlockType.TEXT:
+            result.append(block["content"])
+            continue
+        result.extend(_collect_list_text(block.get("content", [])))
+    return result
+
+
+@pytest.mark.parametrize(
+    ("value", "num_fmt", "expected"),
+    [
+        (36, "chineseCounting", "三十六"),
+        (101, "chineseCountingThousand", "一百零一"),
+        (27, "upperLetter", "AA"),
+        (28, "lowerLetter", "ab"),
+        (36, "upperRoman", "XXXVI"),
+        (9, "decimalZero", "09"),
+    ],
+)
+def test_format_numbering_value(value: int, num_fmt: str, expected: str) -> None:
+    assert DocxConverter._format_numbering_value(value, num_fmt) == expected
+
+
+def test_custom_chinese_multilevel_labels_are_preserved() -> None:
+    stream = _build_numbered_docx(
+        levels=[
+            {
+                "ilvl": 0,
+                "start": 36,
+                "num_fmt": "chineseCountingThousand",
+                "lvl_text": "第%1条",
+            },
+            {
+                "ilvl": 1,
+                "start": 1,
+                "num_fmt": "chineseCounting",
+                "lvl_text": "（%2）",
+            },
+        ],
+        paragraphs=[
+            (0, "本制度由行政部负责解释。"),
+            (1, "例行检查"),
+            (1, "专项检查"),
+            (0, "本制度自发布之日起施行。"),
+        ],
+    )
+
+    converter = DocxConverter()
+    converter.convert(stream)
+
+    assert _collect_list_text(converter.pages[0]) == [
+        "第三十六条 本制度由行政部负责解释。",
+        "（一） 例行检查",
+        "（二） 专项检查",
+        "第三十七条 本制度自发布之日起施行。",
+    ]
+
+    list_block = parse_list_block(converter.pages[0][0])
+    assert list_block is not None
+    assert _flatten_list_items(list_block) == [
+        "- 第三十六条 本制度由行政部负责解释。",
+        "    - （一） 例行检查",
+        "    - （二） 专项检查",
+        "- 第三十七条 本制度自发布之日起施行。",
+    ]
+
+
+def test_plain_decimal_list_keeps_markdown_ordering() -> None:
+    stream = _build_numbered_docx(
+        levels=[
+            {
+                "ilvl": 0,
+                "start": 3,
+                "num_fmt": "decimal",
+                "lvl_text": "%1.",
+            }
+        ],
+        paragraphs=[(0, "First"), (0, "Second")],
+    )
+
+    converter = DocxConverter()
+    converter.convert(stream)
+
+    list_block = converter.pages[0][0]
+    assert list_block["attribute"] == "ordered"
+    assert list_block["start"] == 3
+    assert [item["content"] for item in list_block["content"]] == ["First", "Second"]


### PR DESCRIPTION
## Motivation

Fixes #5356.

DOCX lists can define visible labels through `w:lvlText`, including templates such as `第%1条` and `（%2）`. The converter previously classified the list from `w:numFmt` but did not render those templates, so custom and multilevel numbering disappeared from the Markdown output.

## Modification

- Read `w:lvlText` and the referenced level's `w:numFmt` from `numbering.xml`.
- Render decimal-zero, Roman, alphabetic, and Chinese counting values for list placeholders.
- Preserve standard `%N.` decimal lists as native Markdown ordered lists.
- Emit custom Word labels in the item text and use an unordered Markdown container to avoid duplicate numbering.
- Add synthetic regression tests for Chinese multilevel labels, number formatting, and standard decimal-list compatibility.

## BC-breaking (Optional)

No. Standard decimal ordered-list output is preserved. The change restores labels that were previously lost for custom numbering formats.

## Use cases (Optional)

Converting policy and administrative DOCX files that use labels such as `第三十六条`, `（一）`, Roman numerals, letters, or zero-padded numbering.

## Validation

- `11 passed in 1.77s` for `test_docx_numbering.py` and `test_office_parser_regressions.py`
- Ruff passed for the modified source and new test (`ANN`, `E501`, and `F841` excluded because they are existing repository findings)
- `git diff --check` passed

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug is added in the unit tests.
- [x] The modification is covered by relevant unit tests.
- [x] No documentation change is required because this restores existing DOCX conversion behavior without changing the public interface.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
