### PR TITLE
docs(next): add pitfalls, invariants and code-map for 4.x

### DIFF
--- a/docs/next/README.md
+++ b/docs/next/README.md
@@ -49,6 +49,9 @@
 | 配置 | [config.md](config.md) | 配置专题文档仍待继续核对 | CLI、服务端、SDK 开发 |
 | Telemetry | [telemetry.md](telemetry.md) | 用户讨论 / 旧路线图底稿迁移内容 | 产品、核心开发、数据分析、合规参与者 |
 | 开放问题 | [open-questions.md](open-questions.md) | 各专题文档、用户讨论 | 核心开发、编程 Agent、文档维护者 |
+| 模块地图 | [code-map.md](code-map.md) | 代码结构分析报告（MINERU-1）对照代码核实固化 | 首次接触 4.x 代码的贡献者、核心开发、编程 Agent |
+| 开发陷阱 | [pitfalls.md](pitfalls.md) | 代码结构分析报告（MINERU-1）对照代码核实固化 | 核心开发、编程 Agent、代码审查者 |
+| 不变量红线 | [invariants.md](invariants.md) | 代码结构分析报告（MINERU-1）对照代码核实固化 | 核心开发、编程 Agent、代码审查者 |
 
 ## 整理原则
 

--- a/docs/next/code-map.md
+++ b/docs/next/code-map.md
@@ -1,0 +1,76 @@
+# 模块地图
+
+状态: Draft
+读者: 核心开发、编程 Agent、首次接触 4.x 代码的贡献者
+范围: next 分支（4.x Alpha）的模块职责、入口与两条主调用链
+基准: 本文件以 commit `317428b8`（2026-09-01，next 分支）为基准核实。
+
+**维护规则**：结构性改动（模块新增/删除/职责迁移、入口或调用链变化）合并时必须同步更新本文件；纯函数级改动不需要。
+
+## 1. 入口声明
+
+`pyproject.toml:137-140` 声明 4 个 console script：
+
+| 入口 | 指向 |
+|---|---|
+| `mineru` | `mineru.cli.main:main` |
+| `mineru-kit` | `mineru.kit.main:main` |
+| `mineru-router` | `mineru.kit.router.cli:main` |
+| `mineru-gradio` | `mineru.cli_old.gradio_app:main` |
+
+## 2. 模块职责表
+
+| 模块 | 职责 | 关键锚点 |
+|---|---|---|
+| `mineru/cli/` | 面向 agent 的文档中心 CLI，16 个顶层命令（parse/read/scan/watch/search/find/usage/list/show/telemetry/server/config/invalidate/forget/cleanup/version，注册顺序见 `TOP_LEVEL_COMMAND_ORDER`） | `cli/main.py:22-40`、`cli/commands/*.py` |
+| `mineru/doclib/` | 本地文档库常驻服务：入库、SHA256 去重、解析调度、缓存、搜索、配置。FastAPI + SQLite(WAL) + FTS5，路由→`services/`→`core/` 三层 | `doclib/server.py`（2439 行）；`doclib/services/{parse,search,scan,config,cleanup}_svc.py`；`doclib/core/{db,fts,file_io}.py` |
+| `mineru/doclib/background/` | 后台 asyncio 任务：ingest（入库）、parse_worker（解析执行）、scan_worker / watch（目录监听）、parse_server_health（parse-server 托管与健康探测）、device_monitor、compaction（批次合并）、telemetry_flush | 各文件顶部 docstring；`background/parse_worker.py:15` |
+| `mineru/parser/` | parse-server 与解析门面：`api_server.py`（2495 行，独立进程）、`api_client.py`（HTTP 客户端）、`tier.py`（tier/backend 解析）、`mineru_parser.py`（`MinerUParser` 统一解析入口）、`base.py`（Middle JSON schema） | `parser/mineru_parser.py`、`parser/tier.py` |
+| `mineru/backend/` | 解析引擎：`analyze.py`（`doc_analyze` 统一门面）→ `analysis/`（按格式分派：`pdf/`、`csv.py`、`epub.py`、`html.py`、`ofd.py`、`office.py`）→ `postprocess/`（Middle JSON 组装、段落/标题/列表/表格合并、`llm_aided.py`、`legacy_schema_adapter.py`） | `backend/analyze.py`、`backend/analysis/pdf/pipeline.py` |
+| `mineru/model/` | 模型层：`flash/`（纯 CPU 本地结构化解析器族：pdf / office / epub / html / ofd / csv）；`runtime/`（`device.py` 设备与 light/full 栈、`hybrid.py` 原子模型分派、`onnx.py`）；`layout/ mfr/ ocr/ table/ vlm/`（ML 模型实现）；`_internal/pytorchocr` | `model/runtime/device.py:48`、`model/runtime/hybrid.py` |
+| `mineru/render/` | 输出渲染：markdown / content_list(v2) / structured_content / docx / epub / html / pdf | `render/api.py`（唯一渲染入口）、`render/contracts.py` |
+| `mineru/kit/` | 服务端工具 CLI：`parse` / `api-server` / `vlm-server` / `router` / `models`，面向自部署/多卡部署 | `kit/main.py`、`kit/commands/*.py` |
+| `mineru/cli_old/` | 3.x CLI 原样迁入的兼容层（client / fast_api / gradio_app / router 等），仅改导入路径与裁剪 | 仅 `mineru-gradio` 入口引用 |
+| 顶层类型/配置 | `types.py`（1317 行，Tier / locator / 各 Response 模型）、`errors.py`（错误协议）、`config.py`（MINERU_HOME、UDS/TCP、model stack）、`filetypes.py`（扩展名→tier 语义） | `config.py`（`Config`）、`errors.py:20` |
+| `docs/next/` | 4.x 全套设计文档：architecture / tiers / errors / middle-json + 33 篇 ADR（`decisions/0001-0033`）+ 实施计划 `docs/plans/` | `docs/next/README.md` |
+| `tests/unittest/` | 约 2372 个测试函数 | — |
+
+## 3. 主调用链
+
+### 3.1 解析链（`mineru parse <file>`）
+
+```
+cli/commands/parse.py parse_cmd（--remote 选项 :100）
+  → DoclibClient（doclib/client.py）经 UDS（$MINERU_HOME/doclib.sock；UDS 不可用回退
+    TCP 127.0.0.1:15980，见 config.py 与 doclib/endpoint.py）
+  → doclib/server.py → ParseService.submit（services/parse_svc.py:726：校验 tier/privacy/
+    page_range/扩展名；privacy = "remote"|"local" :754）写入 parses 表任务队列
+  → ParseWorkerPool（background/parse_worker.py:15）→ process_doc（parse_svc.py:931）按 tier 分派：
+    · flash   → 进程内本地 flash 解析（parse_svc.py:971 附近，"local(flash)"）
+    · basic/standard/advanced → _parse_via_api（parse_svc.py:1146）三选一：
+        managed（doclib 自动拉起 `mineru-kit api-server --tier … --no-flash --preload-models`，
+                 background/parse_server_health.py:98-113；TCP 127.0.0.1:16580）
+        self_hosted（parse_server.local.self_hosted_url）
+        remote（parse_server.remote.url）
+      均不可用时抛 no_engine（parse_svc.py:1239）
+  → parse-server 侧：parser/api_server.py → MinerUParser（parser/mineru_parser.py，按后缀路由）
+    → doc_analyze（backend/analyze.py）→ analysis/<格式> → postprocess → MiddleJson(schema 2.0)
+    → 解析产物写回 doclib（background/compaction.py 合并批次）
+```
+
+### 3.2 读取链（`mineru read <locator>`）
+
+```
+cli/commands/read.py:25 read_cmd
+  → DoclibClient.read_content
+  → doclib/server.py:684 _build_read_plan_from_locator（locator 解析在 :1484 _parse_doc_locator）
+  → 从缓存页取内容、按 --limit 截断
+  → 生成 ContentNextRequest（server.py:2142 _next_content_request；模型定义 doclib/types.py:293）
+  → CLI 侧拼 `<!-- Next: mineru read … -->` 续读标记（cli/commands/read.py:164）
+```
+
+## 4. 相关文档
+
+- 陷阱与兼容面联动：[pitfalls.md](pitfalls.md)
+- 不变量红线：[invariants.md](invariants.md)
+- 系统架构与设计：[architecture.md](architecture.md)、[decisions/README.md](decisions/README.md)

