### PR TITLE
fix(hybrid): deduplicate repeated VLM list blocks before OCR

### DIFF
--- a/mineru/backend/hybrid/hybrid_analyze.py
+++ b/mineru/backend/hybrid/hybrid_analyze.py
@@ -12,6 +12,9 @@ from mineru_vl_utils import MinerUClient
 from mineru_vl_utils.structs import BlockType, ContentBlock
 from tqdm import tqdm
 
+from mineru.backend.hybrid.hybrid_block_dedup import (
+    deduplicate_vlm_model_blocks,
+)
 from mineru.backend.hybrid.hybrid_model_output_to_middle_json import (
     append_page_model_list_to_middle_json,
     apply_server_side_postprocess,
@@ -749,6 +752,10 @@ def _apply_vlm_ocr_det_sidecars_for_window(
     hybrid_pipeline_model,
 ):
     """为VLM-OCR路径追加OCR det空文本行和行内公式框sidecar。"""
+    model_list[:] = [
+        deduplicate_vlm_model_blocks(page_model_list)
+        for page_model_list in model_list
+    ]
     formula_mask_inputs = _build_formula_mask_inputs(images_layout_res)
     inline_formula_list = _build_inline_formula_det_inputs(images_layout_res)
     np_images = [np.asarray(pil_image).copy() for pil_image in images_pil_list]

--- a/mineru/backend/hybrid/hybrid_block_dedup.py
+++ b/mineru/backend/hybrid/hybrid_block_dedup.py
@@ -1,0 +1,93 @@
+# Copyright (c) Opendatalab. All rights reserved.
+import re
+from typing import Any
+
+from mineru.utils.boxbase import calculate_iou
+
+_VLM_TEXT_BLOCK_TYPES = {
+    "text",
+    "title",
+    "doc_title",
+    "paragraph_title",
+    "ref_text",
+}
+_VLM_STRUCTURAL_BLOCK_TYPES = {"list"}
+_VLM_DEDUP_BLOCK_TYPES = _VLM_TEXT_BLOCK_TYPES | _VLM_STRUCTURAL_BLOCK_TYPES
+_NEAR_IDENTICAL_IOU_THRESHOLD = 0.95
+
+
+def _normalize_text(text: object) -> str:
+    return re.sub(r"\s+", " ", str(text or "")).strip()
+
+
+def _block_text(block: dict[str, Any]) -> str:
+    if block.get("content") is not None:
+        return _normalize_text(block["content"])
+
+    span_contents = (str(span.get("content") or "") for line in block.get("lines", []) for span in line.get("spans", []))
+    return _normalize_text("".join(span_contents))
+
+
+def _has_near_identical_bbox(
+    left: dict[str, Any],
+    right: dict[str, Any],
+) -> bool:
+    left_bbox = left.get("bbox")
+    right_bbox = right.get("bbox")
+    if not left_bbox or not right_bbox:
+        return False
+    return calculate_iou(left_bbox, right_bbox) >= _NEAR_IDENTICAL_IOU_THRESHOLD
+
+
+def deduplicate_vlm_model_blocks(
+    blocks: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """删除同一页面中语义和位置均近似相同的VLM块。"""
+    unique_blocks = []
+
+    for block in blocks:
+        block_type = block.get("type") or block.get("label")
+        if block_type not in _VLM_DEDUP_BLOCK_TYPES:
+            unique_blocks.append(block)
+            continue
+
+        block_text = _block_text(block)
+        duplicate = False
+        for kept in unique_blocks:
+            kept_type = kept.get("type") or kept.get("label")
+            if block_type != kept_type or not _has_near_identical_bbox(block, kept):
+                continue
+            if block_type in _VLM_STRUCTURAL_BLOCK_TYPES:
+                kept_text = _block_text(kept)
+                if (not block_text and not kept_text) or block_text == kept_text:
+                    duplicate = True
+                    break
+            if block_text and block_text == _block_text(kept):
+                duplicate = True
+                break
+
+        if not duplicate:
+            unique_blocks.append(block)
+
+    return unique_blocks
+
+
+def deduplicate_list_sub_blocks(
+    blocks: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """删除同一列表中语义和位置均近似相同的文本子块。"""
+    unique_blocks = []
+
+    for block in blocks:
+        block_text = _block_text(block)
+        duplicate = any(
+            block.get("type") == kept.get("type")
+            and block_text
+            and block_text == _block_text(kept)
+            and _has_near_identical_bbox(block, kept)
+            for kept in unique_blocks
+        )
+        if not duplicate:
+            unique_blocks.append(block)
+
+    return unique_blocks

--- a/mineru/backend/hybrid/hybrid_magic_model.py
+++ b/mineru/backend/hybrid/hybrid_magic_model.py
@@ -4,6 +4,7 @@ import re
 
 from loguru import logger
 
+from mineru.backend.hybrid.hybrid_block_dedup import deduplicate_list_sub_blocks
 from mineru.utils.boxbase import calculate_overlap_area_in_bbox1_area_ratio
 from mineru.utils.enum_class import ContentType, BlockType, NotExtractType
 from mineru.utils.guess_suffix_or_lang import guess_language_by_text
@@ -477,6 +478,8 @@ class MagicModel:
 
     def get_all_spans(self):
         return self.all_spans
+
+
 def fix_list_blocks(list_blocks, text_blocks, ref_text_blocks):
     for list_block in list_blocks:
         list_block["blocks"] = []
@@ -497,6 +500,9 @@ def fix_list_blocks(list_blocks, text_blocks, ref_text_blocks):
                 list_block["blocks"].append(block)
                 need_remove_blocks.append(block)
                 break
+
+    for list_block in list_blocks:
+        list_block["blocks"] = deduplicate_list_sub_blocks(list_block["blocks"])
 
     for block in need_remove_blocks:
         if block in text_blocks:

--- a/tests/unittest/test_hybrid_block_deduplication.py
+++ b/tests/unittest/test_hybrid_block_deduplication.py
@@ -1,0 +1,175 @@
+# Copyright (c) Opendatalab. All rights reserved.
+from copy import deepcopy
+
+from mineru.backend.hybrid.hybrid_block_dedup import (
+    deduplicate_list_sub_blocks,
+    deduplicate_vlm_model_blocks,
+)
+from mineru.backend.hybrid.hybrid_magic_model import fix_list_blocks
+
+
+def _middle_text_block(
+    content: str,
+    bbox: list[float | int],
+    block_index: int,
+) -> dict:
+    return {
+        "bbox": bbox,
+        "type": "text",
+        "angle": 0,
+        "lines": [
+            {
+                "bbox": bbox,
+                "spans": [
+                    {
+                        "bbox": bbox,
+                        "type": "text",
+                        "content": content,
+                    }
+                ],
+            }
+        ],
+        "index": block_index,
+    }
+
+
+def _middle_block_text(block: dict) -> str:
+    return block["lines"][0]["spans"][0]["content"]
+
+
+def test_deduplicate_vlm_model_blocks_removes_repeated_text_and_list_blocks() -> None:
+    option_b = {
+        "type": "text",
+        "bbox": [0.034, 0.868, 0.246, 0.892],
+        "content": "B、色谱峰峰高",
+    }
+    list_block = {
+        "type": "list",
+        "bbox": [0.032, 0.840, 0.342, 0.976],
+    }
+    same_text_at_another_position = {
+        **option_b,
+        "bbox": [0.034, 0.668, 0.246, 0.692],
+    }
+    different_text_at_same_position = {
+        **option_b,
+        "content": "B、色谱峰峰宽",
+    }
+    different_list_at_same_position = {
+        **list_block,
+        "content": "different list",
+    }
+
+    result = deduplicate_vlm_model_blocks(
+        [
+            option_b,
+            list_block,
+            *[deepcopy(list_block) for _ in range(4)],
+            deepcopy(option_b),
+            same_text_at_another_position,
+            different_text_at_same_position,
+            different_list_at_same_position,
+        ]
+    )
+
+    assert result == [
+        option_b,
+        list_block,
+        same_text_at_another_position,
+        different_text_at_same_position,
+        different_list_at_same_position,
+    ]
+
+
+def test_deduplicate_list_sub_blocks_removes_only_semantic_geometric_duplicates() -> None:
+    option_b = _middle_text_block(
+        "B、色谱峰峰高",
+        [14, 561, 107, 577],
+        11,
+    )
+    duplicate_option_b = _middle_text_block(
+        " B、色谱峰峰高 ",
+        [14.2, 561, 107.2, 577],
+        20,
+    )
+    same_text_at_another_position = _middle_text_block(
+        "B、色谱峰峰高",
+        [14, 661, 107, 677],
+        21,
+    )
+    different_text_at_same_position = _middle_text_block(
+        "B、色谱峰峰宽",
+        [14, 561, 107, 577],
+        22,
+    )
+    empty_block = _middle_text_block("", [14, 561, 107, 577], 23)
+    duplicate_empty_block = deepcopy(empty_block)
+    duplicate_empty_block["index"] = 24
+
+    result = deduplicate_list_sub_blocks(
+        [
+            option_b,
+            duplicate_option_b,
+            same_text_at_another_position,
+            different_text_at_same_position,
+            empty_block,
+            duplicate_empty_block,
+        ]
+    )
+
+    assert result == [
+        option_b,
+        same_text_at_another_position,
+        different_text_at_same_position,
+        empty_block,
+        duplicate_empty_block,
+    ]
+
+
+def test_fix_list_blocks_removes_repeated_options_from_grouped_list() -> None:
+    option_contents = [
+        "A、色谱柱理论板数",
+        "B、色谱峰峰高",
+        "C、色谱峰保留时间",
+        "D、色谱峰分离度",
+        "E、色谱峰面积重复性",
+    ]
+    option_bboxes = [
+        [13, 543, 135, 559],
+        [14, 561, 107, 577],
+        [14, 579, 134, 595],
+        [14, 598, 120, 613],
+        [14, 615, 148, 631],
+    ]
+    options = [
+        _middle_text_block(content, bbox, index)
+        for index, (content, bbox) in enumerate(
+            zip(option_contents, option_bboxes),
+            start=10,
+        )
+    ]
+    duplicated_options = [
+        _middle_text_block(content, bbox, index)
+        for index, (content, bbox) in enumerate(
+            zip(option_contents[1:], option_bboxes[1:]),
+            start=20,
+        )
+    ]
+    list_blocks = [
+        {
+            "bbox": [13, 543, 148, 631],
+            "type": "list",
+            "lines": [],
+        }
+    ]
+
+    fixed_lists, remaining_text, remaining_ref_text = fix_list_blocks(
+        list_blocks,
+        options + duplicated_options,
+        [],
+    )
+
+    fixed_contents = [_middle_block_text(block) for block in fixed_lists[0]["blocks"]]
+    assert fixed_contents == option_contents
+    assert remaining_text == []
+    assert remaining_ref_text == []


### PR DESCRIPTION
## Motivation

Hybrid high-effort OCR can receive repeated text and list blocks from the VLM result. The repeated blocks have the same semantic content and nearly identical bounding boxes. Each repeated block is then processed by OCR detection and appended to the sidecar result, which amplifies the model duplication into repeated list options in Markdown.

A captured failing result contained five identical list containers and repeated B-E options. Cropping the content into a short standalone page changed the layout prediction and hid the problem, so post-processing is needed for stable full-page parsing.

Related to #5367.

## Modification

- Deduplicate Hybrid VLM text blocks when their type and normalized content match and their IoU is at least 0.95.
- Deduplicate structural list blocks when their semantic content is both empty or equal and their IoU is at least 0.95.
- Apply the deduplication before OCR detection sidecars are generated, avoiding repeated OCR work and duplicate sidecars.
- Defensively deduplicate semantic-geometric duplicate children inside a grouped list before Markdown generation.
- Preserve the first block and retain same text at different positions, different text at the same position, and empty text blocks.

## BC-breaking

No public API or output schema changes.

## Verification

- python -m pytest -q --no-cov tests/unittest/test_hybrid_block_deduplication.py: 3 passed
- Ruff lint and format checks pass for the added module and tests.
- Existing Hybrid files pass Ruff E/W checks.
- On the captured failing model output, text/list blocks are reduced from 22 to 14, removing four repeated list containers and four repeated text blocks.
- On the captured middle JSON, grouped list children are reduced from 9 to the expected 5 options.

## Checklist

- [x] Lint and formatting checks were run for the changed code.
- [x] The bug is covered by unit tests.
- [x] Safety boundaries for same text at different positions and different text at the same position are covered.
- [x] No documentation change is needed because there is no public API or configuration change.
- [ ] Downstream integration testing by maintainers, if needed.
- [ ] CLA confirmation.