### PR TITLE
fix(schema): join schema 1.0 spans within a line instead of newline-separating them

### DIFF
--- a/mineru/backend/postprocess/legacy_schema_adapter.py
+++ b/mineru/backend/postprocess/legacy_schema_adapter.py
@@ -123,12 +123,18 @@ def _denormalize_bbox(bbox: Any, width: float, height: float) -> tuple[float, fl
 
 
 def _extract_lines_content(lines: list[dict[str, Any]]) -> tuple[str, str]:
-    """从 lines[].spans[] 提取文本 content 和第一个 image_path。"""
-    parts: list[str] = []
+    """从 lines[].spans[] 提取文本 content 和第一个 image_path。
+
+    schema 1.0 的 span 是同一行内的水平切片（字体/样式变化就会切开），
+    所以行内 span 必须无分隔符拼接，只有行与行之间才换行；
+    否则一行里每个 span 都会变成独立的一行，把句子拆碎。
+    """
+    line_texts: list[str] = []
     image_path = ""
     for line in lines:
         if not isinstance(line, dict):
             continue
+        parts: list[str] = []
         for span in line.get("spans") or []:
             if not isinstance(span, dict):
                 continue
@@ -137,7 +143,9 @@ def _extract_lines_content(lines: list[dict[str, Any]]) -> tuple[str, str]:
                 parts.append(text)
             if not image_path and span.get("image_path"):
                 image_path = span["image_path"]
-    return "\n".join(parts), image_path
+        if parts:
+            line_texts.append("".join(parts))
+    return "\n".join(line_texts), image_path
 
 
 def _denormalize_lines(

--- a/tests/unittest/test_parse_result_contract.py
+++ b/tests/unittest/test_parse_result_contract.py
@@ -122,6 +122,44 @@ def test_parse_result_from_json_restores_pages() -> None:
     assert restored.middle_json.file_suffix == "pdf"
 
 
+def test_parse_result_from_dict_joins_spans_within_a_line() -> None:
+    """验证 schema 1.0 回推时行内 span 无分隔符拼接，只有跨行才换行。"""
+    data = {
+        "pages": [
+            {
+                "page_idx": 0,
+                "page_size": [600.0, 800.0],
+                "preproc_blocks": [
+                    {
+                        "index": 0,
+                        "type": "text",
+                        "bbox": [60.0, 100.0, 540.0, 130.0],
+                        "lines": [
+                            {
+                                "bbox": [60.0, 100.0, 540.0, 115.0],
+                                # 同一行被样式切成 3 个 span
+                                "spans": [
+                                    {"type": "text", "content": "The measured value is "},
+                                    {"type": "text", "content": "42"},
+                                    {"type": "text", "content": " mV at the gate."},
+                                ],
+                            },
+                            {
+                                "bbox": [60.0, 115.0, 540.0, 130.0],
+                                "spans": [{"type": "text", "content": "Second line."}],
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+    restored = ParseResult.from_dict(data)
+
+    assert restored.pages[0].blocks[0].content == "The measured value is 42 mV at the gate.\nSecond line."
+
+
 def test_parse_result_export_pages_returns_defensive_copy() -> None:
     """验证调用方修改导出页面副本时不会污染 ParseResult 内部状态。"""
     image_cache = ImagePayloadCache()

--- a/tests/unittest/test_parser_api_contract.py
+++ b/tests/unittest/test_parser_api_contract.py
@@ -1666,7 +1666,8 @@ def test_legacy_pdf_info_leaves_content_untouched_when_html_missing_or_empty() -
 
     pages = _pages_from_middle_json({"pdf_info": [_legacy_page_with_spans([span_no_html, span_empty_html])]})
 
-    assert _table_body_content(pages[0].blocks) == "keep\nkeep"
+    # 两个 span 同属一行，回推时无分隔符拼接；本用例断言的是 normalizer 没有改写 content。
+    assert _table_body_content(pages[0].blocks) == "keepkeep"
 
 
 def test_legacy_pdf_info_normalizes_spans_in_nested_blocks_and_all_block_lists() -> None:


### PR DESCRIPTION
## Summary

- `_extract_lines_content` in `backend/postprocess/legacy_schema_adapter.py` now joins spans within a
  line with no separator and only inserts `\n` between lines

In schema 1.0 a span is a horizontal slice of one line — any font or style change splits a line into
several spans. The adapter flattened `lines[].spans[]` into a single list and joined the whole thing
with `"\n"`, so every span became its own line:

```python
parts.append(text)          # every span of every line lands in one flat list
...
return "\n".join(parts), image_path
```

Round-tripping a 1.0 payload through `ParseResult.from_dict()` therefore shreds sentences. One text
block, one line, three spans:

```
before: 'The measured value is \n42\n mV at the gate.'
after : 'The measured value is 42 mV at the gate.'
```

This is also a divergence from `master`, which concatenates spans with no separator — see
`backend/vlm/vlm_middle_json_mkcontent.py` (`block_text += span['content']`) and
`backend/pipeline/para_split.py` (`line_text += span['content'].strip()`). Nothing under
`backend/postprocess/` normalises embedded newlines afterwards, so they reach the renderer verbatim.

## Validation

- added `test_parse_result_from_dict_joins_spans_within_a_line` to `test_parse_result_contract.py` —
  the existing legacy round-trip test only uses one span per line, so this case was uncovered.
  It fails on unpatched `next` — the block comes back as
  `'The measured value is \n42\n mV at the gate.\nSecond line.'` — and passes with the fix
- `test_parse_result_contract.py`: `8 passed` with impl + test, `7 passed` with impl only
  (confirms exactly one test added), `1 failed` with test only
- full suite on `next` @ 9747f8cf before: `55 failed, 2908 passed`; after: `55 failed, 2909 passed` —
  identical failure set, `+1` passing test, no regressions
- `ruff check` clean on all three changed files

## One incidental assertion updated

`test_legacy_pdf_info_leaves_content_untouched_when_html_missing_or_empty` fed two spans into a
**single** line and asserted `"keep\nkeep"`. That test is about `_normalize_legacy_pdf_info_spans`
not rewriting `content` when `html` is missing or empty — the `\n` was a by-product of the joining
bug, not the property under test — so it is now `"keepkeep"` with a comment. The two sibling tests
in that group use a single span each and are untouched. Say the word if you would rather keep `\n`
between spans for `table` blocks and scope the fix to text blocks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