--- a/docs/next/code-map.md
+++ b/docs/next/code-map.md
@@ -43,13 +43,13 @@
 cli/commands/parse.py parse_cmd（--remote 选项 :100）
   → DoclibClient（doclib/client.py）经 UDS（$MINERU_HOME/doclib.sock；UDS 不可用回退
     TCP 127.0.0.1:15980，见 config.py 与 doclib/endpoint.py）
-  → doclib/server.py → ParseService.submit（services/parse_svc.py:726：校验 tier/privacy/
+  → doclib/server.py → ParseService.request_parse（services/parse_svc.py:719：校验 tier/privacy/
     page_range/扩展名；privacy = "remote"|"local" :754）写入 parses 表任务队列
   → ParseWorkerPool（background/parse_worker.py:15）→ process_doc（parse_svc.py:931）按 tier 分派：
     · flash   → 进程内本地 flash 解析（parse_svc.py:971 附近，"local(flash)"）
     · basic/standard/advanced → _parse_via_api（parse_svc.py:1146）三选一：
-        managed（doclib 自动拉起 `mineru-kit api-server --tier … --no-flash --preload-models`，
-                 background/parse_server_health.py:98-113；TCP 127.0.0.1:16580）
+        managed（doclib 自动拉起 `python -m mineru.parser.api_server`，
+                 managed 进程参数见 background/parse_server_health.py:98-113；TCP 127.0.0.1:16580）
         self_hosted（parse_server.local.self_hosted_url）
         remote（parse_server.remote.url）
       均不可用时抛 no_engine（parse_svc.py:1239）

