### PR TITLE
build(test): declare the markdown test dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ test = [
     "pytest-cov",
     "coverage",
     "fuzzywuzzy",
+    "markdown",
     "tomli; python_version < '3.11'",
 ]
 torch = [


### PR DESCRIPTION
## Summary

- declare `markdown` (Python-Markdown) in the `test` optional-dependency group

`tests/unittest/test_render_html_table.py:1` does `import markdown`, but the package is not
declared anywhere in `pyproject.toml` — the only occurrence of the string `"markdown"` in that file
is inside `[project].keywords`. A pytest collection error is fatal to the whole run, so on a clean
`.[test]` environment the entire suite is skipped:

```
$ python -m pytest tests/unittest --no-cov
collected 2889 items / 1 error
E   ModuleNotFoundError: No module named 'markdown'
!!!!!!!! Interrupted: 1 error during collection !!!!!!!!
$ echo $?
2
```

This is not visible in CI because `.github/workflows/cli.yml` runs `coverage run`, whose
`command_line` targets a single file rather than the suite. `docs/requirements.txt` carries
`markdown-gfm-admonition` for the mkdocs build, but that file is not part of the test environment.

## Validation

- `uv pip install --dry-run -e ".[test]"` on this branch resolves `markdown==3.10.3`; on
  `next` @ 04390cda it resolves nothing matching `markdown`
- with the dependency present, `python -m pytest tests/unittest --no-cov` collects and executes
  2889 tests instead of exiting 2 at collection (remaining failures are pre-existing on `next` and
  unrelated to this change)
- no source or test files touched, so there is nothing to regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)
