### PR TITLE
feat: add request priority scheduling for mineru-api

### DIFF
--- a/docs/en/usage/quick_usage.md
+++ b/docs/en/usage/quick_usage.md
@@ -45,6 +45,7 @@ If you need to adjust parsing options through custom parameters, you can also ch
   >
   >- `POST /tasks` returns immediately with a `task_id`. `POST /file_parse` uses the same task manager internally, waits for the task to finish, and then returns the final result synchronously.
   >- When a task is waiting in the queue, both the submission response and task-status response may include `queued_ahead` to indicate how many tasks are ahead of it.
+  >- `POST /file_parse` and `POST /tasks` accept an optional integer form field `priority`. When execution slots are contended, tasks with a larger `priority` are scheduled first, while tasks with the same priority keep submission order. The default is 0, which preserves the traditional first-come-first-served behavior, and each task's priority is echoed in its status payload.
   >- Tasks are tracked only in-process for a single `mineru-api` instance. Task status is not preserved across service restarts, `--reload`, or multi-process deployments.
   >- Completed or failed tasks are retained for 24 hours by default, then their task state and output directory are cleaned automatically. After cleanup, task status and result endpoints return `404`.
   >- Use `MINERU_API_TASK_RETENTION_SECONDS` and `MINERU_API_TASK_CLEANUP_INTERVAL_SECONDS` to adjust retention and cleanup polling intervals.

--- a/docs/zh/usage/quick_usage.md
+++ b/docs/zh/usage/quick_usage.md
@@ -45,6 +45,7 @@ mineru -p <input_path> -o <output_path>
   >
   >- `POST /tasks` 会立即返回 `task_id`；`POST /file_parse` 会在内部提交到同一个任务管理器，等待任务完成后同步返回最终结果。
   >- 当任务处于排队状态时，任务提交结果和状态查询结果中可能会返回 `queued_ahead` 字段，用于表示前方排队任务数。
+  >- `POST /file_parse` 和 `POST /tasks` 接受可选的整数表单字段 `priority`。并发槽位竞争时，`priority` 较大的任务优先调度，相同优先级保持提交顺序；默认值 0 保持传统的先来先服务行为，任务状态中会回显其优先级。
   >- 任务为单进程、进程内状态实现，服务重启、`--reload` 热重载或多进程部署后不保证仍可查询历史任务状态。
   >- 默认任务完成或失败后保留 24 小时，随后自动清理任务状态和输出目录；清理后访问任务状态或结果会返回 `404`。
   >- 可通过环境变量 `MINERU_API_TASK_RETENTION_SECONDS` 和 `MINERU_API_TASK_CLEANUP_INTERVAL_SECONDS` 调整保留时长与清理轮询间隔。

--- a/mineru/cli/api_request.py
+++ b/mineru/cli/api_request.py
@@ -48,6 +48,7 @@ class ParseRequestOptions:
     response_format_zip: bool
     return_original_file: bool
     client_side_output_generation: bool
+    priority: int
     start_page_id: int
     end_page_id: int
 
@@ -201,6 +202,17 @@ async def parse_request_form(
             ),
         ),
     ] = False,