--- a/docs/next/invariants.md
+++ b/docs/next/invariants.md
@@ -24,7 +24,7 @@
 
 - 不得改变既有 error code 的语义或取值集合的成员含义；已发布的 code 视为对外契约。
 - 不得随意改动 code → type 与 code → HTTP 的映射关系；新增 code 必须同时登记进两张表。
-- 响应外层结构（OpenAI 兼容 `{type, code, message, param}`）不得变更；扩展字段见 `docs/next/errors.md` 与 `docs/next/pitfalls.md` 第 4 条。
+- 响应外层结构（OpenAI 兼容 `{type, code, message, param}`）不得变更；扩展字段见 `docs/next/errors.md` 与 `docs/next/pitfalls.md` 第 3 条。
 
 ## 3. Middle JSON schema 2.0 输出契约（ADR-0020）
 

--- a/docs/next/invariants.md
+++ b/docs/next/invariants.md
@@ -18,7 +18,7 @@
 
 ## 2. 错误码语义稳定
 
-`mineru/errors.py` 定义了结构化错误协议：code → type 映射（`_ERROR_TYPE_MAP` `errors.py:20`）、code → HTTP 覆盖表（`_ERROR_CODE_STATUS_MAP` `errors.py:119`）、响应构造（`error_response` `errors.py:208`）。
+`mineru/errors.py` 定义了结构化错误协议：code → type 映射（`_ERROR_TYPE_MAP` `errors.py:20`）、code → HTTP 覆盖表（`_ERROR_CODE_STATUS_MAP` `errors.py:118`）、响应构造（`error_response` `errors.py:208`）。
 
 红线：
 
