### PR TITLE
fix(api): cap torch CPU threads to stop OpenMP thread growth in mineru-api

### DIFF
--- a/docs/en/usage/cli_tools.md
+++ b/docs/en/usage/cli_tools.md
@@ -176,6 +176,12 @@ Here are the environment variables and their descriptions:
     * Used to set the cleanup polling interval for expired tasks, in seconds.
     * Default is `300` seconds (5 minutes).
 
+- `MINERU_CPU_NUM_THREADS`:
+    * Used to set the maximum number of CPU threads a single torch CPU operator may use in `mineru-api`.
+    * Default is `8`, clamped to the CPU core count of the machine.
+    * `mineru-api` dispatches CPU work with `asyncio.to_thread()`, and OpenMP (libgomp) keeps one persistent worker team per thread that enters a parallel region. Without an upper bound, the process thread count grows towards `thread_pool_size * cpu_count` on many-core hosts.
+    * If any of `OMP_NUM_THREADS`, `MKL_NUM_THREADS` or `OPENBLAS_NUM_THREADS` is already set, that configuration is respected and no default is applied. If this variable is unset, `MINERU_INTRA_OP_NUM_THREADS` is used as a fallback.
+
 - `MINERU_INTRA_OP_NUM_THREADS`:
     * Used to set the intra_op thread count for ONNX models, affects the computation speed of individual operators
     * Default is `-1` (auto-select), can be set to other values via environment variable to adjust the thread count.

--- a/docs/zh/usage/cli_tools.md
+++ b/docs/zh/usage/cli_tools.md
@@ -168,6 +168,12 @@ MinerU命令行工具的某些参数存在相同功能的环境变量配置，�
     * 用于设置任务清理轮询间隔（秒）
     * 默认为 `300` 秒（5 分钟）。
 
+- `MINERU_CPU_NUM_THREADS`：
+    * 用于设置 `mineru-api` 中单个 torch CPU 算子可使用的最大线程数。
+    * 默认为 `8`，并会被限制在机器实际 CPU 核心数以内。
+    * `mineru-api` 通过 `asyncio.to_thread()` 调度 CPU 计算，而 OpenMP（libgomp）会为每个进入过并行区的线程保留一组常驻 worker。若不设置上限，多核机器上进程线程数会朝着 `线程池大小 * CPU 核心数` 增长。
+    * 若已设置 `OMP_NUM_THREADS`、`MKL_NUM_THREADS` 或 `OPENBLAS_NUM_THREADS` 中任意一个，则尊重既有配置、不再应用默认值。若未设置本变量，则回退使用 `MINERU_INTRA_OP_NUM_THREADS`。
+
 - `MINERU_INTRA_OP_NUM_THREADS`：
     * 用于设置onnx模型的intra_op线程数，影响单个算子的计算速度
     * 默认为`-1`（自动选择），可通过环境变量设置为其他值以调整线程数。

--- a/mineru/cli/fast_api.py
+++ b/mineru/cli/fast_api.py
@@ -67,6 +67,7 @@ from mineru.utils.config_reader import (
     get_processing_window_size,
 )
 from mineru.utils.guess_suffix_or_lang import guess_suffix_by_path
+from mineru.utils.os_env_config import apply_cpu_thread_limit
 from mineru.utils.pdf_image_tools import shutdown_pdf_render_executor
 from mineru.version import __version__
 
@@ -234,6 +235,17 @@ def create_app():
     _request_semaphore = asyncio.Semaphore(max_concurrent_requests)
     if is_main_multiprocessing_process():
         logger.info(f"Request concurrency limited to {max_concurrent_requests}")