+    priority: Annotated[
+        int,
+        Form(
+            description=(
+                "Request scheduling priority. Larger values are scheduled first "
+                "(aligned with vLLM priority semantics); requests with the same "
+                "priority keep submission order. Defaults to 0, which preserves "
+                "the traditional first-come-first-served behavior."
+            ),
+        ),
+    ] = 0,
     start_page_id: Annotated[
         int,
         Form(description="The starting page for PDF parsing, beginning from 0"),
@@ -249,6 +261,7 @@ async def parse_request_form(
         response_format_zip=response_format_zip,
         return_original_file=effective_return_original_file,
         client_side_output_generation=client_side_output_generation,
+        priority=priority,
         start_page_id=start_page_id,
         end_page_id=end_page_id,
     )

--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -165,6 +165,7 @@ class AsyncParseTask:
     end_page_id: int
     upload_names: list[str]
     uploads: list[str]
+    priority: int = 0
     submit_order: int = 0
     started_at: Optional[str] = None
     completed_at: Optional[str] = None
@@ -179,6 +180,7 @@ class AsyncParseTask:
             "task_id": self.task_id,
             "status": self.status,
             "backend": self.backend,
+            "priority": self.priority,
             "file_names": self.file_names,
             "created_at": self.created_at,
             "started_at": self.started_at,
@@ -908,6 +910,7 @@ async def create_async_parse_task(
             response_format_zip=request_options.response_format_zip,
             return_original_file=request_options.return_original_file,
             client_side_output_generation=request_options.client_side_output_generation,
+            priority=request_options.priority,
             start_page_id=request_options.start_page_id,
             end_page_id=request_options.end_page_id,
             upload_names=[upload.original_name for upload in uploads],
@@ -928,7 +931,11 @@ class AsyncTaskManager:
         self.app = fastapi_app
         self.tasks: dict[str, AsyncParseTask] = {}
         self.task_events: dict[str, asyncio.Event] = {}
-        self.queue: asyncio.Queue[str] = asyncio.Queue()
+        # Entries are (-priority, submit_order, task_id) tuples so that larger
+        # priorities dequeue first while equal priorities keep submission order.
+        self.queue: asyncio.PriorityQueue[tuple[int, int, str]] = (
+            asyncio.PriorityQueue()
+        )
         self.dispatcher_task: Optional[asyncio.Task[Any]] = None
         self.cleanup_task: Optional[asyncio.Task[Any]] = None
         self.active_tasks: set[asyncio.Task[Any]] = set()
@@ -981,7 +988,7 @@ class AsyncTaskManager:
         self._next_submit_order += 1
         self.tasks[task.task_id] = task
         self.task_events[task.task_id] = asyncio.Event()
-        await self.queue.put(task.task_id)
+        await self.queue.put((-int(task.priority), task.submit_order, task.task_id))
 
     def get(self, task_id: str) -> Optional[AsyncParseTask]:
         return self.tasks.get(task_id)
@@ -993,13 +1000,14 @@ class AsyncTaskManager:
         if task.status != TASK_PENDING:
             return 0
 
+        task_key = (-int(task.priority), task.submit_order)
         return sum(
             1
             for other_task in self.tasks.values()
             if (
                 other_task.task_id != task_id
                 and other_task.status == TASK_PENDING
-                and 0 < other_task.submit_order < task.submit_order
+                and (-int(other_task.priority), other_task.submit_order) < task_key
             )
         )
 
@@ -1096,11 +1104,31 @@ class AsyncTaskManager:
     async def _dispatcher_loop(self) -> None:
         try:
             while True:
-                task_id = await self.queue.get()
-                processor = asyncio.create_task(
-                    self._process_task(task_id),
-                    name=f"mineru-fastapi-task-{task_id}",
-                )
+                if _request_semaphore is None:
+                    _neg_priority, _submit_order, task_id = await self.queue.get()
+                    processor = asyncio.create_task(
+                        self._process_task(task_id),
+                        name=f"mineru-fastapi-task-{task_id}",
+                    )
+                else:
+                    # Acquire an execution slot *before* dequeuing. Dequeuing
+                    # first would spawn processors in submission order, and the
+                    # semaphore's FIFO wake-up would then hand freed slots out
+                    # in submission order too, silently nullifying the priority
+                    # ordering whenever the queue is (momentarily) empty — the
+                    # common case under sparse arrivals.
+                    await _request_semaphore.acquire()
+                    try:
+                        _neg_priority, _submit_order, task_id = await self.queue.get()
+                    except BaseException:
+                        _request_semaphore.release()
+                        raise
+                    processor = asyncio.create_task(
+                        self._process_task(
+                            task_id, held_semaphore=_request_semaphore
+                        ),
+                        name=f"mineru-fastapi-task-{task_id}",
+                    )
                 self.active_tasks.add(processor)
                 processor.add_done_callback(self._on_processor_done)
                 self.queue.task_done()
@@ -1133,13 +1161,22 @@ class AsyncTaskManager:
             logger.error(f"Async task processor crashed: {exception}")
             self.last_worker_error = str(exception)
 
-    async def _process_task(self, task_id: str) -> None:
+    async def _process_task(
+        self,
+        task_id: str,
+        held_semaphore: Optional[asyncio.Semaphore] = None,
+    ) -> None:
         task = self.tasks.get(task_id)
         if task is None:
+            if held_semaphore is not None:
+                held_semaphore.release()
             return
 
         try:
-            if _request_semaphore is not None:
+            if held_semaphore is not None:
+                # The dispatcher already holds the execution slot for this task.
+                await self._run_task(task)
+            elif _request_semaphore is not None:
                 async with _request_semaphore:
                     await self._run_task(task)
             else:
@@ -1152,6 +1189,9 @@ class AsyncTaskManager:
             task.completed_at = utc_now_iso()
             self._signal_task_event(task_id)
             logger.exception(f"Async task failed: {task_id}")
+        finally:
+            if held_semaphore is not None:
+                held_semaphore.release()
 
     async def _run_task(self, task: AsyncParseTask) -> None:
         task.status = TASK_PROCESSING

--- a/tests/unittest/test_fast_api_priority_scheduling.py
+++ b/tests/unittest/test_fast_api_priority_scheduling.py
@@ -1,0 +1,245 @@
+# Copyright (c) Opendatalab. All rights reserved.
+"""Unit tests for request priority scheduling in mineru-api.
+
+Covers the task-level priority queue of ``AsyncTaskManager``:
+- priority ordering under backlog,
+- submission-order FIFO for equal priorities,
+- ``get_queued_ahead`` semantics under priority ordering,
+- the slot-first dispatcher (regression: under sparse arrivals a naive
+  dequeue-then-acquire dispatcher hands freed slots out in submission
+  order, silently nullifying priorities),
+- execution-slot release on task failure.
+"""
+import asyncio
+import time
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import pytest
+
+from mineru.cli import fast_api
+
+
+def _make_task(task_id: str, priority: int = 0) -> fast_api.AsyncParseTask:
+    return fast_api.AsyncParseTask(
+        task_id=task_id,
+        status=fast_api.TASK_PENDING,
+        backend="pipeline",
+        file_names=[f"{task_id}.pdf"],
+        created_at=fast_api.utc_now_iso(),
+        output_dir=f"/tmp/{task_id}",
+        effort="high",
+        parse_method="auto",
+        lang_list=["ch"],
+        formula_enable=True,
+        table_enable=True,
+        image_analysis=True,
+        server_url=None,
+        return_md=True,
+        return_middle_json=False,
+        return_model_output=False,
+        return_content_list=False,
+        return_images=False,
+        response_format_zip=False,
+        return_original_file=False,
+        client_side_output_generation=False,
+        priority=priority,
+        start_page_id=0,
+        end_page_id=99999,
+        upload_names=[f"{task_id}.pdf"],
+        uploads=[],
+    )
+
+
+class _FakeApp:
+    class state:
+        config = {}
+
+
+class _ParseJobController:
+    """Stands in for run_parse_job: records start order, blocks on gates."""
+
+    def __init__(self):
+        self.started: list[str] = []
+        self.gates: dict[str, asyncio.Event] = {}
+        self.fail_ids: set[str] = set()
+
+    async def run(self, **kwargs: Any) -> list[str]:
+        task_id = kwargs["request_options"].task_id
+        if task_id in self.fail_ids:
+            raise RuntimeError(f"simulated parse failure: {task_id}")
+        self.started.append(task_id)
+        gate = asyncio.Event()
+        self.gates[task_id] = gate
+        await gate.wait()
+        return [task_id]
+
+
+async def _wait_until(condition: Callable[[], bool], timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not condition():
+        if time.monotonic() > deadline:
+            raise AssertionError("condition not met within timeout")
+        await asyncio.sleep(0.01)
+
+
+async def _wait_all_started(
+    controller: _ParseJobController, count: int, timeout: float = 5.0
+) -> None:
+    """Release gates as tasks progress so each freed slot admits the next one."""
+    deadline = time.monotonic() + timeout
+    while len(controller.started) < count:
+        for gate in controller.gates.values():
+            gate.set()
+        if time.monotonic() > deadline:
+            raise AssertionError("not all tasks started within timeout")
+        await asyncio.sleep(0.01)
+
+
+@pytest.fixture()
+def task_manager(monkeypatch: pytest.MonkeyPatch) -> Iterator[fast_api.AsyncTaskManager]:
+    monkeypatch.setenv("MINERU_API_TASK_RETENTION_SECONDS", "0")
+    original_semaphore = fast_api._request_semaphore
+    manager = fast_api.AsyncTaskManager(_FakeApp())
+    yield manager
+    fast_api._request_semaphore = original_semaphore
+
+
+def test_backlog_dequeues_high_priority_first(
+    task_manager: fast_api.AsyncTaskManager,
+) -> None:
+    async def scenario() -> list[str]:
+        for task_id, priority in (("low", 0), ("high", 10), ("mid", 5)):
+            await task_manager.submit(_make_task(task_id, priority))
+        order = []
+        for _ in range(3):
+            _neg_priority, _submit_order, task_id = await task_manager.queue.get()
+            order.append(task_id)
+        return order
+
+    assert asyncio.run(scenario()) == ["high", "mid", "low"]
+
+
+def test_same_priority_keeps_submission_order(
+    task_manager: fast_api.AsyncTaskManager,
+) -> None:
+    async def scenario() -> list[str]:
+        for task_id in ("first", "second", "third"):
+            await task_manager.submit(_make_task(task_id, 5))
+        order = []
+        for _ in range(3):
+            _neg_priority, _submit_order, task_id = await task_manager.queue.get()
+            order.append(task_id)
+        return order
+
+    assert asyncio.run(scenario()) == ["first", "second", "third"]
+
+
+def test_queued_ahead_respects_priority(
+    task_manager: fast_api.AsyncTaskManager,
+) -> None:
+    async def scenario() -> dict[str, int]:
+        await task_manager.submit(_make_task("p10", 10))
+        await task_manager.submit(_make_task("p5a", 5))
+        await task_manager.submit(_make_task("p5b", 5))
+        await task_manager.submit(_make_task("p0", 0))
+        return {
+            task_id: task_manager.get_queued_ahead(task_id)
+            for task_id in ("p10", "p5a", "p5b", "p0")
+        }
+
+    assert asyncio.run(scenario()) == {"p10": 0, "p5a": 1, "p5b": 2, "p0": 3}
+
+
+def test_slot_first_dispatcher_prefers_high_priority_under_sparse_arrivals(
+    task_manager: fast_api.AsyncTaskManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression test for the slot-first dispatcher.
+
+    With one execution slot busy and an *empty* queue, submitting a
+    default-priority task followed by a high-priority task must give the
+    high-priority task the first freed slot. A dequeue-then-acquire
+    dispatcher would spawn processors in submission order and the
+    semaphore's FIFO wake-up would hand the slot to the low-priority task.
+    """
+    controller = _ParseJobController()
+    monkeypatch.setattr(fast_api, "run_parse_job", controller.run)
+    fast_api._request_semaphore = asyncio.Semaphore(1)
+
+    async def scenario() -> list[str]:
+        await task_manager.start()
+        try:
+            await task_manager.submit(_make_task("busy", 0))
+            await _wait_until(lambda: controller.started == ["busy"])
+
+            # Sparse arrivals while the only slot is busy.
+            await task_manager.submit(_make_task("low", 0))
+            await task_manager.submit(_make_task("high", 10))
+            await asyncio.sleep(0.05)
+
+            controller.gates["busy"].set()
+            await _wait_all_started(controller, 3)
+            return list(controller.started)
+        finally:
+            for gate in controller.gates.values():
+                gate.set()
+            await task_manager.shutdown()
+
+    assert asyncio.run(scenario()) == ["busy", "high", "low"]
+
+
+def test_held_slot_released_on_task_failure(
+    task_manager: fast_api.AsyncTaskManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    controller = _ParseJobController()
+    controller.fail_ids = {"boom"}
+    monkeypatch.setattr(fast_api, "run_parse_job", controller.run)
+    fast_api._request_semaphore = asyncio.Semaphore(1)
+
+    async def scenario() -> None:
+        await task_manager.start()
+        try:
+            await task_manager.submit(_make_task("boom", 0))
+            await _wait_until(
+                lambda: task_manager.get("boom").status == fast_api.TASK_FAILED
+            )
+
+            # The dispatcher may already hold the freed slot while waiting for
+            # new work, so a functional check is used instead of the semaphore
+            # value: a newly submitted task must still get executed, proving
+            # the slot was not leaked by the failed task.
+            await task_manager.submit(_make_task("next", 0))
+            await _wait_until(lambda: "next" in controller.started)
+            controller.gates["next"].set()
+            await _wait_until(
+                lambda: task_manager.get("next").status == fast_api.TASK_COMPLETED
+            )
+        finally:
+            for gate in controller.gates.values():
+                gate.set()
+            await task_manager.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_no_semaphore_runs_all_tasks_without_slot_gating(
+    task_manager: fast_api.AsyncTaskManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without a concurrency cap every submitted task runs unconditionally."""
+    controller = _ParseJobController()
+    monkeypatch.setattr(fast_api, "run_parse_job", controller.run)
+    fast_api._request_semaphore = None
+
+    async def scenario() -> list[str]:
+        await task_manager.start()
+        try:
+            for task_id, priority in (("low", 0), ("high", 10)):
+                await task_manager.submit(_make_task(task_id, priority))
+            await _wait_until(lambda: len(controller.started) == 2)
+            return sorted(controller.started)
+        finally:
+            for gate in controller.gates.values():
+                gate.set()
+            await task_manager.shutdown()
+
+    assert asyncio.run(scenario()) == ["high", "low"]


### PR DESCRIPTION
## Motivation

`mineru-api` currently schedules parse tasks strictly first-come-first-served. In real deployments the queue often mixes very different workloads: interactive requests where a human is waiting on the response, and large batch jobs that can tolerate hours of delay. Today there is no way to let an urgent interactive request overtake a backlog of batch work — the only options are cancelling jobs or restarting the service.

This PR adds an opt-in per-request `priority` to `POST /file_parse` and `POST /tasks` so deployments can express scheduling preference, while keeping the default behavior byte-for-byte identical to today's FIFO. The priority semantics intentionally follow vLLM (`larger = scheduled first`) so they are familiar to anyone already running vLLM-based MinerU backends, and they leave a clean upgrade path to engine-level pass-through in a later PR.

Design context and the slot-first dispatcher analysis are in the Ideas discussion linked above.

## Modification

- `mineru/cli/api_request.py`
  - New optional integer form field `priority` (default `0`) in the shared `parse_request_form` / `ParseRequestOptions`, so both `mineru-api` and `mineru-router` expose it from a single source of truth (the router proxies multipart fields transparently).
- `mineru/cli/fast_api.py`
  - `AsyncParseTask` gains `priority: int = 0`; the value is echoed back in the task status payload.
  - `AsyncTaskManager.queue` changes from `asyncio.Queue` to `asyncio.PriorityQueue`, keyed on `(-priority, submit_order, task_id)`: larger priority dequeues first; equal priorities keep submission order.
  - `get_queued_ahead` counts tasks with a strictly smaller key, so the reported queue position matches actual scheduling order.
  - The dispatcher is restructured to be **slot-first**: it acquires an execution slot (`_request_semaphore`) *before* taking the next task from the queue. This matters under sparse arrivals: with the previous dequeue-then-acquire structure, a freed slot is handed out by the semaphore's FIFO wake-up order to processors that were already spawned in submission order, silently nullifying priorities. The unit tests include a regression case that fails with the old structure. The semaphore is passed to `_process_task` and released in its `finally`, so slots cannot leak on task failure.
- `docs/en/usage/quick_usage.md`, `docs/zh/usage/quick_usage.md`
  - Document the new `priority` field, its semantics, and the default.
- `tests/unittest/test_fast_api_priority_scheduling.py` (new)
  - 6 unit tests: priority ordering under backlog, FIFO for equal priorities, `queued_ahead` semantics, the slot-first dispatcher under sparse arrivals (starvation regression), slot release on task failure, and the no-semaphore path.

No changes are required in `mineru-router` — it stages the multipart request and forwards `form.multi_items()` verbatim, so the new field flows through automatically.

## BC-breaking (Optional)

None.

- `priority` defaults to `0`, and every task with the same priority keeps submission order — the default deployment schedules exactly as before.
- The wire change is additive: one new optional form field, one new key in the status payload. Existing clients that never send `priority` are unaffected.
- No public function signatures changed.

## Use cases (Optional)

Mixed interactive + batch deployment (the motivating production case, validated on Ascend 910B + vLLM):

```bash
# Urgent interactive request jumps the backlog
curl -X POST http://127.0.0.1:8000/tasks \
  -F "files=@contract.pdf" \
  -F "return_md=true" \
  -F "priority=10"

# Overnight batch job keeps the default
curl -X POST http://127.0.0.1:8000/tasks \
  -F "files=@archive_scan.pdf" \
  -F "return_md=true"
```

Known trade-off (also noted in the discussion): there is no aging, so a permanently starved low-priority queue is possible if high-priority traffic never stops. This matches vLLM's behavior and keeps the scheduler simple; aging can be layered on later if maintainers want it.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