@@ -37,9 +37,7 @@ Middle JSON 的对外 schema 固定为 `2.0`（`mineru/parser/base.py:20` `MIDDL
 
 ## 4. 依赖方向：基础层不得反向引用上层
 
-稳定依赖方向为 `utils/types → model → backend → render → parser/kit/doclib`，禁止上层模块被基础层反向引用（事实源：`CLAUDE.md` "5.1 目录职责"，此处引用并保持单一事实源）。
-
-配套规则：mineru 子模块之间只用 relative import。
+依赖方向红线以 `CLAUDE.md`「5.1 目录职责」为单一事实源，此处不复述。配套规则 mineru 子模块之间只用 relative import，同样以 `CLAUDE.md`「Import 规范」为准，不在此复制。违反任一即视为回归。
 
 ## 5. 定位符协议语法向后兼容
 

--- a/docs/next/invariants.md
+++ b/docs/next/invariants.md
@@ -1,0 +1,51 @@
+# 不变量红线
+
+状态: Draft
+读者: 核心开发、编程 Agent、代码审查者
+范围: Agent / 人类改动**永远不允许违反**的硬约束
+来源: MINERU-1 代码结构分析报告对照代码复核后固化；行号以 commit `317428b8` 为基准。
+
+违反任何一条都视为回归。改动触及这些位置时，PR 描述必须说明不破坏对应不变量。
+
+## 1. 隐私边界：本地解析失败绝不静默回退 remote
+
+文档内容默认全本地处理；只有显式 `--remote`（CLI）或 `privacy="remote"` 才把 PDF/图片发往远端 parse-server。
+
+- `privacy` 二值赋值：`mineru/doclib/services/parse_svc.py:754`
+- 门控集合：remote 仅支持 PDF/图片（`remote_unsupported_for_file_type` `parse_svc.py:772`）、remote 禁 flash（`tier_unsupported_for_remote` `:778`）、质量 tier 仅限 PDF/图片（`tier_unsupported_for_file_type` `:784`）
+
+红线：解析失败、引擎不可用、超时等任何情况下，都不得把用户文档自动发往远端。失败路径必须原样报错（如 `no_engine`，`parse_svc.py:1239`），由用户显式改用 `--remote`。
+
+## 2. 错误码语义稳定
+
+`mineru/errors.py` 定义了结构化错误协议：code → type 映射（`_ERROR_TYPE_MAP` `errors.py:20`）、code → HTTP 覆盖表（`_ERROR_CODE_STATUS_MAP` `errors.py:119`）、响应构造（`error_response` `errors.py:208`）。
+
+红线：
+
+- 不得改变既有 error code 的语义或取值集合的成员含义；已发布的 code 视为对外契约。
+- 不得随意改动 code → type 与 code → HTTP 的映射关系；新增 code 必须同时登记进两张表。
+- 响应外层结构（OpenAI 兼容 `{type, code, message, param}`）不得变更；扩展字段见 `docs/next/errors.md` 与 `docs/next/pitfalls.md` 第 4 条。
+
+## 3. Middle JSON schema 2.0 输出契约（ADR-0020）
+
+Middle JSON 的对外 schema 固定为 `2.0`（`mineru/parser/base.py:20` `MIDDLE_JSON_SCHEMA_VERSION`）；稳定的是对外 JSON / Pydantic 模型层，不是 SQLite 表结构（ADR-0020：`docs/next/decisions/0020-doclib-schema-stability-boundary.md`）。
+
+红线：
+
+- 不输出 `_backend` / `_version_name` / `pdf_info` / `_ocr_enable` / `_vlm_ocr_enable` 等旧字段；旧字段只能作为受支持旧 payload 的迁移输入出现（legacy 读取路径见 `parser/base.py:20-47` 与 `backend/postprocess/legacy_schema_adapter.py`）。
+- 改动输出结构即破坏性变更：必须走 ADR 流程，并同步 `docs/next/api/changes.md`、`docs/next/middle-json.md` 与 compaction（`doclib/background/compaction.py:27`）。
+
+## 4. 依赖方向：基础层不得反向引用上层
+
+稳定依赖方向为 `utils/types → model → backend → render → parser/kit/doclib`，禁止上层模块被基础层反向引用（事实源：`CLAUDE.md` "5.1 目录职责"，此处引用并保持单一事实源）。
+
+配套规则：mineru 子模块之间只用 relative import。
+
+## 5. 定位符协议语法向后兼容
+
+内容定位符语法 `doc:{short_id}/tier:{tier}/page:{n}[/block:{n}[/char:{n}]]` 定义于 `mineru/doclib/locators.py:10-16` 的 `_CURSOR_RE`；构造器 `page_ref` / `block_ref` / `block_char_ref` 在 `locators.py:33-46`。
+
+红线：
+
+- 已发布格式的 locator（含持久化在缓存、续读标记 `<!-- Next: mineru read … -->` 中的）必须永久可解析；扩展语法只能以追加段的方式演进，不得改变既有段语义。
+- `short_id` 取 sha256 十六进制前缀、冲突时延长（`doclib/services/parse_svc.py:247-282`），不得改换派生方式。

--- a/docs/next/pitfalls.md
+++ b/docs/next/pitfalls.md
@@ -1,0 +1,60 @@
+# 开发陷阱清单
+
+状态: Draft
+读者: 核心开发、编程 Agent、代码审查者
+范围: 4.x（next 分支）开发中已知的结构性陷阱与兼容面联动要求
+来源: MINERU-1 代码结构分析报告（SHANNON，2026-09-01），逐条对照代码复核后固化。行号以 commit `317428b8` 为基准。
+
+本清单收录的是"改动前必须知道，否则容易做错"的事项。每条给出代码锚点与正确做法；纯推测、无法操作的观察不收录。
+
+## 1. 两个大文件不再堆功能
+
+- `mineru/parser/api_server.py`（2495 行，parse-server，"MinerU v1 REST API"）
+- `mineru/doclib/server.py`（2439 行，doclib 常驻服务端）
+
+这两个文件已是仓库中最大的单文件。新增功能不要继续堆入，按现有分层放入对应模块：
+
+- parse-server：路由 / 服务逻辑分层放置，与 `doclib/services/` → `doclib/core/` 的分层方式对齐。
+- doclib：路由进 `server.py` 的路由层，业务进 `doclib/services/`（如 `parse_svc.py`、`search_svc.py`），存储与 IO 进 `doclib/core/`（`db.py`、`fts.py`、`file_io.py`）。
+
+仓库 `tests/unittest/` 下约 2372 个测试函数是拆分与重构的安全网。
+
+## 2. 双轨兼容面的联动要求
+
+### 2.1 tier / backend 双入参过渡层
+
+`parser/tier.py:230` 的 `resolve_tier_and_backend(tier, backend)` 是为旧专家用户保留的过渡层：同时接受公开 `tier` 和本地专家 `backend` 入参，并做兼容性校验（`_backend_supports_tier`）。
+
+- 新代码只走 `tier`；`backend_for_tier`（`parser/tier.py:183`）已保证 basic/standard/advanced 共用同一个 hybrid-engine，仅 effort 不同（`HYBRID_EFFORT_BY_TIER` `parser/tier.py:25`）。
+- 不要新增依赖 `backend` 入参的分支；`pipeline`/`vlm-*` 仅作为 legacy 别名存在。
+
+### 2.2 Middle JSON legacy 读取三件套
+
+改 Middle JSON 结构时必须同步检查三处，否则旧缓存文档读取会断：
+
+1. legacy 读取：`mineru/parser/base.py:20-47` —— 识别 3.4.5 `pdf_info` 与 schema 1.0 `pages` 包装（`_legacy_raw_pages`），`MIDDLE_JSON_SCHEMA_VERSION = "2.0"`；
+2. legacy 适配：`mineru/backend/postprocess/legacy_schema_adapter.py` —— 旧 payload 单向回推为 raw model-list；
+3. 批次合并：`mineru/doclib/background/compaction.py:27-32` —— 仅合并同 schema 批次。
+
+新增或调整 Middle JSON 字段时，先确认 ADR-0020（schema stability boundary）是否覆盖该字段，再同步上述三处与 `docs/next/middle-json.md`。
+
+## 3. Alpha 高频迭代，公开 API 未稳定
+
+4.x 处于 Alpha prerelease，迭代节奏约为日均 10 个提交，公开 API 未稳定（变更专门记录在 `docs/next/api/changes.md`）。
+
+- 外部集成应 pin 具体 commit，不要跟浮动的 next HEAD。
+- 内部改动涉及 NEXT v1 API 行为变化时，必须在 `docs/next/api/changes.md` 追加条目。
+
+## 4. 错误协议：设计已定、实现缺位的部分
+
+`docs/next/errors.md` 已设计 `user_action` / `retryable` / `docs_url` 扩展字段，但 `mineru/errors.py` 的 `error_response`（`errors.py:208`）目前只输出 OpenAI 兼容的 `{type, code, message, param}`，全仓无 Python 实现点。
+
+- 依赖这些扩展字段的调用方代码不要提前编写。
+- 补齐该缺口是自然切入点：改 `errors.py` 的 `error_response` 与 CLI JSON 输出，并同步 `docs/next/errors.md` 状态。
+
+## 5. 仓库约定速查
+
+两条来自 `AGENTS.md` / `CLAUDE.md` 的硬约定，最容易在自动生成提交时违反：
+
+- mineru 子模块之间只使用 **relative import**（`from .base import X`），不用 `import mineru.xxx` 绝对导入。
+- commit message / PR body 禁用 `fixes|closes|resolves #n`（会在 merge 后自动关闭 issue），用 `Refs #n`。

