### PR TITLE
docs: add OrcaRouter example for llm-aided-config

### DIFF
--- a/docs/en/usage/quick_usage.md
+++ b/docs/en/usage/quick_usage.md
@@ -151,6 +151,16 @@ Here are some available configuration options:
              "enable": false
           }
           ```
+    * You can also use any OpenAI-compatible gateway that speaks the `openai protocol`, such as [OrcaRouter](https://www.orcarouter.ai). Point `base_url` at the gateway and use one of its model identifiers as `model`, for example:
+          ```json
+          "llm-aided-config": {
+             "api_key": "your_api_key",
+             "base_url": "https://api.orcarouter.ai/v1",
+             "model": "orcarouter/auto",
+             "enable_thinking": false,
+             "enable": false
+          }
+          ```
   
 - `models-dir`: 
     * Used to specify local model storage directory

--- a/docs/zh/usage/quick_usage.md
+++ b/docs/zh/usage/quick_usage.md
@@ -151,6 +151,16 @@ MinerU 现已实现开箱即用，但也支持通过配置文件扩展功能。�
              "enable": false
           }
           ```
+    * 您也可以使用任何支持`openai协议`的网关，例如[OrcaRouter](https://www.orcarouter.ai)。将`base_url`指向网关地址，并在`model`中使用其模型标识，例如：
+          ```json
+          "llm-aided-config": {
+             "api_key": "your_api_key",
+             "base_url": "https://api.orcarouter.ai/v1",
+             "model": "orcarouter/auto",
+             "enable_thinking": false,
+             "enable": false
+          }
+          ```
   
 - `models-dir`：
     * 用于指定本地模型存储目录，请为`pipeline`和`vlm`后端分别指定模型目录，


### PR DESCRIPTION
## Motivation

MinerU's `llm-aided-config` powers LLM-assisted title hierarchy, and it already speaks the `openai protocol` with a configurable `base_url`, so any OpenAI-compatible gateway works out of the box. The docs currently only show Alibaba Cloud Bailian (DashScope) as the example, so users who prefer a gateway that routes across many models at a single endpoint have to guess at the `base_url`/`model` values.

This PR documents [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible AI gateway, as a first-class example next to the existing DashScope snippet — mirroring the exact JSON shape the config already consumes.

## Modification

- `docs/en/usage/quick_usage.md`: add an OrcaRouter example under `llm-aided-config`, using `base_url: https://api.orcarouter.ai/v1` and the `orcarouter/auto` routing model, in the same format as the DashScope example.
- `docs/zh/usage/quick_usage.md`: the same example in the Chinese docs.

The `openai protocol` config path is untouched — this only documents another supported endpoint, consistent with how the DashScope example is presented.

## BC-breaking

None. Documentation only.

## Use cases

Users can now use MinerU's LLM-assisted title hierarchy with OrcaRouter in one step:

```json
"llm-aided-config": {
   "api_key": "your_api_key",
   "base_url": "https://api.orcarouter.ai/v1",
   "model": "orcarouter/auto",
   "enable_thinking": false,
   "enable": true
}
```

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class example means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The example configuration was verified against the live gateway: `POST https://api.orcarouter.ai/v1/chat/completions` with `model: orcarouter/auto` returned HTTP 200 with a normal completion.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.

---

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