+
+    # CPU work is dispatched with asyncio.to_thread(), i.e. onto the event loop's
+    # default ThreadPoolExecutor. libgomp gives every one of those long-lived pool
+    # workers its own OpenMP team, so an uncapped team size makes the process
+    # thread count grow towards pool_size * os.cpu_count(). See issue #5472.
+    applied_cpu_thread_limit = apply_cpu_thread_limit()
+    if applied_cpu_thread_limit is not None and is_main_multiprocessing_process():
+        logger.info(
+            f"Torch CPU threads limited to {applied_cpu_thread_limit}; "
+            "set MINERU_CPU_NUM_THREADS or OMP_NUM_THREADS to override"
+        )
 
     app.add_middleware(GZipMiddleware, minimum_size=1000)
     app.state.public_bind_exposed = env_flag_enabled(

--- a/mineru/utils/os_env_config.py
+++ b/mineru/utils/os_env_config.py
@@ -1,10 +1,88 @@
 # Copyright (c) Opendatalab. All rights reserved.
 import os
+from typing import Optional
+
+# Environment variables through which a deployment can pin the size of the CPU
+# thread pools of the native math libraries (libgomp / MKL / OpenBLAS) used by
+# the torch CPU path. If any of them is set we must not override the operator.
+CPU_THREAD_LIMIT_ENV_NAMES = (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+)
+
+# Upper bound applied when no explicit thread limit is configured.
+# libgomp keeps one worker team of ``num_threads`` threads alive per master thread
+# that entered a parallel region, and the workers of a ``ThreadPoolExecutor``
+# (used by ``asyncio.to_thread``) live for the whole process lifetime. Without a
+# cap, every pool worker that touches a torch CPU op permanently costs one team
+# sized to the whole machine, so a long-running server grows towards
+# ``pool_size * os.cpu_count()`` OS threads. See issue #5472.
+DEFAULT_CPU_THREAD_LIMIT = 8
 
 
 def get_op_num_threads(env_name: str) -> int:
     env_value = os.getenv(env_name, None)
     return get_value_from_string(env_value, -1)
+
+
+def cpu_thread_limit_already_configured() -> bool:
+    """Whether the deployment already pinned the native CPU thread pools."""
+    return any(os.getenv(env_name) is not None for env_name in CPU_THREAD_LIMIT_ENV_NAMES)
+
+
+def resolve_cpu_thread_limit(
+    default_limit: int = DEFAULT_CPU_THREAD_LIMIT,
+    cpu_count: Optional[int] = None,
+) -> int:
+    """Resolve the number of CPU threads a single torch CPU operator may use.
+
+    ``MINERU_CPU_NUM_THREADS`` takes precedence, then ``MINERU_INTRA_OP_NUM_THREADS``
+    so a single variable can tune both the ONNX and the torch CPU paths. Invalid
+    or non-positive values fall back to ``default_limit``, and the result is
+    clamped to ``[1, cpu_count]`` like the ONNX session options in
+    ``mineru.model.table.rec``.
+    """
+    if cpu_count is None:
+        cpu_count = os.cpu_count() or 1
+
+    configured = get_op_num_threads("MINERU_CPU_NUM_THREADS")
+    if configured == -1:
+        configured = get_op_num_threads("MINERU_INTRA_OP_NUM_THREADS")
+    if configured == -1:
+        configured = default_limit
+
+    return max(1, min(configured, max(1, cpu_count)))
+
+
+def apply_cpu_thread_limit(
+    default_limit: int = DEFAULT_CPU_THREAD_LIMIT,
+    cpu_count: Optional[int] = None,
+) -> Optional[int]:
+    """Cap the per-thread torch CPU pool unless the deployment configured it.
+
+    Applied through ``torch.set_num_threads`` rather than by exporting
+    ``OMP_NUM_THREADS``, so that the VLM engines keep their own
+    ``OMP_NUM_THREADS=1`` default (they only set it when it is still unset).
+
+    :return: the limit that was applied, or ``None`` when nothing was changed
+        because the deployment already pinned the thread pools or torch is not
+        installed.
+    """
+    if cpu_thread_limit_already_configured():
+        return None
+
+    try:
+        import torch
+    except ImportError:
+        return None
+
+    limit = resolve_cpu_thread_limit(default_limit=default_limit, cpu_count=cpu_count)
+    if torch.get_num_threads() <= limit:
+        return None
+
+    torch.set_num_threads(limit)
+    return limit
 
 
 def get_load_images_timeout() -> int:

--- a/tests/unittest/test_cpu_thread_limit.py
+++ b/tests/unittest/test_cpu_thread_limit.py
@@ -1,0 +1,149 @@
+# Copyright (c) Opendatalab. All rights reserved.
+"""CPU 线程上限的回归测试，覆盖 issue #5472 中导致线程泄漏的场景。
+
+libgomp 会为每个进入过 OpenMP 并行区的 master 线程保留一组常驻 worker，
+而 ``asyncio.to_thread`` 使用的 ``ThreadPoolExecutor`` 线程与进程同生命周期，
+因此单个算子的线程数如果不设上限，长时间运行的 ``mineru-api`` 进程线程数会
+朝着 ``线程池大小 * os.cpu_count()`` 增长。
+"""
+import sys
+import types
+
+import pytest
+
+from mineru.utils import os_env_config
+from mineru.utils.os_env_config import (
+    CPU_THREAD_LIMIT_ENV_NAMES,
+    DEFAULT_CPU_THREAD_LIMIT,
+    apply_cpu_thread_limit,
+    cpu_thread_limit_already_configured,
+    resolve_cpu_thread_limit,
+)
+
+
+class _FakeTorch(types.ModuleType):
+    """记录 set_num_threads 调用的 torch 替身。"""
+
+    def __init__(self, num_threads: int) -> None:
+        super().__init__("torch")
+        self._num_threads = num_threads
+        self.set_calls: list[int] = []
+
+    def get_num_threads(self) -> int:
+        """返回当前 torch CPU 线程数。"""
+        return self._num_threads
+
+    def set_num_threads(self, num_threads: int) -> None:
+        """记录并应用 torch CPU 线程数。"""
+        self.set_calls.append(num_threads)
+        self._num_threads = num_threads
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> pytest.MonkeyPatch:
+    """清空所有相关环境变量，模拟未做任何线程配置的默认部署。"""
+    for env_name in CPU_THREAD_LIMIT_ENV_NAMES:
+        monkeypatch.delenv(env_name, raising=False)
+    monkeypatch.delenv("MINERU_CPU_NUM_THREADS", raising=False)
+    monkeypatch.delenv("MINERU_INTRA_OP_NUM_THREADS", raising=False)
+    return monkeypatch
+
+
+def _install_fake_torch(monkeypatch: pytest.MonkeyPatch, num_threads: int) -> _FakeTorch:
+    fake_torch = _FakeTorch(num_threads)
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    return fake_torch
+
+
+def test_resolve_defaults_to_thread_limit_when_unset(clean_env: pytest.MonkeyPatch) -> None:
+    """未做任何配置时应回落到默认上限，而不是整机核心数。"""
+    assert resolve_cpu_thread_limit(cpu_count=96) == DEFAULT_CPU_THREAD_LIMIT
+
+
+def test_resolve_never_exceeds_cpu_count(clean_env: pytest.MonkeyPatch) -> None:
+    """小核心机器上的上限不得超过实际核心数。"""
+    assert resolve_cpu_thread_limit(cpu_count=2) == 2
+    assert resolve_cpu_thread_limit(cpu_count=1) == 1
+
+
+def test_resolve_prefers_mineru_cpu_num_threads(clean_env: pytest.MonkeyPatch) -> None:
+    """MINERU_CPU_NUM_THREADS 优先级最高。"""
+    clean_env.setenv("MINERU_CPU_NUM_THREADS", "4")
+    clean_env.setenv("MINERU_INTRA_OP_NUM_THREADS", "16")
+    assert resolve_cpu_thread_limit(cpu_count=96) == 4
+
+
+def test_resolve_falls_back_to_intra_op_num_threads(clean_env: pytest.MonkeyPatch) -> None:
+    """未设置专用变量时复用既有的 MINERU_INTRA_OP_NUM_THREADS。"""
+    clean_env.setenv("MINERU_INTRA_OP_NUM_THREADS", "6")
+    assert resolve_cpu_thread_limit(cpu_count=96) == 6
+
+
+@pytest.mark.parametrize("bad_value", ["abc", "0", "-4", ""])
+def test_resolve_falls_back_on_invalid_values(
+    clean_env: pytest.MonkeyPatch,
+    bad_value: str,
+) -> None:
+    """非法或非正数取值必须回落到默认上限，而不是崩溃或放开上限。"""
+    clean_env.setenv("MINERU_CPU_NUM_THREADS", bad_value)
+    assert resolve_cpu_thread_limit(cpu_count=96) == DEFAULT_CPU_THREAD_LIMIT
+
+
+def test_apply_caps_torch_threads_on_many_core_host(clean_env: pytest.MonkeyPatch) -> None:
+    """核心场景：96 核机器上默认必须收敛线程数，这正是 #5472 的泄漏场景。"""
+    fake_torch = _install_fake_torch(clean_env, num_threads=96)
+
+    applied = apply_cpu_thread_limit(cpu_count=96)
+
+    assert applied == DEFAULT_CPU_THREAD_LIMIT
+    assert fake_torch.set_calls == [DEFAULT_CPU_THREAD_LIMIT]
+    assert fake_torch.get_num_threads() == DEFAULT_CPU_THREAD_LIMIT
+
+
+@pytest.mark.parametrize("env_name", CPU_THREAD_LIMIT_ENV_NAMES)
+def test_apply_respects_explicit_env_configuration(
+    clean_env: pytest.MonkeyPatch,
+    env_name: str,
+) -> None:
+    """部署方已显式配置线程数时不得覆盖，也不得改动 torch 线程数。"""
+    clean_env.setenv(env_name, "2")
+    fake_torch = _install_fake_torch(clean_env, num_threads=96)
+
+    assert cpu_thread_limit_already_configured() is True
+    assert apply_cpu_thread_limit(cpu_count=96) is None
+    assert fake_torch.set_calls == []
+
+
+def test_apply_does_not_raise_torch_threads(clean_env: pytest.MonkeyPatch) -> None:
+    """torch 线程数已低于上限时不得反向调高，避免放大 OpenMP team。"""
+    fake_torch = _install_fake_torch(clean_env, num_threads=4)
+
+    assert apply_cpu_thread_limit(cpu_count=96) is None
+    assert fake_torch.set_calls == []
+    assert fake_torch.get_num_threads() == 4
+
+
+def test_apply_is_a_noop_without_torch(clean_env: pytest.MonkeyPatch) -> None:
+    """未安装 torch 的环境下必须安静跳过，不能让 API 启动失败。"""
+    clean_env.setitem(sys.modules, "torch", None)
+
+    assert apply_cpu_thread_limit(cpu_count=96) is None
+
+
+def test_apply_is_idempotent(clean_env: pytest.MonkeyPatch) -> None:
+    """重复调用不应反复设置，便于在启动路径上安全调用。"""
+    fake_torch = _install_fake_torch(clean_env, num_threads=96)
+
+    assert apply_cpu_thread_limit(cpu_count=96) == DEFAULT_CPU_THREAD_LIMIT
+    assert apply_cpu_thread_limit(cpu_count=96) is None
+    assert fake_torch.set_calls == [DEFAULT_CPU_THREAD_LIMIT]
+
+
+def test_vlm_omp_default_is_not_shadowed(clean_env: pytest.MonkeyPatch) -> None:
+    """修复不得通过导出 OMP_NUM_THREADS 生效，否则会顶掉 VLM 引擎自己的 =1 默认值。"""
+    _install_fake_torch(clean_env, num_threads=96)
+
+    apply_cpu_thread_limit(cpu_count=96)
+
+    for env_name in CPU_THREAD_LIMIT_ENV_NAMES:
+        assert os_env_config.os.getenv(env_name) is None


### PR DESCRIPTION
## Motivation

Fixes #5472.

`mineru-api` leaks OS threads until it plateaus at roughly `thread_pool_size × nproc` (~3000 on the reporter's 96-core host), which forced them to run an external watchdog restarting the container above 1500 threads (317 preventive restarts in three weeks).

I reproduced the mechanism and it matches the report:

- `mineru-api` dispatches its CPU work with `asyncio.to_thread()`, i.e. onto the event loop's default `ThreadPoolExecutor` (`max_workers = min(32, nproc + 4)`).
- libgomp keeps one **persistent** worker team per *master* thread that has entered a parallel region, and those pool workers live for the whole process lifetime, so each pool worker that touches a torch CPU op permanently costs one OpenMP team sized to the whole machine.
- The threads are not Python threads, confirming the reporter's `py-spy` observation.

I also confirmed the coverage gap on current `master` (`4fe4bde1`): `OMP_NUM_THREADS` is defaulted in exactly three places, all on the VLM path — `mineru/backend/vlm/vlm_analyze.py:115`, `mineru/model/vlm/vllm_server.py:60`, `mineru/model/vlm/lmdeploy_server.py:83`. The `mineru-api` / `fast_api` path (used by `pipeline` and `hybrid-engine`) has no upper bound at all.

### Measurement

Linux container, 18 cores, torch 2.14.0, thread count read from `/proc/self/status` `Threads:`, same `asyncio.to_thread` dispatch pattern, process fully idle at each sample:

| | before (no cap) | after (`MINERU_CPU_NUM_THREADS` default `8`) |
|---|---:|---:|
| after startup + warmup | 18 | 15 |
| after parse #1 (2 pool workers) | 54 (**+36**) | 31 (**+16**) |
| after parse #2 (4 pool workers) | 90 (**+36**) | 47 (**+16**) |
| after parse #3 (6 pool workers) | 126 (**+36**) | 63 (**+16**) |
| after parse #4 (8 pool workers) | 162 (**+36**) | 79 (**+16**) |
| after parse #5 (10 pool workers) | 198 (**+36**) | 95 (**+16**) |
| Python threads (`threading.active_count()`) | 11 | 11 |

That is `+18 = nproc` per newly-touched pool worker before, `+8 = the cap` after, while the Python thread count is unchanged — i.e. the growth is OpenMP teams, not Python threads.

## Modification

- `mineru/utils/os_env_config.py`: add `resolve_cpu_thread_limit()` and `apply_cpu_thread_limit()`, following the existing `get_op_num_threads` / `get_value_from_string` conventions and the same `1 <= n <= cpu_count` clamping the ONNX session options in `mineru/model/table/rec/**` already use.
- `mineru/cli/fast_api.py`: call `apply_cpu_thread_limit()` from `create_app()`.
- `tests/unittest/test_cpu_thread_limit.py`: 16 regression tests.
- `docs/{en,zh}/usage/cli_tools.md`: document `MINERU_CPU_NUM_THREADS`.

Deliberate design choices:

- **Applied via `torch.set_num_threads()`, not by exporting `OMP_NUM_THREADS`.** The three VLM sites above only set `OMP_NUM_THREADS` when it is still unset, so exporting it here would silently shadow their own `=1` default. I verified both `torch.set_num_threads(4)` and an env var produce the same `4 threads per pool worker` result, so the env var is not needed to get the fix.
- **Never overrides an explicit deployment config.** If any of `OMP_NUM_THREADS` / `MKL_NUM_THREADS` / `OPENBLAS_NUM_THREADS` is set, the function returns `None` and changes nothing. Verified: with `OMP_NUM_THREADS=2` the growth stays at `+4` per worker and torch stays at 2 threads.
- **Never raises an already-lower thread count**, so it cannot accidentally enlarge a team.
- **No global hard-coding**: `MINERU_CPU_NUM_THREADS` takes precedence, then the existing `MINERU_INTRA_OP_NUM_THREADS`, then the default of `8`, always clamped to `os.cpu_count()`.
- **Not applied process-wide** — only in `create_app()`, so the CLI and the VLM/GPU paths are untouched.

I picked `8` as a starting point because it matches the value the reporter validated. Happy to change the number, the variable name, or move the call site if you prefer a different default-thread policy.

## BC-breaking (Optional)

No API change. One behaviour change: on a many-core host with no thread env vars set, a single torch CPU operator in `mineru-api` now uses at most 8 threads instead of `nproc`. This is the point of the fix (the reporter notes the uncapped teams also cause heavy CPU oversubscription), and any deployment wanting the old behaviour can set `MINERU_CPU_NUM_THREADS` or `OMP_NUM_THREADS` explicitly.

## Use cases (Optional)

```bash
# default: capped at min(8, nproc)
mineru-api --host 0.0.0.0 --port 8000

# tune explicitly
MINERU_CPU_NUM_THREADS=16 mineru-api --host 0.0.0.0 --port 8000

# already-pinned deployments are left alone
OMP_NUM_THREADS=4 mineru-api --host 0.0.0.0 --port 8000
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.

### Verification detail

The repo has no `.pre-commit-config.yaml`, so I used the repo's own `ruff` config from `pyproject.toml`. `ruff check` reports an identical set of 17 pre-existing findings on the two touched modules before and after my change (all `ANN`/`C408`/`W292` that already existed); the new test file is clean.

```
$ python -m pytest tests/unittest/test_cpu_thread_limit.py -o addopts="" -q
................                                                         [100%]
16 passed in 0.01s

$ ruff check tests/unittest/test_cpu_thread_limit.py
All checks passed!
```

Rollback counter-proof — keeping the new tests and reverting only the body of `apply_cpu_thread_limit()` to the pre-fix behaviour:

```
FAILED tests/unittest/test_cpu_thread_limit.py::test_apply_caps_torch_threads_on_many_core_host
FAILED tests/unittest/test_cpu_thread_limit.py::test_apply_is_idempotent
2 failed, 14 passed
```
(`assert None == 8` in both cases.) Reverting the implementation file entirely instead makes the module fail to import, so the tests genuinely exercise the new behaviour.

### Not verified

- I did **not** reproduce this on a 96-core host or against the reporter's exact stack (torch 2.11 + vllm 0.21 + CUDA); my measurements are on an 18-core Linux container with torch 2.14 CPU-only.
- I did **not** run a real end-to-end `/file_parse` request with models loaded — I reproduced the leak mechanism through the same `asyncio.to_thread` + torch CPU op dispatch pattern rather than by parsing PDFs, so the absolute numbers in the issue (`+97` per document) are not reproduced, only the per-pool-worker scaling law.
- The `hybrid-engine` / `pipeline` end-to-end throughput impact of the cap is not benchmarked; the existing `tests/unittest/test_e2e.py` and the other two unit test modules could not run in my environment because of missing optional deps (`loguru`, `pdftext`, `python-docx`) — they fail to collect identically on unmodified `master`, so this is unrelated to the change.