--- a/docs/next/pitfalls.md
+++ b/docs/next/pitfalls.md
@@ -22,7 +22,7 @@
 
 1. legacy 读取：`mineru/parser/base.py:20-47` —— 识别 3.4.5 `pdf_info` 与 schema 1.0 `pages` 包装（`_legacy_raw_pages`），`MIDDLE_JSON_SCHEMA_VERSION = "2.0"`；
 2. legacy 适配：`mineru/backend/postprocess/legacy_schema_adapter.py` —— 旧 payload 单向回推为 raw model-list；
-3. 批次合并：`mineru/doclib/background/compaction.py:27-32` —— 仅合并同 schema 批次。
+3. 批次合并：`mineru/doclib/background/compaction.py:23` `_normalize_batch_pages` 会把 schema 2.0、1.0、3.4.5 批次归一化后**跨 schema 合并**（legacy 批次经 `legacy_schema_adapter` 转换参与），并非只合并 2.0 批次；schema 无法识别时抛 stale-cache 错误并放弃本轮压缩（`compaction.py:37`）。
 
 新增或调整 Middle JSON 字段时，先确认 ADR-0020（schema stability boundary）是否覆盖该字段，再同步上述三处与 `docs/next/middle-json.md`。
 

--- a/docs/next/pitfalls.md
+++ b/docs/next/pitfalls.md
@@ -7,28 +7,16 @@
 
 本清单收录的是"改动前必须知道，否则容易做错"的事项。每条给出代码锚点与正确做法；纯推测、无法操作的观察不收录。
 
-## 1. 两个大文件不再堆功能
+## 1. 双轨兼容面的联动要求
 
-- `mineru/parser/api_server.py`（2495 行，parse-server，"MinerU v1 REST API"）
-- `mineru/doclib/server.py`（2439 行，doclib 常驻服务端）
-
-这两个文件已是仓库中最大的单文件。新增功能不要继续堆入，按现有分层放入对应模块：
-
-- parse-server：路由 / 服务逻辑分层放置，与 `doclib/services/` → `doclib/core/` 的分层方式对齐。
-- doclib：路由进 `server.py` 的路由层，业务进 `doclib/services/`（如 `parse_svc.py`、`search_svc.py`），存储与 IO 进 `doclib/core/`（`db.py`、`fts.py`、`file_io.py`）。
-
-仓库 `tests/unittest/` 下约 2372 个测试函数是拆分与重构的安全网。
-
-## 2. 双轨兼容面的联动要求
-
-### 2.1 tier / backend 双入参过渡层
+### 1.1 tier / backend 双入参过渡层
 
 `parser/tier.py:230` 的 `resolve_tier_and_backend(tier, backend)` 是为旧专家用户保留的过渡层：同时接受公开 `tier` 和本地专家 `backend` 入参，并做兼容性校验（`_backend_supports_tier`）。
 
 - 新代码只走 `tier`；`backend_for_tier`（`parser/tier.py:183`）已保证 basic/standard/advanced 共用同一个 hybrid-engine，仅 effort 不同（`HYBRID_EFFORT_BY_TIER` `parser/tier.py:25`）。
 - 不要新增依赖 `backend` 入参的分支；`pipeline`/`vlm-*` 仅作为 legacy 别名存在。
 
-### 2.2 Middle JSON legacy 读取三件套
+### 1.2 Middle JSON legacy 读取三件套
 
 改 Middle JSON 结构时必须同步检查三处，否则旧缓存文档读取会断：
 
@@ -38,21 +26,21 @@
 
 新增或调整 Middle JSON 字段时，先确认 ADR-0020（schema stability boundary）是否覆盖该字段，再同步上述三处与 `docs/next/middle-json.md`。
 
-## 3. Alpha 高频迭代，公开 API 未稳定
+## 2. Alpha 高频迭代，公开 API 未稳定
 
 4.x 处于 Alpha prerelease，迭代节奏约为日均 10 个提交，公开 API 未稳定（变更专门记录在 `docs/next/api/changes.md`）。
 
 - 外部集成应 pin 具体 commit，不要跟浮动的 next HEAD。
 - 内部改动涉及 NEXT v1 API 行为变化时，必须在 `docs/next/api/changes.md` 追加条目。
 
-## 4. 错误协议：设计已定、实现缺位的部分
+## 3. 错误协议：设计已定、实现缺位的部分
 
 `docs/next/errors.md` 已设计 `user_action` / `retryable` / `docs_url` 扩展字段，但 `mineru/errors.py` 的 `error_response`（`errors.py:208`）目前只输出 OpenAI 兼容的 `{type, code, message, param}`，全仓无 Python 实现点。
 
 - 依赖这些扩展字段的调用方代码不要提前编写。
 - 补齐该缺口是自然切入点：改 `errors.py` 的 `error_response` 与 CLI JSON 输出，并同步 `docs/next/errors.md` 状态。
 
-## 5. 仓库约定速查
+## 4. 仓库约定速查
 
 两条来自 `AGENTS.md` / `CLAUDE.md` 的硬约定，最容易在自动生成提交时违反：
 


### PR DESCRIPTION
## 动机

把 4.x（next 分支）代码结构深度分析（Multica MINERU-1 报告）中的成果固化为仓库内正式文档，避免这些知识只存在于对话里。对应 Multica 工作区任务 MINERU-7。

## 方案

新增三篇文档 + 更新文档地图，全部为纯文档改动：

- **`docs/next/pitfalls.md`（开发陷阱清单）**：tier/backend 双入参过渡层（`parser/tier.py:230`）新代码只走 tier；Middle JSON legacy 读取三件套联动（`parser/base.py:20-47` + `backend/postprocess/legacy_schema_adapter.py` + `background/compaction.py:27`）；Alpha 高频迭代与 `docs/next/api/changes.md` 要求；错误协议 `user_action`/`retryable`/`docs_url` 设计已定、实现缺位的现状；AGENTS.md 两条硬约定速查。
- **`docs/next/invariants.md`（不变量红线）**：5 条硬约束，每条带代码锚点——隐私边界（`parse_svc.py:754` 起，失败绝不静默回退 remote）、错误码语义（`errors.py:20/119/208`）、Middle JSON schema 2.0 输出契约（ADR-0020）、依赖方向 `utils/types → model → backend → render → parser/kit/doclib`（引用 CLAUDE.md 单一事实源）、定位符协议语法向后兼容（`doclib/locators.py:10-16`）。
- **`docs/next/code-map.md`（模块地图）**：4 个 console script 入口、模块职责表、parse 与 read 两条主调用链（含 file:line 锚点）、维护规则（结构性改动须同步更新），标注以 commit `317428b8` 为基准。
- **`docs/next/README.md`**：文档地图表新增三行（含读者与定位）。

报告结论入库前已逐条对照 next HEAD（`317428b8`）重新核实；纯推测内容未收录；经评审移除了"两个大文件不再堆功能"一条。

## 验证

- 纯文档改动，无代码变更，不涉及测试/lint 行为。
- 报告中的行号类结论均通过 grep/sed 对照 HEAD 复核（数处 1-5 行偏移已按代码修正）。
- `git diff --stat` 确认仅 4 个文档文件变化。

Refs #7
